### PR TITLE
fix(cli): resolve auth sign-in dynamically (no hardcoded plugin)

### DIFF
--- a/packages/bunadmin-cli/templates/typescript-vite/src/pages/[group]-[name].tsx
+++ b/packages/bunadmin-cli/templates/typescript-vite/src/pages/[group]-[name].tsx
@@ -5,13 +5,23 @@ import {
   SchemaContainer,
   withoutLayout,
   useRouter,
+  DEFAULT_AUTH_PLUGIN,
   MenuType
 } from "@xbuilder/bunadmin"
 import PluginTable from "../components/PluginTable"
 import DefaultLayout from "../components/DefaultLayout"
 import Error from "../components/Error"
 import Index from "./index"
-import { SignIn as AuthComponent } from "@xbuilder/bunadmin-auth-local"
+import { getDynamicIndex } from "../pluginRegistry"
+
+// Auth sign-in component is resolved from the configured auth plugin
+// (VITE_AUTH_PLUGIN) via the registry — no hardcoded plugin import.
+function AuthComponent() {
+  const name = process.env.VITE_AUTH_PLUGIN || DEFAULT_AUTH_PLUGIN
+  const plugin = getDynamicIndex()[name]
+  const SignIn = plugin && plugin.SignIn
+  return SignIn ? <SignIn /> : null
+}
 
 const DynamicGroupNamePage = ({
   leftMenuData,


### PR DESCRIPTION
Follow-up to #54. The Vite template's `[group]-[name].tsx` hardcoded:
```ts
import { SignIn as AuthComponent } from "@xbuilder/bunadmin-auth-local"
```
So a `bunadmin new` project using a different auth plugin (e.g. PocketBase) had to **edit source**, and the build broke outright if `auth-local` wasn't installed (caught while testing the PocketBase demo).

## Fix
Resolve the auth sign-in component from the configured `VITE_AUTH_PLUGIN` via the plugin registry:
```ts
function AuthComponent() {
  const name = process.env.VITE_AUTH_PLUGIN || DEFAULT_AUTH_PLUGIN
  const SignIn = getDynamicIndex()[name]?.SignIn
  return SignIn ? <SignIn /> : null
}
```
Switching auth plugins is now a **`.env`-only** change — no hardcoded plugin import.

## Verified
Demo project with `VITE_AUTH_PLUGIN=@xbuilder/bunadmin-auth-pocketbase` (no auth-local installed):
- `vite build` ✓ (no hardcoded auth-plugin import remains)
- bundle wires PocketBase auth (`auth-with-password`) via dynamic resolution
- live auth + list round-trips against PocketBase ✓