### PR TITLE
Fix undeclared react-beautiful-dnd dep + template dynamic import

### DIFF
--- a/packages/bunadmin-cli/templates/typescript-vite/src/components/DefaultLayout/index.tsx
+++ b/packages/bunadmin-cli/templates/typescript-vite/src/components/DefaultLayout/index.tsx
@@ -6,6 +6,7 @@ import {
   ENV,
   store
 } from "@xbuilder/bunadmin"
+import { importPlugin, hasPlugin } from "../../pluginRegistry"
 
 export default function DefaultLayout(props: DefaultLayoutProps) {
   const { children, leftMenu } = props
@@ -26,10 +27,9 @@ export default function DefaultLayout(props: DefaultLayoutProps) {
   useEffect(() => {
     ;(async () => {
       if (!ENV.NOTIFICATION_PLUGIN) return
-      const customNotificationPath = ENV.NOTIFICATION_PLUGIN
-      const { NotificationTable, notificationCount } = await import(
-        `../../plugins/${customNotificationPath}`
-      )
+      const p = ENV.NOTIFICATION_PLUGIN
+      if (!hasPlugin(p)) return
+      const { NotificationTable, notificationCount } = await importPlugin(p)
       if (!NotificationTable || !notificationCount) return
       setNotifyTable(NotificationTable)
       setNotifyCount(notificationCount)

--- a/packages/bunadmin/package.json
+++ b/packages/bunadmin/package.json
@@ -47,6 +47,7 @@
     "notistack": "^3.0.1",
     "prism-react-renderer": "^1.3.3",
     "react": "^18.3.1",
+    "react-beautiful-dnd": "^13.1.1",
     "react-dom": "^18.3.1",
     "react-dropzone": "^14.2.1",
     "react-eva-icons": "0.0.8",


### PR DESCRIPTION
Found by a **pre-publish dry run**: scaffolded a project from the new CLI Vite template, `file:`-linked it to the local workspace packages, and built it — surfacing two bugs that publishing would have shipped broken.

## 1. `@xbuilder/bunadmin` missing `react-beautiful-dnd` dependency
`FileExplorer/Uploader.tsx` imports `react-beautiful-dnd`, but it was never in `dependencies` (only `@types/...` in devDeps). The monorepo hoists it, so it works locally — but a **published consumer** fails with `Cannot find module 'react-beautiful-dnd'`. Added `^13.1.1` to deps.

## 2. CLI template `DefaultLayout` dynamic import
The template's `DefaultLayout` still used `import(`../../plugins/${customNotificationPath}`)` (carried over from the CRA template), which Vite's `dynamic-import-vars` rejects. Switched to the template's `pluginRegistry` `importPlugin`/`hasPlugin`.

## Verification
Scaffolded `bunadmin-test` (sibling dir, `file:`-linked to local `@xbuilder/*`):
- `yarn install` ✓
- `vite build` ✓ (774 modules transformed, generator ran clean)
- `vite dev` ✓ (HTTP 200, ready in 849ms)

Monorepo `lerna tsc:build` (10 pkgs) ✓.