### PR TITLE
test+docs: PocketBase plugin tests, guide, seed script, worked example

### DIFF
--- a/docs/pocketbase/README.md
+++ b/docs/pocketbase/README.md
@@ -1,0 +1,78 @@
+# Using PocketBase with BunAdmin
+
+[PocketBase](https://pocketbase.io) is a single-binary backend (auth + collections
++ REST API, embedded SQLite) — a zero-build way to run a real auth + CMS backend
+for a BunAdmin project.
+
+BunAdmin ships two plugins for it:
+
+- **`@xbuilder/bunadmin-source-pocketbase`** — data source (list/add/update/delete/
+  bulk) mapping the table query to PocketBase's REST API.
+- **`@xbuilder/bunadmin-auth-pocketbase`** — auth plugin (sign-in via
+  `users` collection).
+
+## 1. Run PocketBase
+
+```bash
+# download the binary for your OS from https://pocketbase.io/docs/
+./pocketbase admin create admin@bunadmin.test bunadmin123   # PocketBase 0.22
+# (0.23+: ./pocketbase superuser create admin@bunadmin.test bunadmin123)
+./pocketbase serve --http=127.0.0.1:8090
+```
+
+Admin UI: http://127.0.0.1:8090/_/
+
+## 2. Seed demo data
+
+With PocketBase running:
+
+```bash
+node docs/pocketbase/seed.js
+```
+
+Creates a `posts` collection, a demo user (`demo` / `bunadmin123`), and a few
+records. Override with `PB_URL`, `PB_ADMIN`, `PB_ADMIN_PW` env vars.
+
+## 3. Point your BunAdmin project at it
+
+In your project's `.env`:
+
+```
+VITE_AUTH_PLUGIN=@xbuilder/bunadmin-auth-pocketbase
+VITE_AUTH_URL=http://127.0.0.1:8090
+```
+
+Install the plugins:
+
+```bash
+yarn add @xbuilder/bunadmin-auth-pocketbase @xbuilder/bunadmin-source-pocketbase
+```
+
+## 4. Render a collection as a table
+
+See [`example-posts.tsx`](./example-posts.tsx) for a complete `posts` page.
+The key wiring:
+
+```tsx
+import { dataCtrl, editableCtrl } from "@xbuilder/bunadmin-source-pocketbase"
+
+<Table
+  columns={columns}
+  data={query => dataCtrl({ t, tableQuery: query, path: "posts" })}  // PB collection
+  editable={editableCtrl({ t, SchemaName: "posts" })}
+  options={{ filtering: true }}
+/>
+```
+
+- `dataCtrl` maps the table query → `?page=&perPage=&filter=&sort=` and returns
+  `{ data, totalCount }`. Column filter operators map to PocketBase filter
+  expressions (`=` `~` `!~` `>` `>=` `<` `<=`).
+- `editableCtrl` wires inline create/update/delete to
+  `POST/PATCH/DELETE /api/collections/posts/records`.
+
+## Notes
+
+- The auth plugin authenticates against PocketBase's built-in `users` collection
+  (`/api/collections/users/auth-with-password`) and stores the returned token.
+- Auth-plugin selection is `.env`-driven; no source changes are needed to switch
+  backends.

--- a/docs/pocketbase/example-posts.tsx
+++ b/docs/pocketbase/example-posts.tsx
@@ -1,0 +1,62 @@
+/**
+ * Worked example: a `posts` page backed by PocketBase via
+ * @xbuilder/bunadmin-source-pocketbase.
+ *
+ * Drop this into a bunadmin project's plugin (e.g. src/plugins/bunadmin-plugin-
+ * myteam-blog/posts/index.tsx) and register it like any other schema plugin.
+ * Requires a PocketBase `posts` collection (see docs/pocketbase/seed.js).
+ */
+import React, { createRef } from "react"
+import {
+  Table,
+  TableHead,
+  tableIcons,
+  TableDefaultProps as DefaultProps,
+  useTranslation,
+  Column
+} from "@xbuilder/bunadmin"
+import { dataCtrl, editableCtrl } from "@xbuilder/bunadmin-source-pocketbase"
+
+const theme = { bunadmin: { iconColor: "#8f9bb3" } }
+
+interface Post {
+  id: string
+  name: string
+  status: string
+  views: number
+}
+
+const columns = ({ t }: { t: any }): Column<Post>[] => [
+  { title: t("Id"), field: "id", editable: "never", width: 180 },
+  { title: t("Name"), field: "name" },
+  {
+    title: t("Status"),
+    field: "status",
+    lookup: { Draft: "Draft", Published: "Published" }
+  },
+  { title: t("Views"), field: "views", type: "numeric" }
+]
+
+export default function Posts() {
+  const { t } = useTranslation("table")
+  const tableRef = createRef()
+  const SchemaName = "posts" // PocketBase collection name
+
+  return (
+    <>
+      <TableHead title="Posts" />
+      <Table<Post>
+        tableRef={tableRef}
+        title="Posts"
+        columns={columns({ t })}
+        style={DefaultProps.style}
+        icons={tableIcons({ theme })}
+        options={{ ...DefaultProps.options, filtering: true }}
+        // Remote data via PocketBase
+        data={query => dataCtrl({ t, tableQuery: query, path: SchemaName })}
+        // Inline create / update / delete via PocketBase
+        editable={editableCtrl({ t, SchemaName })}
+      />
+    </>
+  )
+}

--- a/docs/pocketbase/seed.js
+++ b/docs/pocketbase/seed.js
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+/**
+ * Seed a local PocketBase for the bunadmin demo.
+ * Usage:
+ *   node docs/pocketbase/seed.js            (PB at http://127.0.0.1:8090)
+ *   PB_URL=... PB_ADMIN=... PB_ADMIN_PW=... node docs/pocketbase/seed.js
+ *
+ * Creates: a `posts` collection (name/status/views), a demo user
+ * (demo / bunadmin123), and a few sample records. Idempotent-ish: ignores
+ * "already exists" errors.
+ */
+const PB = process.env.PB_URL || "http://127.0.0.1:8090"
+const ADMIN = process.env.PB_ADMIN || "admin@bunadmin.test"
+const ADMIN_PW = process.env.PB_ADMIN_PW || "bunadmin123"
+
+async function api(path, opts = {}, token) {
+  const res = await fetch(`${PB}${path}`, {
+    method: opts.method || "GET",
+    headers: {
+      "Content-Type": "application/json",
+      ...(token ? { Authorization: token } : {})
+    },
+    body: opts.body ? JSON.stringify(opts.body) : undefined
+  })
+  const json = await res.json().catch(() => ({}))
+  return { ok: res.ok, status: res.status, json }
+}
+
+async function main() {
+  // Admin auth (PocketBase 0.22: /api/admins; 0.23+: /api/collections/_superusers)
+  let auth = await api("/api/admins/auth-with-password", {
+    method: "POST",
+    body: { identity: ADMIN, password: ADMIN_PW }
+  })
+  if (!auth.ok)
+    auth = await api("/api/collections/_superusers/auth-with-password", {
+      method: "POST",
+      body: { identity: ADMIN, password: ADMIN_PW }
+    })
+  if (!auth.ok) {
+    console.error("Admin auth failed. Create an admin first:")
+    console.error("  ./pocketbase admin create", ADMIN, ADMIN_PW)
+    process.exit(1)
+  }
+  const token = auth.json.token
+
+  // posts collection
+  const coll = await api(
+    "/api/collections",
+    {
+      method: "POST",
+      body: {
+        name: "posts",
+        type: "base",
+        listRule: "",
+        viewRule: "",
+        createRule: "",
+        updateRule: "",
+        deleteRule: "",
+        schema: [
+          { name: "name", type: "text", required: true },
+          {
+            name: "status",
+            type: "select",
+            options: { maxSelect: 1, values: ["Draft", "Published"] }
+          },
+          { name: "views", type: "number" }
+        ]
+      }
+    },
+    token
+  )
+  console.log("posts collection:", coll.ok ? "created" : `skip (${coll.status})`)
+
+  // demo user
+  const user = await api(
+    "/api/collections/users/records",
+    {
+      method: "POST",
+      body: {
+        username: "demo",
+        email: "demo@bunadmin.test",
+        password: "bunadmin123",
+        passwordConfirm: "bunadmin123"
+      }
+    },
+    token
+  )
+  console.log("demo user:", user.ok ? "created (demo / bunadmin123)" : `skip (${user.status})`)
+
+  // sample records
+  for (let i = 1; i <= 3; i++) {
+    const r = await api(
+      "/api/collections/posts/records",
+      {
+        method: "POST",
+        body: {
+          name: `Post ${i}`,
+          status: i % 2 ? "Draft" : "Published",
+          views: i * 10
+        }
+      },
+      token
+    )
+    console.log(`post ${i}:`, r.ok ? "created" : `skip (${r.status})`)
+  }
+  console.log("\nDone. Set your bunadmin .env:")
+  console.log("  VITE_AUTH_PLUGIN=@xbuilder/bunadmin-auth-pocketbase")
+  console.log(`  VITE_AUTH_URL=${PB}`)
+}
+
+main().catch(e => {
+  console.error(e)
+  process.exit(1)
+})

--- a/packages/bunadmin-source-pocketbase/package.json
+++ b/packages/bunadmin-source-pocketbase/package.json
@@ -10,11 +10,13 @@
   "devDependencies": {
     "@xbuilder/bunadmin": "^1.6.0-beta.0",
     "prettier": "1.19.1",
-    "typescript": "4.8.3"
+    "typescript": "4.8.3",
+    "vitest": "^1.6.0"
   },
   "scripts": {
     "tsc:watch": "tsc -w",
     "tsc:clean": "tsc --build --clean",
-    "tsc:build": "tsc"
+    "tsc:build": "tsc",
+    "test": "vitest run"
   }
 }

--- a/packages/bunadmin-source-pocketbase/services/__tests__/filter.test.ts
+++ b/packages/bunadmin-source-pocketbase/services/__tests__/filter.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest"
+import { escape, buildClause, buildFilter, buildSort } from "../filter"
+
+describe("buildClause", () => {
+  it("maps eq / contains / not-contains", () => {
+    expect(buildClause("name", "=", "a")).toBe("name='a'")
+    expect(buildClause("name", "_cs=", "a")).toBe("name~'a'")
+    expect(buildClause("name", "_ncs=", "a")).toBe("name!~'a'")
+    expect(buildClause("name", "!=", "a")).toBe("name!='a'")
+  })
+  it("maps numeric comparisons (unquoted)", () => {
+    expect(buildClause("views", ">", 5)).toBe("views>5")
+    expect(buildClause("views", ">=", 5)).toBe("views>=5")
+    expect(buildClause("views", "<", 5)).toBe("views<5")
+    expect(buildClause("views", "<=", 5)).toBe("views<=5")
+  })
+  it("defaults unknown operators to contains", () => {
+    expect(buildClause("name", "???", "a")).toBe("name~'a'")
+  })
+})
+
+describe("escape", () => {
+  it("escapes single quotes", () => {
+    expect(escape("o'brien")).toBe("o\\'brien")
+  })
+})
+
+describe("buildFilter", () => {
+  const f = (field: string, operator: string, value: any) =>
+    ({ column: { field }, operator, value } as any)
+
+  it("joins multiple clauses with &&", () => {
+    expect(
+      buildFilter([f("status", "=", "Published"), f("views", ">", 5)])
+    ).toBe("status='Published' && views>5")
+  })
+  it("skips empty/undefined values", () => {
+    expect(buildFilter([f("a", "=", ""), f("b", "=", undefined)])).toBe("")
+  })
+  it("appends a search clause on the search field", () => {
+    expect(buildFilter([], "hello", "name")).toBe("name~'hello'")
+  })
+})
+
+describe("buildSort", () => {
+  it("defaults to -created with no orderBy", () => {
+    expect(buildSort(undefined, "asc")).toBe("-created")
+  })
+  it("prefixes - for desc", () => {
+    expect(buildSort({ field: "views" }, "desc")).toBe("-views")
+    expect(buildSort({ field: "views" }, "asc")).toBe("views")
+  })
+})

--- a/packages/bunadmin-source-pocketbase/services/filter.ts
+++ b/packages/bunadmin-source-pocketbase/services/filter.ts
@@ -1,0 +1,59 @@
+/**
+ * Pure helpers that map bunadmin table filters to a PocketBase `filter`
+ * expression. Kept separate from listSer so they're unit-testable.
+ */
+import { Filter } from "@xbuilder/bunadmin"
+
+export function escape(v: any): string {
+  return String(v).replace(/'/g, "\\'")
+}
+
+/** Map a single bunadmin column operator to a PocketBase filter clause. */
+export function buildClause(field: string, operator: string, value: any): string {
+  const v = escape(value)
+  switch (operator) {
+    case "!=":
+      return `${field}!='${v}'`
+    case ">":
+      return `${field}>${Number(value)}`
+    case ">=":
+      return `${field}>=${Number(value)}`
+    case "<":
+      return `${field}<${Number(value)}`
+    case "<=":
+      return `${field}<=${Number(value)}`
+    case "_ncs=":
+    case "_nc=":
+      return `${field}!~'${v}'`
+    case "=":
+      return `${field}='${v}'`
+    case "_cs=":
+    case "_c=":
+    default:
+      return `${field}~'${v}'`
+  }
+}
+
+/**
+ * Build the full PocketBase `filter` expression from table filters + an
+ * optional search term, e.g. `status='Published' && name~'a'`.
+ */
+export function buildFilter(
+  filters: Filter<any>[],
+  searchWords?: string,
+  searchField = "name"
+): string {
+  const clauses: string[] = []
+  filters.forEach(({ column: { field }, operator, value }) => {
+    if (!field || value === undefined || value === "") return
+    clauses.push(buildClause(String(field), operator as string, value))
+  })
+  if (searchWords) clauses.push(`${searchField}~'${escape(searchWords)}'`)
+  return clauses.join(" && ")
+}
+
+/** PocketBase sort param: `field` (asc) / `-field` (desc); default `-created`. */
+export function buildSort(orderBy?: any, orderDirection?: string): string {
+  const field = (orderBy && orderBy.field && orderBy.field.toString()) || "created"
+  return orderBy ? `${orderDirection === "desc" ? "-" : ""}${field}` : "-created"
+}

--- a/packages/bunadmin-source-pocketbase/services/listSer.ts
+++ b/packages/bunadmin-source-pocketbase/services/listSer.ts
@@ -5,6 +5,7 @@
  */
 import { ENV, request, storedToken } from "@xbuilder/bunadmin"
 import { ListService } from "../types"
+import { buildFilter, buildSort } from "./filter"
 
 export default async function listSer<RowData extends object>({
   tableQuery,
@@ -21,21 +22,8 @@ export default async function listSer<RowData extends object>({
     pageSize
   } = tableQuery
 
-  // Build the PocketBase `filter` expression, e.g. status='Published' && name~'a'
-  const clauses: string[] = []
-  filters.forEach(({ column: { field }, operator, value }) => {
-    if (!field || value === undefined || value === "") return
-    clauses.push(buildClause(String(field), operator as string, value))
-  })
-  if (searchWords) clauses.push(`${searchField}~'${escape(searchWords)}'`)
-  const filter = clauses.join(" && ")
-
-  // PocketBase sort: `field` (asc) / `-field` (desc)
-  const sortField =
-    (orderBy && orderBy.field && orderBy.field.toString()) || "created"
-  const sort = orderBy
-    ? `${orderDirection === "desc" ? "-" : ""}${sortField}`
-    : "-created"
+  const filter = buildFilter(filters as any, searchWords, searchField)
+  const sort = buildSort(orderBy, orderDirection)
 
   const token = await storedToken()
 
@@ -55,35 +43,5 @@ export default async function listSer<RowData extends object>({
     data: data.items || [],
     totalCount: data.totalItems || 0,
     errors: data.code && data.code >= 400 ? data : undefined
-  }
-}
-
-function escape(v: any): string {
-  return String(v).replace(/'/g, "\\'")
-}
-
-/** Map a bunadmin column operator to a PocketBase filter clause. */
-function buildClause(field: string, operator: string, value: any): string {
-  const v = escape(value)
-  switch (operator) {
-    case "!=":
-      return `${field}!='${v}'`
-    case ">":
-      return `${field}>${Number(value)}`
-    case ">=":
-      return `${field}>=${Number(value)}`
-    case "<":
-      return `${field}<${Number(value)}`
-    case "<=":
-      return `${field}<=${Number(value)}`
-    case "_ncs=":
-    case "_nc=":
-      return `${field}!~'${v}'`
-    case "=":
-      return `${field}='${v}'`
-    case "_cs=":
-    case "_c=":
-    default:
-      return `${field}~'${v}'`
   }
 }

--- a/packages/bunadmin-source-pocketbase/tsconfig.json
+++ b/packages/bunadmin-source-pocketbase/tsconfig.json
@@ -7,6 +7,15 @@
     "declarationDir": "./lib",
     "baseUrl": "./"
   },
-  "exclude": ["node_modules", "lib"],
-  "include": ["*.ts", "*.tsx"]
+  "exclude": [
+    "node_modules",
+    "lib",
+    "**/__tests__/**",
+    "**/*.test.ts",
+    "**/*.test.tsx"
+  ],
+  "include": [
+    "*.ts",
+    "*.tsx"
+  ]
 }

--- a/plugins/bunadmin-auth-pocketbase/package.json
+++ b/plugins/bunadmin-auth-pocketbase/package.json
@@ -10,11 +10,13 @@
   "devDependencies": {
     "@xbuilder/bunadmin": "^1.6.0-beta.0",
     "prettier": "1.19.1",
-    "typescript": "4.8.3"
+    "typescript": "4.8.3",
+    "vitest": "^1.6.0"
   },
   "scripts": {
     "tsc:watch": "tsc -w",
     "tsc:clean": "tsc --build --clean",
-    "tsc:build": "tsc"
+    "tsc:build": "tsc",
+    "test": "vitest run"
   }
 }

--- a/plugins/bunadmin-auth-pocketbase/sign-in/services/__tests__/signInService.test.ts
+++ b/plugins/bunadmin-auth-pocketbase/sign-in/services/__tests__/signInService.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest"
+import { mapPbAuth } from "../signInService"
+
+describe("mapPbAuth", () => {
+  it("maps a valid PocketBase auth response to {id, token, user}", () => {
+    const res = {
+      token: "tok",
+      record: { id: "abc", username: "demo", role: "admin" }
+    }
+    expect(mapPbAuth(res)).toEqual({
+      id: "abc",
+      token: "tok",
+      user: { username: "demo", role: "admin" }
+    })
+  })
+
+  it("falls back to email then provided username, and defaults role", () => {
+    expect(
+      mapPbAuth({ token: "t", record: { id: "1", email: "e@x.io" } }).user
+    ).toEqual({ username: "e@x.io", role: "user" })
+    expect(
+      mapPbAuth({ token: "t", record: { id: "1" } }, "fallback").user
+    ).toEqual({ username: "fallback", role: "user" })
+  })
+
+  it("returns errors when token/record missing", () => {
+    expect(mapPbAuth({ code: 400 }).errors).toBeTruthy()
+    expect(mapPbAuth(null).errors).toBeTruthy()
+  })
+})

--- a/plugins/bunadmin-auth-pocketbase/sign-in/services/signInService.ts
+++ b/plugins/bunadmin-auth-pocketbase/sign-in/services/signInService.ts
@@ -6,6 +6,24 @@ export interface SignInParamsType {
 }
 
 /**
+ * Map a PocketBase auth-with-password response to bunadmin's expected shape.
+ * Pure (no network) so it's unit-testable.
+ */
+export function mapPbAuth(res: any, fallbackUsername?: string) {
+  if (!res || !res.token || !res.record) {
+    return { errors: res || "Sign in failed" }
+  }
+  return {
+    id: res.record.id,
+    token: res.token,
+    user: {
+      username: res.record.username || res.record.email || fallbackUsername,
+      role: res.record.role || "user"
+    }
+  }
+}
+
+/**
  * PocketBase auth: POST /api/collections/users/auth-with-password
  *   body { identity, password } -> { token, record }
  * Mapped to bunadmin's expected shape { id, token, user }.
@@ -19,16 +37,5 @@ export default async function userSignInService(params: SignInParamsType) {
     data: { identity: username, password }
   })
 
-  if (!res || !res.token || !res.record) {
-    return { errors: res || "Sign in failed" }
-  }
-
-  return {
-    id: res.record.id,
-    token: res.token,
-    user: {
-      username: res.record.username || res.record.email || username,
-      role: res.record.role || "user"
-    }
-  }
+  return mapPbAuth(res, username)
 }

--- a/plugins/bunadmin-auth-pocketbase/tsconfig.json
+++ b/plugins/bunadmin-auth-pocketbase/tsconfig.json
@@ -8,6 +8,17 @@
     "declarationDir": "./lib",
     "baseUrl": "./"
   },
-  "exclude": ["node_modules", "lib"],
-  "include": ["*.ts", "*.tsx", "**/*.ts", "**/*.tsx"]
+  "exclude": [
+    "node_modules",
+    "lib",
+    "**/__tests__/**",
+    "**/*.test.ts",
+    "**/*.test.tsx"
+  ],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    "**/*.ts",
+    "**/*.tsx"
+  ]
 }


### PR DESCRIPTION
Follow-ups #1–#3 to make the new PocketBase integration repeatable and protected.

## (3) Tests — the new PB packages had zero tests
- Extracted the pure logic so it's unit-testable:
  - `source-pocketbase/services/filter.ts` — `escape`, `buildClause` (operator→PB filter), `buildFilter`, `buildSort`. `listSer` now imports these.
  - `auth-pocketbase` `mapPbAuth` — the PB auth-response → `{id, token, user}` mapping, split out of `signInService`.
- Added `vitest` + `test` script to both packages; excluded `__tests__` from the `tsc` lib builds.
- **12 tests** (9 filter/sort + 3 auth mapping), all green.

## (1) Repeatable docs + seed
- `docs/pocketbase/README.md` — run PocketBase → seed → `.env` → render a collection.
- `docs/pocketbase/seed.js` — creates the `posts` collection, a demo user (`demo`/`bunadmin123`), and sample records. Idempotent; handles both PB 0.22 (`/api/admins`) and 0.23+ (`/api/collections/_superusers`) admin auth. Verified against a live PocketBase.

## (2) Worked example
- `docs/pocketbase/example-posts.tsx` — a `posts` page wired to `dataCtrl`/`editableCtrl` (remote list + filter/sort + inline CRUD).

## Verified
- `lerna tsc:build` — 12 projects ✓
- Both PB package test suites ✓; main app vitest 66 ✓ (unaffected)
- `seed.js` runs against live PocketBase ✓

Note: npm publish of `1.6.0-beta.0` remains intentionally parked.