### PR TITLE
fix: don't force auth-local as a runtime dep of @xbuilder/bunadmin

### DIFF
--- a/packages/bunadmin/package.json
+++ b/packages/bunadmin/package.json
@@ -35,7 +35,6 @@
   "dependencies": {
     "@headlessui/react": "^1.7.19",
     "@reduxjs/toolkit": "1.8.4",
-    "@xbuilder/bunadmin-auth-local": "^1.6.0-beta.0",
     "del": "^6.1.1",
     "dexie": "^3.2.2",
     "dexie-export-import": "^1.0.3",
@@ -57,6 +56,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.45.0",
+    "@xbuilder/bunadmin-auth-local": "^1.6.0-beta.0",
     "@testing-library/jest-dom": "^5.11.10",
     "@testing-library/react": "^15.0.7",
     "@types/jest": "^26.0.15",

--- a/packages/bunadmin/src/utils/node/plugin-action.ts
+++ b/packages/bunadmin/src/utils/node/plugin-action.ts
@@ -74,9 +74,13 @@ export function getPluginNames(packageJson: string): string[] {
 
   try {
     const content = b.toString()
-    const obj: { [k: string]: string } = JSON.parse(content)
+    const obj: {
+      dependencies?: { [k: string]: string }
+      devDependencies?: { [k: string]: string }
+    } = JSON.parse(content)
 
-    pluginNames = Object.keys(obj.dependencies || {}).filter(k => {
+    const allDeps = { ...obj.dependencies, ...obj.devDependencies }
+    pluginNames = Object.keys(allDeps).filter(k => {
       const matchPlugins = [
         "bunadmin-auth",
         "bunadmin-upload",


### PR DESCRIPTION
Found while wiring a demo project to the new PocketBase auth plugin: `@xbuilder/bunadmin` listed `@xbuilder/bunadmin-auth-local` in **`dependencies`**, forcing *every* consumer to install auth-local even when using a different auth plugin. Auth plugins are loaded **dynamically** (generator + `.env`), never imported by bunadmin's source.

## Changes
- Move `@xbuilder/bunadmin-auth-local` from `dependencies` → `devDependencies` (still present for this repo's own dev/demo build).
- `getPluginNames` now scans **both** `dependencies` and `devDependencies`, so the generator still discovers plugins declared in either (keeps the main app's auth working).

## Verification
- Generator rediscovers auth-local from devDeps (auth index populated) ✓
- Main app `vite build` ✓; `lerna tsc:build` (10 pkgs) ✓; `vitest` 66 ✓
- A consumer project using **pocketbase auth (no auth-local)** now `yarn install`s **clean** — previously it 404'd on the forced `auth-local@^1.6.0-beta.0` and needed a resolution workaround.

## Related follow-up (not in this PR)
The CLI template's `[group]-[name].tsx` hardcodes `import { SignIn } from "@xbuilder/bunadmin-auth-local"`. The default template defaulting to auth-local is reasonable, but switching auth plugins currently requires editing that import — worth a follow-up to make the auth component configurable.