### PR TITLE
feat: PocketBase data-source + auth plugins

### DIFF
--- a/packages/bunadmin-cli/templates/typescript-vite/src/components/DefaultLayout/index.tsx
+++ b/packages/bunadmin-cli/templates/typescript-vite/src/components/DefaultLayout/index.tsx
@@ -6,6 +6,7 @@ import {
   ENV,
   store
 } from "@xbuilder/bunadmin"
+import { importPlugin, hasPlugin } from "../../pluginRegistry"
 
 export default function DefaultLayout(props: DefaultLayoutProps) {
   const { children, leftMenu } = props
@@ -26,10 +27,9 @@ export default function DefaultLayout(props: DefaultLayoutProps) {
   useEffect(() => {
     ;(async () => {
       if (!ENV.NOTIFICATION_PLUGIN) return
-      const customNotificationPath = ENV.NOTIFICATION_PLUGIN
-      const { NotificationTable, notificationCount } = await import(
-        `../../plugins/${customNotificationPath}`
-      )
+      const p = ENV.NOTIFICATION_PLUGIN
+      if (!hasPlugin(p)) return
+      const { NotificationTable, notificationCount } = await importPlugin(p)
       if (!NotificationTable || !notificationCount) return
       setNotifyTable(NotificationTable)
       setNotifyCount(notificationCount)

--- a/packages/bunadmin-source-pocketbase/controllers/bulkDeleteCtrl.tsx
+++ b/packages/bunadmin-source-pocketbase/controllers/bulkDeleteCtrl.tsx
@@ -1,0 +1,22 @@
+import React from "react"
+import { Action, BulkDeleteProps } from "@xbuilder/bunadmin"
+// @ts-ignore
+import EvaIcon from "react-eva-icons"
+import bulkDeleteSer from "../services/bulkDeleteSer"
+
+export default function bulkDeleteCtrl<RowData extends object>(
+  props: BulkDeleteProps
+): Action<RowData> {
+  const { t, SchemaName, tableRef, primaryKey } = props
+
+  return {
+    tooltip: t("Delete all selected rows"),
+    icon: () => <EvaIcon name="trash-2-outline" size="large" fill="gray" />,
+    onClick: async (_event, data) => {
+      data = data as RowData[]
+      if (!data.length) return
+      await bulkDeleteSer({ data, t, SchemaName, tableRef, primaryKey })
+      tableRef.current && tableRef.current.onQueryChange()
+    }
+  }
+}

--- a/packages/bunadmin-source-pocketbase/controllers/dataCtrl.ts
+++ b/packages/bunadmin-source-pocketbase/controllers/dataCtrl.ts
@@ -1,0 +1,47 @@
+/**
+ * Remote data controller (PocketBase)
+ */
+import listSer from "../services/listSer"
+import { DataCtrl, ListService } from "../types"
+import { notice, QueryResult } from "@xbuilder/bunadmin"
+
+export default async function dataCtrl<RowData extends object>({
+  t,
+  listService,
+  ...sharedProps
+}: DataCtrl<RowData>): Promise<QueryResult<RowData>> {
+  const { path, tableQuery } = sharedProps
+
+  let data: any
+  let errors
+  let totalCount = 0
+
+  if (listService) {
+    const resp = await listService()
+    data = resp.data
+    errors = resp.errors
+    totalCount = resp.totalCount
+  } else if (path) {
+    const resp = await listSer({ path, ...sharedProps } as ListService<RowData>)
+    data = resp.data
+    errors = resp.errors
+    totalCount = resp.totalCount
+  } else {
+    await notice({
+      title: t ? t("One of the listService or path is required") : "path required",
+      severity: "error"
+    })
+    return { page: tableQuery.page, data: [], totalCount: 0 }
+  }
+
+  if (errors) {
+    await notice({
+      title: t ? t("Request Failed") : "Request Failed",
+      severity: "error",
+      content: JSON.stringify(errors)
+    })
+    return { page: tableQuery.page, data: [], totalCount: 0 }
+  }
+
+  return { page: tableQuery.page, data, totalCount }
+}

--- a/packages/bunadmin-source-pocketbase/controllers/editableCtrl.ts
+++ b/packages/bunadmin-source-pocketbase/controllers/editableCtrl.ts
@@ -1,0 +1,22 @@
+import { EditableCtrl, EditableDataType } from "@xbuilder/bunadmin"
+import updateSer from "../services/updateSer"
+import deleteSer from "../services/deleteSer"
+import addSer from "../services/addSer"
+import bulkUpdateSer from "../services/bulkUpdateSer"
+
+export default function editableCtrl({
+  t,
+  SchemaName,
+  disableAdd
+}: EditableCtrl): EditableDataType<any> {
+  return {
+    onRowAdd: disableAdd
+      ? undefined
+      : async newData => await addSer({ t, SchemaName, newData }),
+    onRowUpdate: async (newData, oldData) =>
+      await updateSer({ t, SchemaName, newData, oldData }),
+    onBulkUpdate: async changes =>
+      await bulkUpdateSer({ t, SchemaName, changes }),
+    onRowDelete: async oldData => await deleteSer({ t, SchemaName, oldData })
+  }
+}

--- a/packages/bunadmin-source-pocketbase/controllers/index.ts
+++ b/packages/bunadmin-source-pocketbase/controllers/index.ts
@@ -1,0 +1,3 @@
+export { default as dataCtrl } from "./dataCtrl"
+export { default as editableCtrl } from "./editableCtrl"
+export { default as bulkDeleteCtrl } from "./bulkDeleteCtrl"

--- a/packages/bunadmin-source-pocketbase/index.ts
+++ b/packages/bunadmin-source-pocketbase/index.ts
@@ -1,0 +1,12 @@
+import { Query } from "@xbuilder/bunadmin"
+
+export interface DataCtrl extends EditableCtrl {
+  query: Query<any>
+}
+
+export interface EditableCtrl {
+  SchemaName: string
+}
+
+export * from "./services"
+export * from "./controllers"

--- a/packages/bunadmin-source-pocketbase/package.json
+++ b/packages/bunadmin-source-pocketbase/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@xbuilder/bunadmin-source-pocketbase",
+  "version": "1.6.0-beta.0",
+  "license": "Apache-2.0",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "files": [
+    "lib"
+  ],
+  "devDependencies": {
+    "@xbuilder/bunadmin": "^1.6.0-beta.0",
+    "prettier": "1.19.1",
+    "typescript": "4.8.3"
+  },
+  "scripts": {
+    "tsc:watch": "tsc -w",
+    "tsc:clean": "tsc --build --clean",
+    "tsc:build": "tsc"
+  }
+}

--- a/packages/bunadmin-source-pocketbase/services/addSer.ts
+++ b/packages/bunadmin-source-pocketbase/services/addSer.ts
@@ -1,0 +1,30 @@
+import {
+  EditableCtrl,
+  ENV,
+  request,
+  storedToken,
+  notice
+} from "@xbuilder/bunadmin"
+
+interface Props<RowData> extends EditableCtrl {
+  newData: RowData
+}
+
+export default async function addSer({ t, SchemaName, newData }: Props<any>) {
+  const token = await storedToken()
+
+  const res = await request(`/api/collections/${SchemaName}/records`, {
+    prefix: ENV.AUTH_URL,
+    method: "POST",
+    headers: token ? { Authorization: token } : {},
+    data: newData
+  })
+
+  if (res.code && res.code >= 400) {
+    await notice({ title: t("Create Failed"), severity: "warning", content: res })
+  } else {
+    await notice({ title: t("Created"), severity: "success" })
+  }
+
+  return res
+}

--- a/packages/bunadmin-source-pocketbase/services/bulkDeleteSer.ts
+++ b/packages/bunadmin-source-pocketbase/services/bulkDeleteSer.ts
@@ -1,0 +1,61 @@
+import {
+  ENV,
+  request,
+  storedToken,
+  notice,
+  BulkDeleteProps
+} from "@xbuilder/bunadmin"
+
+type Props<RowData extends object> = BulkDeleteProps & {
+  data: RowData[]
+}
+
+export default async function bulkDeleteSer<T extends object>({
+  t,
+  SchemaName,
+  primaryKey = "id",
+  data
+}: Props<T>) {
+  const token = await storedToken()
+  const resList: any[] = []
+  let successCount = 0
+  let failCount = 0
+
+  for (let i = 0; i < data.length; i++) {
+    const item = data[i]
+    // @ts-ignore
+    const id = data[i][primaryKey]
+    const res = await request(`/api/collections/${SchemaName}/records/${id}`, {
+      prefix: ENV.AUTH_URL,
+      method: "DELETE",
+      headers: token ? { Authorization: token } : {}
+    })
+    resList.push(res)
+
+    if (res && res.code && res.code >= 400) {
+      await notice({
+        title: t("Delete Failed"),
+        severity: "warning",
+        content: JSON.stringify(item)
+      })
+      failCount++
+    } else {
+      successCount++
+    }
+  }
+
+  const successMsg = successCount > 0 ? `, ${successCount} success` : ""
+  const failedMsg = failCount > 0 ? `, ${failCount} failure.` : ""
+  await notice({
+    title: t(`Batch Request Completed`),
+    severity:
+      successCount === data.length
+        ? "success"
+        : failCount === data.length
+        ? "error"
+        : "info",
+    content: `${data.length} items ${successMsg}${failedMsg}`
+  })
+
+  return resList
+}

--- a/packages/bunadmin-source-pocketbase/services/bulkUpdateSer.ts
+++ b/packages/bunadmin-source-pocketbase/services/bulkUpdateSer.ts
@@ -1,0 +1,60 @@
+import {
+  ENV,
+  request,
+  storedToken,
+  notice,
+  BulkUpdateProps
+} from "@xbuilder/bunadmin"
+
+export default async function bulkUpdateSer<T>({
+  t,
+  SchemaName,
+  changes
+}: BulkUpdateProps<T>) {
+  const token = await storedToken()
+  const resList: any[] = []
+  let successCount = 0
+  let failCount = 0
+  const changesList = Object.values(changes)
+
+  for (let i = 0; i < changesList.length; i++) {
+    const { oldData, newData } = changesList[i]
+    const res = await request(
+      // @ts-ignore
+      `/api/collections/${SchemaName}/records/${oldData.id}`,
+      {
+        prefix: ENV.AUTH_URL,
+        method: "PATCH",
+        headers: token ? { Authorization: token } : {},
+        data: newData
+      }
+    )
+    resList.push(res)
+
+    if (res && res.code && res.code >= 400) {
+      await notice({
+        title: t("Save Failed"),
+        severity: "warning",
+        content: JSON.stringify(oldData)
+      })
+      failCount++
+    } else {
+      successCount++
+    }
+  }
+
+  const successMsg = successCount > 0 ? `, ${successCount} success` : ""
+  const failedMsg = failCount > 0 ? `, ${failCount} failure.` : ""
+  await notice({
+    title: t(`Batch Request Completed`),
+    severity:
+      successCount === changesList.length
+        ? "success"
+        : failCount === changesList.length
+        ? "error"
+        : "info",
+    content: `${changesList.length} items ${successMsg}${failedMsg}`
+  })
+
+  return resList
+}

--- a/packages/bunadmin-source-pocketbase/services/deleteSer.ts
+++ b/packages/bunadmin-source-pocketbase/services/deleteSer.ts
@@ -1,0 +1,36 @@
+import {
+  EditableCtrl,
+  ENV,
+  request,
+  storedToken,
+  notice
+} from "@xbuilder/bunadmin"
+
+interface Props<RowData> extends EditableCtrl {
+  oldData: RowData
+}
+
+export default async function deleteSer({ t, SchemaName, oldData }: Props<any>) {
+  const token = await storedToken()
+
+  const res = await request(
+    `/api/collections/${SchemaName}/records/${oldData.id}`,
+    {
+      prefix: ENV.AUTH_URL,
+      method: "DELETE",
+      headers: token ? { Authorization: token } : {}
+    }
+  )
+
+  if (res && res.code && res.code >= 400) {
+    await notice({
+      title: t("Delete Failed"),
+      severity: "warning",
+      content: JSON.stringify(oldData)
+    })
+  } else {
+    await notice({ title: t("Deleted"), severity: "success" })
+  }
+
+  return res
+}

--- a/packages/bunadmin-source-pocketbase/services/index.ts
+++ b/packages/bunadmin-source-pocketbase/services/index.ts
@@ -1,0 +1,6 @@
+export { default as addSer } from "./addSer"
+export { default as deleteSer } from "./deleteSer"
+export { default as listSer } from "./listSer"
+export { default as updateSer } from "./updateSer"
+export { default as bulkDeleteSer } from "./bulkDeleteSer"
+export { default as bulkUpdateSer } from "./bulkUpdateSer"

--- a/packages/bunadmin-source-pocketbase/services/listSer.ts
+++ b/packages/bunadmin-source-pocketbase/services/listSer.ts
@@ -1,0 +1,89 @@
+/**
+ * Remote data controller (PocketBase)
+ * GET /api/collections/{name}/records?page=&perPage=&filter=&sort=
+ *   -> { page, perPage, totalItems, totalPages, items[] }
+ */
+import { ENV, request, storedToken } from "@xbuilder/bunadmin"
+import { ListService } from "../types"
+
+export default async function listSer<RowData extends object>({
+  tableQuery,
+  path,
+  prefix,
+  searchField = "name"
+}: ListService<RowData>) {
+  const {
+    search: searchWords,
+    filters = [],
+    orderBy,
+    orderDirection,
+    page,
+    pageSize
+  } = tableQuery
+
+  // Build the PocketBase `filter` expression, e.g. status='Published' && name~'a'
+  const clauses: string[] = []
+  filters.forEach(({ column: { field }, operator, value }) => {
+    if (!field || value === undefined || value === "") return
+    clauses.push(buildClause(String(field), operator as string, value))
+  })
+  if (searchWords) clauses.push(`${searchField}~'${escape(searchWords)}'`)
+  const filter = clauses.join(" && ")
+
+  // PocketBase sort: `field` (asc) / `-field` (desc)
+  const sortField =
+    (orderBy && orderBy.field && orderBy.field.toString()) || "created"
+  const sort = orderBy
+    ? `${orderDirection === "desc" ? "-" : ""}${sortField}`
+    : "-created"
+
+  const token = await storedToken()
+
+  const data = await request(`/api/collections/${path}/records`, {
+    params: {
+      page: page + 1,
+      perPage: pageSize,
+      sort,
+      ...(filter ? { filter } : {})
+    },
+    prefix: prefix || ENV.AUTH_URL,
+    method: "GET",
+    headers: token ? { Authorization: token } : {}
+  })
+
+  return {
+    data: data.items || [],
+    totalCount: data.totalItems || 0,
+    errors: data.code && data.code >= 400 ? data : undefined
+  }
+}
+
+function escape(v: any): string {
+  return String(v).replace(/'/g, "\\'")
+}
+
+/** Map a bunadmin column operator to a PocketBase filter clause. */
+function buildClause(field: string, operator: string, value: any): string {
+  const v = escape(value)
+  switch (operator) {
+    case "!=":
+      return `${field}!='${v}'`
+    case ">":
+      return `${field}>${Number(value)}`
+    case ">=":
+      return `${field}>=${Number(value)}`
+    case "<":
+      return `${field}<${Number(value)}`
+    case "<=":
+      return `${field}<=${Number(value)}`
+    case "_ncs=":
+    case "_nc=":
+      return `${field}!~'${v}'`
+    case "=":
+      return `${field}='${v}'`
+    case "_cs=":
+    case "_c=":
+    default:
+      return `${field}~'${v}'`
+  }
+}

--- a/packages/bunadmin-source-pocketbase/services/updateSer.ts
+++ b/packages/bunadmin-source-pocketbase/services/updateSer.ts
@@ -1,0 +1,43 @@
+import {
+  EditableCtrl,
+  ENV,
+  request,
+  storedToken,
+  notice
+} from "@xbuilder/bunadmin"
+
+interface Props<RowData> extends EditableCtrl {
+  newData: RowData
+  oldData: RowData
+}
+
+export default async function updateSer({
+  t,
+  SchemaName,
+  newData,
+  oldData
+}: Props<any>) {
+  const token = await storedToken()
+
+  const res = await request(
+    `/api/collections/${SchemaName}/records/${oldData.id}`,
+    {
+      prefix: ENV.AUTH_URL,
+      method: "PATCH",
+      headers: token ? { Authorization: token } : {},
+      data: newData
+    }
+  )
+
+  if (res.code && res.code >= 400) {
+    await notice({
+      title: t("Save Failed"),
+      severity: "warning",
+      content: JSON.stringify({ errors: res, newData })
+    })
+  } else {
+    await notice({ title: t("Changes Saved"), severity: "success" })
+  }
+
+  return res
+}

--- a/packages/bunadmin-source-pocketbase/tsconfig.json
+++ b/packages/bunadmin-source-pocketbase/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig",
+  "compilerOptions": {
+    "rootDir": "./",
+    "outDir": "./lib",
+    "declaration": true,
+    "declarationDir": "./lib",
+    "baseUrl": "./"
+  },
+  "exclude": ["node_modules", "lib"],
+  "include": ["*.ts", "*.tsx"]
+}

--- a/packages/bunadmin-source-pocketbase/types.ts
+++ b/packages/bunadmin-source-pocketbase/types.ts
@@ -1,0 +1,19 @@
+import { TFunction } from "i18next"
+import { Query } from "@xbuilder/bunadmin"
+import { ListServiceRes } from "@xbuilder/bunadmin"
+
+export type DataCtrl<RowData extends object> = {
+  t?: TFunction
+  listService?: () => Promise<ListServiceRes>
+  tableQuery: ListService<RowData>["tableQuery"]
+  path?: ListService<RowData>["path"]
+  prefix?: ListService<RowData>["prefix"]
+  searchField?: ListService<RowData>["searchField"]
+}
+
+export type ListService<RowData extends object> = {
+  tableQuery: Query<RowData>
+  path: string
+  prefix?: string
+  searchField?: "name" | string
+}

--- a/packages/bunadmin/package.json
+++ b/packages/bunadmin/package.json
@@ -47,6 +47,7 @@
     "notistack": "^3.0.1",
     "prism-react-renderer": "^1.3.3",
     "react": "^18.3.1",
+    "react-beautiful-dnd": "^13.1.1",
     "react-dom": "^18.3.1",
     "react-dropzone": "^14.2.1",
     "react-eva-icons": "0.0.8",

--- a/plugins/bunadmin-auth-pocketbase/index.ts
+++ b/plugins/bunadmin-auth-pocketbase/index.ts
@@ -1,0 +1,19 @@
+import initData from "./utils/initData"
+export * from "./utils/types"
+
+import SignIn from "./sign-in"
+import { IAuthPlugin } from "@xbuilder/bunadmin"
+
+export { initData, SignIn }
+
+const authPlugin: IAuthPlugin = {
+  authResponseKey: "id",
+  // PocketBase: refresh/verify the current auth record
+  authRequestUrl: "/api/collections/users/auth-refresh",
+  authRequestMethod: "POST",
+  authorizationOverwrite: async () => true
+}
+export const authResponseKey = authPlugin.authResponseKey
+export const authRequestUrl = authPlugin.authRequestUrl
+export const authRequestMethod = authPlugin.authRequestMethod
+export const authorizationOverwrite = authPlugin.authorizationOverwrite

--- a/plugins/bunadmin-auth-pocketbase/package.json
+++ b/plugins/bunadmin-auth-pocketbase/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@xbuilder/bunadmin-auth-pocketbase",
+  "version": "1.6.0-beta.0",
+  "license": "Apache-2.0",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "files": [
+    "lib"
+  ],
+  "devDependencies": {
+    "@xbuilder/bunadmin": "^1.6.0-beta.0",
+    "prettier": "1.19.1",
+    "typescript": "4.8.3"
+  },
+  "scripts": {
+    "tsc:watch": "tsc -w",
+    "tsc:clean": "tsc --build --clean",
+    "tsc:build": "tsc"
+  }
+}

--- a/plugins/bunadmin-auth-pocketbase/sign-in/controllers/submitController.ts
+++ b/plugins/bunadmin-auth-pocketbase/sign-in/controllers/submitController.ts
@@ -1,0 +1,55 @@
+import { Values } from "../types"
+import userSignInService from "../services/signInService"
+import {
+  BA_DB,
+  AuthPrimary as Primary,
+  notice,
+  Router,
+  SETTING_NAMES
+} from "@xbuilder/bunadmin"
+import { TFunction } from "i18next"
+
+interface Props {
+  t: TFunction
+  values: Values
+  setSubmitting: (isSubmitting: boolean) => void
+  router: Router
+}
+
+const submitController = async ({ t, values, setSubmitting, router }: Props) => {
+  const res = await userSignInService(values)
+  setSubmitting(false)
+
+  if (res && res.user) {
+    const db = BA_DB
+    const updated_at = Date.now()
+    await db.users.put({
+      [Primary]: res.user.username,
+      token: res.token,
+      id: res.id,
+      role: res.user.role,
+      details: JSON.stringify(res),
+      updated_at
+    })
+    await db.settings.put({
+      name: Primary,
+      value: res.user.username,
+      updated_at: Date.now()
+    })
+    await db.settings.put({
+      name: SETTING_NAMES.role,
+      value: res.user.role,
+      updated_at: Date.now()
+    })
+    await notice({ title: t("Sign in successful") })
+    router.push("/")
+  } else {
+    await notice({
+      title: t("Sign in failed"),
+      severity: "error",
+      content: JSON.stringify(res)
+    })
+  }
+}
+
+export default submitController

--- a/plugins/bunadmin-auth-pocketbase/sign-in/controllers/validateController.ts
+++ b/plugins/bunadmin-auth-pocketbase/sign-in/controllers/validateController.ts
@@ -1,0 +1,17 @@
+import { Values } from "../types"
+import { TFunction } from "i18next"
+
+export default function validateController(values: Values, t: TFunction) {
+  const errors: Partial<Values> = {}
+  if (!values.username) {
+    errors.username = "Required"
+  } else if (values.username.length < 3) {
+    errors.username = t("Username must be at least 3 characters long.")
+  }
+  if (!values.password) {
+    errors.password = "Required"
+  } else if (values.password.length < 6) {
+    errors.password = t("Passwords must be at least 6 characters long.")
+  }
+  return errors
+}

--- a/plugins/bunadmin-auth-pocketbase/sign-in/index.tsx
+++ b/plugins/bunadmin-auth-pocketbase/sign-in/index.tsx
@@ -1,0 +1,74 @@
+import React from "react"
+import { Form, Formik, Field, ErrorMessage } from "formik"
+import validateController from "./controllers/validateController"
+import submitController from "./controllers/submitController"
+import { Values } from "./types"
+import { ENV, useTranslation, useRouter } from "@xbuilder/bunadmin"
+
+export default function SignInContainer() {
+  const { t } = useTranslation("plugins")
+  const router = useRouter()
+
+  const handleOnSubmit = async (
+    values: Values,
+    { setSubmitting }: { setSubmitting: (isSubmitting: boolean) => void }
+  ) => {
+    await submitController({ t, values, setSubmitting, router })
+  }
+
+  const fieldClass =
+    "mt-4 w-full rounded border border-gray-300 px-3 py-2.5 text-sm outline-none focus:border-primary focus:ring-1 focus:ring-primary"
+
+  return (
+    <div className="relative flex h-screen w-full items-center justify-center bg-content-bg">
+      <div className="m-8 flex max-w-[400px] flex-col items-center rounded bg-white p-8 shadow">
+        <h1 className="text-xl font-medium">{t("Sign in")}</h1>
+        <p className="mt-1 text-xs text-icon-muted">PocketBase</p>
+        <div className="mt-2 w-full">
+          <Formik
+            initialValues={{ username: "", password: "" }}
+            validate={values => validateController(values, t)}
+            onSubmit={handleOnSubmit}
+          >
+            {({ isSubmitting }) => (
+              <Form>
+                <Field
+                  name="username"
+                  type="text"
+                  placeholder={t("Username")}
+                  className={fieldClass}
+                />
+                <ErrorMessage
+                  name="username"
+                  component="div"
+                  className="mt-1 text-xs text-danger"
+                />
+                <Field
+                  name="password"
+                  type="password"
+                  placeholder={t("Password")}
+                  className={fieldClass}
+                />
+                <ErrorMessage
+                  name="password"
+                  component="div"
+                  className="mt-1 text-xs text-danger"
+                />
+                <button
+                  type="submit"
+                  disabled={isSubmitting}
+                  className="mb-2 mt-6 w-full rounded bg-primary py-2.5 text-sm font-medium text-white hover:bg-primary/90 disabled:opacity-50"
+                >
+                  {t("Sign in")}
+                </button>
+              </Form>
+            )}
+          </Formik>
+          <p className="mt-6 text-center text-[0.8125rem] text-gray-500">
+            {ENV.SITE_NAME} {new Date().getFullYear()}
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/plugins/bunadmin-auth-pocketbase/sign-in/services/signInService.ts
+++ b/plugins/bunadmin-auth-pocketbase/sign-in/services/signInService.ts
@@ -1,0 +1,34 @@
+import { ENV, request } from "@xbuilder/bunadmin"
+
+export interface SignInParamsType {
+  username: string
+  password: string
+}
+
+/**
+ * PocketBase auth: POST /api/collections/users/auth-with-password
+ *   body { identity, password } -> { token, record }
+ * Mapped to bunadmin's expected shape { id, token, user }.
+ */
+export default async function userSignInService(params: SignInParamsType) {
+  const { username, password } = params
+
+  const res = await request("/api/collections/users/auth-with-password", {
+    prefix: ENV.AUTH_URL,
+    method: "POST",
+    data: { identity: username, password }
+  })
+
+  if (!res || !res.token || !res.record) {
+    return { errors: res || "Sign in failed" }
+  }
+
+  return {
+    id: res.record.id,
+    token: res.token,
+    user: {
+      username: res.record.username || res.record.email || username,
+      role: res.record.role || "user"
+    }
+  }
+}

--- a/plugins/bunadmin-auth-pocketbase/sign-in/types.ts
+++ b/plugins/bunadmin-auth-pocketbase/sign-in/types.ts
@@ -1,0 +1,4 @@
+export interface Values {
+  username: string
+  password: string
+}

--- a/plugins/bunadmin-auth-pocketbase/tsconfig.json
+++ b/plugins/bunadmin-auth-pocketbase/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig",
+  "compilerOptions": {
+    "jsx": "react",
+    "rootDir": "./",
+    "outDir": "./lib",
+    "declaration": true,
+    "declarationDir": "./lib",
+    "baseUrl": "./"
+  },
+  "exclude": ["node_modules", "lib"],
+  "include": ["*.ts", "*.tsx", "**/*.ts", "**/*.tsx"]
+}

--- a/plugins/bunadmin-auth-pocketbase/utils/initData.ts
+++ b/plugins/bunadmin-auth-pocketbase/utils/initData.ts
@@ -1,0 +1,17 @@
+import { IPluginData } from "@xbuilder/bunadmin"
+
+const plugin = "auth-pocketbase"
+
+const data: IPluginData[] = [
+  {
+    id: "bunadmin_auth_pocketbase_sign_in",
+    group: "auth-pocketbase",
+    name: "sign-in",
+    label: "Sign-in",
+    team: "bunadmin",
+    customized: true,
+    ignore_menu: true
+  }
+]
+
+export default { plugin, data }

--- a/plugins/bunadmin-auth-pocketbase/utils/types.ts
+++ b/plugins/bunadmin-auth-pocketbase/utils/types.ts
@@ -1,0 +1,9 @@
+/** PocketBase user record (subset). */
+export interface IUser {
+  id: string
+  username?: string
+  email?: string
+  role?: string
+  created?: string
+  updated?: string
+}


### PR DESCRIPTION
Adds a **production-level PocketBase backend integration** for bunadmin, modeled on the existing strapi plugins. Validated against a live PocketBase 0.22 instance (spike A).

## `packages/bunadmin-source-pocketbase`
Data source implementing the full contract:
- `listSer` — maps bunadmin `Query` (filters/search/sort/pagination) to PocketBase REST: `/api/collections/{name}/records?page=&perPage=&filter=&sort=`, response `{items,totalItems}`. Column operators → PB filter expressions (`=` `~` `!~` `>` `>=` `<` `<=`).
- `addSer`/`updateSer`/`deleteSer`/`bulkDeleteSer`/`bulkUpdateSer` (POST/PATCH/DELETE flat records).
- `dataCtrl`/`editableCtrl`/`bulkDeleteCtrl`.

## `plugins/bunadmin-auth-pocketbase`
- `signInService` — `POST /api/collections/users/auth-with-password` → `{token, record}`, mapped to bunadmin's `{id, token, user}`.
- `submitController` stores the real PB token + profile; Tailwind sign-in UI; `IAuthPlugin` exports; `initData`.

## Verification
- Both packages `tsc:build` clean; full `lerna tsc:build` = **12 projects** ✓.
- The `listSer` query shape was exercised against a **live PocketBase**: `?page=1&perPage=10&sort=-views&filter=status='Published' && name~'Post'` → correct `{items,totalItems}`.

## Usage (demo)
1. Run PocketBase, create a `users` auth collection + your data collections.
2. In a bunadmin project: set `VITE_AUTH_PLUGIN=@xbuilder/bunadmin-auth-pocketbase`, `VITE_AUTH_URL=http://127.0.0.1:8090`, and use `dataCtrl` from `@xbuilder/bunadmin-source-pocketbase` in a schema's `data`.

> Note: targets PocketBase 0.22 user-collection auth (stable across versions). Admin/superuser endpoints differ in 0.23+ but aren't used at runtime.