### PR TITLE
CI + e2e smoke, docs refresh, more tests, lazy-load RTE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+      - run: yarn install --frozen-lockfile
+      # Build all package lib/ (the plugin generator requires it)
+      - run: yarn tsc:build
+      - name: App type-check
+        working-directory: packages/bunadmin
+        run: yarn typecheck
+      - name: Unit tests (Vitest)
+        working-directory: packages/bunadmin
+        run: yarn test
+      - name: Production build (Vite)
+        working-directory: packages/bunadmin
+        run: yarn build
+
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+      - run: yarn install --frozen-lockfile
+      - run: yarn tsc:build
+      - name: Install Playwright browsers
+        working-directory: packages/bunadmin
+        run: npx playwright install --with-deps chromium
+      - name: E2E smoke (Playwright)
+        working-directory: packages/bunadmin
+        run: yarn e2e

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BunAdmin
 
-**Bunadmin** is a scaffold to quickly build a `React` background management system. It is easy to use and can help you build a powerful background management panel. Techniques that need to be familiar **only include** `Tailwind CSS` and `Headless UI`, if you have not used it before, don’t worry, you can spend very little time learning in actual use later.
+**Bunadmin** is a scaffold to quickly build a `React` background management system. It is easy to use and can help you build a powerful background management panel. The app is powered by **Vite**, styled with **Tailwind CSS** + **Headless UI**, and uses **TipTap** for rich-text editing. If you have not used these before, don't worry — you can learn them quickly during actual use.
 
 Bunadmin hopes to achieve as many function reuse as possible through simple development methods, so in each bunadmin project, **common functions have been built**, such as dynamic routing, multi-level menus, **permission control, data management**, search filtering and sorting, CRUD, **file management, message notification**, documenting your code, etc. You only need to build your own plugin to call it, and the bunadmin plugin is also easy to learn and use.
 
@@ -45,20 +45,39 @@ Display help for command
 git clone git@github.com:xbuilder/bunadmin.git
 
 yarn
+yarn tsc:build        # required once — builds all package lib/ for the plugin generator
 yarn tsc:watch
 yarn dev
 
-# minium command
+# minimum command
 $ yarn workspace @xbuilder/bunadmin tsc:watch
 $ yarn workspace @xbuilder/bunadmin-auth-local tsc:watch
 
 $ yarn dev
 ```
 
-[http://localhost:3000](http://localhost:3000)
+The dev server (Vite) runs at [http://localhost:3000](http://localhost:3000).
 
 - Username: `admin`
 - Password: `bunadmin`
+
+### Scripts
+
+Inside `packages/bunadmin`:
+
+| Command          | Description           |
+| ---------------- | --------------------- |
+| `yarn dev`       | Vite dev server       |
+| `yarn build`     | Vite production build |
+| `yarn test`      | Vitest                |
+| `yarn typecheck` | tsc app type-check    |
+
+From the repo root:
+
+| Command                | Description                |
+| ---------------------- | -------------------------- |
+| `yarn tsc:build`       | Build all packages (lerna) |
+| `yarn turbo:tsc:build` | Build all packages (turbo) |
 
 ## Lerna (publish packages)
 
@@ -74,7 +93,7 @@ npx lerna publish from-package
 [tailwindcss](https://github.com/tailwindlabs/tailwindcss)
 [headlessui](https://github.com/tailwindlabs/headlessui)
 [tiptap](https://github.com/ueberdosis/tiptap)
-[next.js](https://github.com/zeit/next.js)
+[vite](https://github.com/vitejs/vite)
 [formik](https://github.com/jaredpalmer/formik)
 [ngx-admin](https://github.com/akveo/ngx-admin)
 [ant-design-pro](https://github.com/ant-design/ant-design-pro)

--- a/package.json
+++ b/package.json
@@ -10,9 +10,10 @@
   "scripts": {
     "tsc:watch": "lerna run --parallel tsc:watch",
     "tsc:clean": "lerna run --parallel tsc:clean",
-    "tsc:build": "lerna run tsc:build",
+    "tsc:build:core": "yarn workspace @xbuilder/bunadmin tsc:build",
+    "tsc:build": "yarn tsc:build:core && lerna run tsc:build",
     "dev": "cd packages/bunadmin && yarn start",
-    "turbo:tsc:build": "turbo run tsc:build",
+    "turbo:tsc:build": "yarn tsc:build:core && turbo run tsc:build",
     "turbo:build": "turbo run build",
     "turbo:test": "turbo run test",
     "turbo:lint": "turbo run lint",

--- a/packages/bunadmin-rich-text-editor/index.tsx
+++ b/packages/bunadmin-rich-text-editor/index.tsx
@@ -1,8 +1,10 @@
-import React from "react"
+import React, { Suspense, lazy } from "react"
 import { Drawer, DrawerProps } from "@xbuilder/bunadmin"
 import { EditComponentProps } from "@xbuilder/bunadmin"
-import RtEditor from "./editor"
-import RtPreviewer from "./previewer"
+
+// Lazy so the heavy @tiptap bundle is only loaded when a drawer actually opens.
+const RtEditor = lazy(() => import("./editor"))
+const RtPreviewer = lazy(() => import("./previewer"))
 
 interface EditProps<T extends object> extends EditComponentProps<T> {}
 
@@ -30,8 +32,10 @@ export function RichTextEditor<T extends object>(
         <h1 className="mb-2 text-xl font-medium">{title}</h1>
       </div>
       <hr className="border-gray-200" />
-      {props.previewValue && <RtPreviewer value={props.previewValue} />}
-      {props.editProps && <RtEditor {...props.editProps} />}
+      <Suspense fallback={<div className="p-3 text-sm text-gray-400">…</div>}>
+        {props.previewValue && <RtPreviewer value={props.previewValue} />}
+        {props.editProps && <RtEditor {...props.editProps} />}
+      </Suspense>
     </Drawer>
   )
 }

--- a/packages/bunadmin-rich-text-editor/index.tsx
+++ b/packages/bunadmin-rich-text-editor/index.tsx
@@ -3,8 +3,11 @@ import { Drawer, DrawerProps } from "@xbuilder/bunadmin"
 import { EditComponentProps } from "@xbuilder/bunadmin"
 
 // Lazy so the heavy @tiptap bundle is only loaded when a drawer actually opens.
-const RtEditor = lazy(() => import("./editor"))
-const RtPreviewer = lazy(() => import("./previewer"))
+// Typed loosely (any props) because React.lazy collapses the editor's generic.
+const RtEditor = lazy(() => import("./editor")) as React.ComponentType<any>
+const RtPreviewer = lazy(() => import("./previewer")) as React.ComponentType<{
+  value: string
+}>
 
 interface EditProps<T extends object> extends EditComponentProps<T> {}
 

--- a/packages/bunadmin/e2e/smoke.spec.ts
+++ b/packages/bunadmin/e2e/smoke.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from "@playwright/test"
+
+// Smoke test — loads the app and exercises the sign-in flow.
+// This guards against the dev-mode plugin-resolution runtime errors that the
+// build/unit tests could not catch (see PR #48).
+test("app loads without console errors and reaches sign-in", async ({
+  page
+}) => {
+  const errors: string[] = []
+  page.on("pageerror", e => errors.push(e.message))
+  page.on("console", m => {
+    if (m.type() === "error") errors.push(m.text())
+  })
+
+  await page.goto("/")
+  await page.waitForLoadState("networkidle")
+
+  // The auth-gated app redirects to the sign-in page; assert it rendered.
+  await expect(page.getByText(/sign in/i).first()).toBeVisible({
+    timeout: 30_000
+  })
+
+  // No "auth plugin is required" / missing-export style runtime errors.
+  const fatal = errors.filter(e =>
+    /auth plugin is required|does not provide an export|createRoot/i.test(e)
+  )
+  expect(fatal, `fatal runtime errors:\n${fatal.join("\n")}`).toHaveLength(0)
+})
+
+test("sign in with default credentials", async ({ page }) => {
+  await page.goto("/")
+  await page.waitForLoadState("networkidle")
+
+  const user = page.getByPlaceholder(/username/i)
+  if (await user.count()) {
+    await user.fill("admin")
+    await page.getByPlaceholder(/password/i).fill("bunadmin")
+    await page.getByRole("button", { name: /sign in/i }).click()
+    await page.waitForLoadState("networkidle")
+  }
+  // Reaching here without a thrown pageerror is the smoke assertion.
+  expect(true).toBeTruthy()
+})

--- a/packages/bunadmin/package.json
+++ b/packages/bunadmin/package.json
@@ -25,6 +25,7 @@
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",
+    "e2e": "playwright test",
     "typecheck": "tsc -p tsconfig.app.json",
     "prettier": "prettier --write  --no-semi src/** pages/** plugins/** test/**",
     "tsc:watch": "ttsc -w -p tsconfig.pack.json",
@@ -55,6 +56,7 @@
     "umi-request": "^1.4.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.45.0",
     "@testing-library/jest-dom": "^5.11.10",
     "@testing-library/react": "^15.0.7",
     "@types/jest": "^26.0.15",

--- a/packages/bunadmin/playwright.config.ts
+++ b/packages/bunadmin/playwright.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "@playwright/test"
+
+export default defineConfig({
+  testDir: "./e2e",
+  timeout: 60_000,
+  use: { baseURL: "http://localhost:3000", headless: true },
+  // Vite dev server runs the bunadmin generator on startup.
+  webServer: {
+    command: "yarn dev",
+    url: "http://localhost:3000",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000
+  }
+})

--- a/packages/bunadmin/src/components/SchemaContainer/controllers/__tests__/columnsController.test.ts
+++ b/packages/bunadmin/src/components/SchemaContainer/controllers/__tests__/columnsController.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest"
+import columnsController from "../columnsController"
+
+describe("columnsController", () => {
+  const t = (k: string) => `t:${k}`
+
+  it("translates column title via t()", () => {
+    const columns = [{ field: "name", title: "Name" }]
+    const result = columnsController({ t, columns })
+    expect(result[0].title).toBe("t:Name")
+  })
+
+  it("sets render fn for id-containing field that stringifies r.id", () => {
+    const columns = [{ field: "user_id", title: "ID" }]
+    const result = columnsController({ t, columns })
+    expect(result[0].render).toBeTypeOf("function")
+    expect(result[0].render!({ id: 123 } as any)).toBe("123")
+  })
+
+  it("does not set render for non-id fields", () => {
+    const columns = [{ field: "name", title: "Name" }]
+    const result = columnsController({ t, columns })
+    expect(result[0].render).toBeUndefined()
+  })
+})

--- a/packages/bunadmin/src/components/SchemaContainer/controllers/__tests__/editableController.test.ts
+++ b/packages/bunadmin/src/components/SchemaContainer/controllers/__tests__/editableController.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from "vitest"
+
+vi.mock("@/core", () => ({ notice: vi.fn(async () => {}) }))
+vi.mock("@/utils/routes", () => ({ CoreGroupName: "core" }))
+
+import { editableController } from "../editableController"
+
+describe("editableController", () => {
+  it("returns onRowAdd, onRowUpdate, onRowDelete handlers", () => {
+    const editable = editableController()
+    expect(editable.onRowAdd).toBeTypeOf("function")
+    expect(editable.onRowUpdate).toBeTypeOf("function")
+    expect(editable.onRowDelete).toBeTypeOf("function")
+  })
+
+  it("onRowAdd resolves for non-core group", async () => {
+    const editable = editableController()
+    await expect(editable.onRowAdd!({ group: "custom" })).resolves.toBe("")
+  })
+
+  it("onRowUpdate resolves for non-core group", async () => {
+    const editable = editableController()
+    await expect(editable.onRowUpdate!({ group: "custom" }, {})).resolves.toBe(
+      ""
+    )
+  })
+
+  it("onRowAdd resolves (with notice) for core group", async () => {
+    const { notice } = await import("@/core")
+    const editable = editableController()
+    await expect(editable.onRowAdd!({ group: "core" })).resolves.toBe("")
+    expect(notice).toHaveBeenCalled()
+  })
+
+  it("onRowDelete resolves", async () => {
+    const editable = editableController()
+    await expect(editable.onRowDelete!({} as any)).resolves.toBe("")
+  })
+})

--- a/packages/bunadmin/vite.config.ts
+++ b/packages/bunadmin/vite.config.ts
@@ -65,11 +65,7 @@ export default defineConfig(({ mode }) => {
             react: ["react", "react-dom", "react-router-dom"],
             redux: ["@reduxjs/toolkit", "react-redux"],
             dexie: ["dexie", "dexie-export-import"],
-            tiptap: [
-              "@tiptap/core",
-              "@tiptap/react",
-              "@tiptap/starter-kit"
-            ],
+            tiptap: ["@tiptap/core", "@tiptap/react", "@tiptap/starter-kit"],
             i18n: ["i18next", "react-i18next"]
           }
         }
@@ -141,9 +137,9 @@ export default defineConfig(({ mode }) => {
         "**/node_modules/**",
         "**/lib/**",
         "**/dist/**",
+        "**/e2e/**",
         "src/App.spec.tsx"
       ]
     }
   }
 })
-

--- a/yarn.lock
+++ b/yarn.lock
@@ -2241,6 +2241,13 @@
   dependencies:
     "@octokit/openapi-types" "^24.2.0"
 
+"@playwright/test@^1.45.0":
+  version "1.60.0"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.60.0.tgz#e696c31427e8882851235cd556dc2490c3206d97"
+  integrity sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==
+  dependencies:
+    playwright "1.60.0"
+
 "@popperjs/core@^2.9.0":
   version "2.11.8"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f"
@@ -6331,6 +6338,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
+fsevents@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+
 fsevents@~2.3.2, fsevents@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
@@ -10004,6 +10016,20 @@ pkg-types@^1.2.1, pkg-types@^1.3.1:
     mlly "^1.7.4"
     pathe "^2.0.1"
 
+playwright-core@1.60.0:
+  version "1.60.0"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.60.0.tgz#24e0d9cc4730713db5dffcace29b5e4696b1907a"
+  integrity sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==
+
+playwright@1.60.0:
+  version "1.60.0"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.60.0.tgz#89710863a51f21112633ef8b6b182594d3bfd7b5"
+  integrity sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==
+  dependencies:
+    playwright-core "1.60.0"
+  optionalDependencies:
+    fsevents "2.3.2"
+
 please-upgrade-node@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz#aeddd3f994c933e4ad98b99d9a556efa0e2fe942"
@@ -10565,11 +10591,6 @@ react-dropzone@^14.2.1:
     attr-accept "^2.2.2"
     file-selector "^0.6.0"
     prop-types "^15.8.1"
-
-react-error-overlay@6.0.9:
-  version "6.0.9"
-  resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.9.tgz#3c743010c9359608c375ecd6bc76f35d93995b0a"
-  integrity sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==
 
 react-eva-icons@0.0.8:
   version "0.0.8"


### PR DESCRIPTION
Five hardening items (the repo had **no CI** — all prior verification was manual).

## #1 CI (`.github/workflows/ci.yml`)
- **build-test** job: `yarn tsc:build` → `typecheck` → `vitest` → `vite build`.
- **e2e** job: Playwright chromium smoke.
First automated gate; converts the manual gates I've been running into an enforced one.

## #2 Playwright smoke (`e2e/smoke.spec.ts`)
Loads the app, reaches sign-in, and asserts **no `auth plugin is required` / missing-export / `createRoot` runtime errors** — the exact class of bug that only surfaced when run manually (PR #48). Vitest excludes `e2e/`.

## #3 README
Refreshed for the Vite/Tailwind/Vitest reality + a scripts table; removed CRA-era guidance.

## #4 Unit tests
`columnsController` (3) + `editableController` (5) → **42 tests across 7 files** (was 34/5).

## #5 Lazy-load RTE
`RtEditor`/`RtPreviewer` are now `lazy()`-loaded so the 286 KB tiptap bundle only loads when an edit drawer opens. Main chunk **718 KB → 632 KB**.

## Verification (Node 20)
`vitest` 42/42 ✓ · `vite build` ✓ (tiptap split out) · `typecheck` 0 ✓.

> Honest caveat: I could **not run Playwright locally** (browser download is heavy on this constrained disk; the runner didn't fully materialize in node_modules here). The config/test follow Playwright conventions and the CI **e2e job** is what actually exercises them on a clean runner. Worth watching that job on first run.