### PR TITLE
Fix DB_VERSION default + dangling tsconfig refs (pre-Vite cleanup)

### DIFF
--- a/packages/bunadmin/src/utils/config/index.ts
+++ b/packages/bunadmin/src/utils/config/index.ts
@@ -1,6 +1,6 @@
 function strToArr(str?: string) {
   if (!str) return []
-  return str.split(/[ ,]+/);
+  return str.split(/[ ,]+/)
 }
 
 export const DEFAULT_AUTH_PLUGIN = "@xbuilder/bunadmin-auth-buncms"
@@ -62,7 +62,7 @@ export const ENV: EnvTypes = {
   DB_VERSION:
     process.env.REACT_APP_DB_VERSION ||
     process.env.NEXT_PUBLIC_DB_VERSION ||
-    "BunadminDatabase",
+    "1",
   ON_I18N:
     process.env.REACT_APP_ON_I18N === "true" ||
     process.env.NEXT_PUBLIC_ON_I18N === "true" ||

--- a/packages/bunadmin/src/utils/database/dx/index.ts
+++ b/packages/bunadmin/src/utils/database/dx/index.ts
@@ -17,9 +17,8 @@ export class BunadminDatabase extends Dexie {
 
   constructor() {
     super(ENV.DB_NAME)
-    this.version(ENV.DB_VERSION ? Number(ENV.DB_VERSION) : 1).stores(
-      BA_STORE_TABLES
-    )
+    const v = Number(ENV.DB_VERSION)
+    this.version(Number.isFinite(v) && v > 0 ? v : 1).stores(BA_STORE_TABLES)
   }
 }
 

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -1,10 +1,4 @@
 {
   "files": [],
-  "references": [
-    { "path": "wescraper" },
-    { "path": "web" },
-    { "path": "desktop" },
-    { "path": "server" },
-    { "path": "css-selector" }
-  ]
+  "references": []
 }


### PR DESCRIPTION
Pre-work for the Vite migration — fixes two pre-existing bugs surfaced during the Vite spike.

## Bug 1 — Dexie "Given version is not a positive number"
`ENV.DB_VERSION` defaulted to the string `"BunadminDatabase"` (copy-pasted from `DB_NAME` directly above it). Since that's truthy, `Number("BunadminDatabase")` → `NaN`, which Dexie rejects. This also **silently broke the plugin generator**: it threw while processing plugin `initData`, so per-plugin schema dirs (`.bunadmin/dynamic/[plugin]/[name]/index.js`) were never emitted.

- `config`: default `DB_VERSION` to `"1"`.
- `dx`: guard `this.version()` against non-positive/NaN values.

**Verified:** generator now completes without error and emits `bunadmin-auth-local/sign-in/index.js`.

## Bug 2 — dangling tsconfig project references
`packages/tsconfig.json` referenced 5 projects that don't exist in this repo (`wescraper`, `web`, `desktop`, `server`, `css-selector`) — leftover from another monorepo. Broke `tsc` project refs and `vite-tsconfig-paths`. Emptied `references`.

## Verification
- CRA `yarn build` — succeeds
- Table tests — 6/6 pass
- generator — emits schema dirs, no error

Unblocks the per-plugin lazy-loading path for the upcoming Vite migration.