### PR TITLE
Add unit tests: plugin-path resolution + gql builders

### DIFF
--- a/packages/bunadmin/src/utils/scripts/__tests__/dataToGql.test.ts
+++ b/packages/bunadmin/src/utils/scripts/__tests__/dataToGql.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest"
+import dataToGql, { filtersToWhere } from "../dataToGql"
+
+describe("dataToGql", () => {
+  it("serializes string fields as quoted gql", () => {
+    expect(dataToGql({ data: { name: "post", id: "1" } })).toBe(
+      `{name: "post", id: "1"}`
+    )
+  })
+
+  it("skips empty values and object values", () => {
+    expect(
+      dataToGql({ data: { name: "post", empty: "", nested: { a: 1 } } })
+    ).toBe(`{name: "post"}`)
+  })
+
+  it("emits null for keys listed in nulls when value is empty", () => {
+    expect(
+      dataToGql({ data: { parent_id: "" }, nulls: { parent_id: true } })
+    ).toBe(`{parent_id: null}`)
+  })
+
+  it("emits unquoted enum values", () => {
+    expect(
+      dataToGql({ data: { status: "Draft" }, enums: { status: true } })
+    ).toBe(`{status: Draft}`)
+  })
+})
+
+describe("filtersToWhere", () => {
+  it("builds an _eq clause by default", () => {
+    const where = filtersToWhere({
+      filters: [{ column: { field: "name" }, operator: "=", value: "x" }] as any
+    })
+    expect(where).toContain(`name: {_eq: "x"}`)
+  })
+
+  it("applies a _like operator with wildcards", () => {
+    const where = filtersToWhere({
+      filters: [
+        { column: { field: "name" }, operator: "=", value: "x" }
+      ] as any,
+      operators: { name: "_like" }
+    })
+    // NOTE: source wraps the value as `"%x%"` then re-quotes it, yielding
+    // doubled quotes — asserting actual behavior, not the ideal form.
+    expect(where).toContain(`_like:`)
+    expect(where).toContain(`%x%`)
+  })
+
+  it("includes the search clause when no filter overrides it", () => {
+    const where = filtersToWhere({
+      filters: [],
+      search: { key: "name", operator: "_like", value: `"%a%"` }
+    })
+    expect(where).toContain("name: {_like:")
+  })
+
+  it("skips empty and object filter values", () => {
+    const where = filtersToWhere({
+      filters: [
+        { column: { field: "a" }, operator: "=", value: "" },
+        { column: { field: "b" }, operator: "=", value: { x: 1 } }
+      ] as any
+    })
+    expect(where).toBe("{ }")
+  })
+})

--- a/packages/bunadmin/src/utils/scripts/__tests__/handlePlugin.test.ts
+++ b/packages/bunadmin/src/utils/scripts/__tests__/handlePlugin.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest"
+import {
+  handlePluginPath,
+  specialPluginGroup,
+  specialPluginSlug
+} from "../handlePlugin"
+
+describe("handlePluginPath", () => {
+  it("maps a regular plugin to bunadmin-plugin-[group]/[name]", () => {
+    expect(
+      handlePluginPath({ team: "bunadmin", group: "blog", name: "category" })
+    ).toBe("bunadmin-plugin-blog/category")
+  })
+
+  it("maps an auth plugin to bunadmin-auth-[group]/[name]", () => {
+    expect(
+      handlePluginPath({ team: "buncms", group: "auth-buncms", name: "users" })
+    ).toBe("bunadmin-auth-buncms/users")
+  })
+
+  it("maps an upload plugin to bunadmin-upload-[group]/[name]", () => {
+    expect(
+      handlePluginPath({
+        team: "buncms",
+        group: "upload-buncms",
+        name: "files"
+      })
+    ).toBe("bunadmin-upload-buncms/files")
+  })
+})
+
+describe("specialPluginGroup", () => {
+  it("collapses auth-* to auth", () => {
+    expect(specialPluginGroup("auth-buncms")).toBe("auth")
+  })
+  it("collapses upload-* to upload", () => {
+    expect(specialPluginGroup("upload-strapi")).toBe("upload")
+  })
+  it("leaves regular groups unchanged", () => {
+    expect(specialPluginGroup("blog")).toBe("blog")
+  })
+})
+
+describe("specialPluginSlug", () => {
+  it("normalizes an auth slug", () => {
+    expect(specialPluginSlug("/auth-buncms/users")).toBe("/auth/users")
+  })
+  it("normalizes an upload slug", () => {
+    expect(specialPluginSlug("/upload-strapi/files")).toBe("/upload/files")
+  })
+  it("leaves a regular slug unchanged", () => {
+    expect(specialPluginSlug("/blog/category")).toBe("/blog/category")
+  })
+})


### PR DESCRIPTION
Phase 2 — start closing the test-coverage gap (was 1 test file after four migrations).

## Added
- **handlePlugin.test.ts** (9 tests) — handlePluginPath/specialPluginGroup/specialPluginSlug. Map team/group/name -> plugin import paths that the Vite pluginRegistry/PluginTable loader depends on.
- **dataToGql.test.ts** (8 tests) — dataToGql + filtersToWhere: string/enum/null serialization, object/empty skipping, _eq/_like operators, search clause. Documents the existing _like double-quote quirk (asserts actual behavior).

## Result
23 tests across 3 files (was 6 in 1). All green under Vitest. Pure-function tests, no mocking.