### PR TITLE
feat(ui): theme toggle + tokenize TopBar/Table (visible design system)

### DIFF
--- a/packages/bunadmin/src/components/Table/components/Pagination.tsx
+++ b/packages/bunadmin/src/components/Table/components/Pagination.tsx
@@ -19,7 +19,7 @@ export default function Pagination({
 }: Props) {
   const btn = "rounded px-2 py-1 disabled:opacity-30"
   return (
-    <div className="flex items-center justify-end gap-4 px-4 py-2 text-sm text-gray-600">
+    <div className="flex items-center justify-end gap-4 px-4 py-2 text-sm text-icon-muted">
       <span>
         {from}-{to} of {total}
       </span>

--- a/packages/bunadmin/src/components/Table/index.tsx
+++ b/packages/bunadmin/src/components/Table/index.tsx
@@ -250,7 +250,7 @@ export default function Table<RowData extends object>(
     }
     return (
       <input
-        className="w-full rounded border border-gray-300 px-2 py-1 text-sm focus:border-primary focus:outline-none"
+        className="w-full rounded border border-bn-border px-2 py-1 text-sm focus:border-primary focus:outline-none"
         value={(data as any)[field] ?? ""}
         onChange={e => setField(field, e.target.value)}
       />
@@ -272,7 +272,7 @@ export default function Table<RowData extends object>(
     return (
       <React.Fragment key={ri}>
         <tr
-          className={`border-b border-gray-100 hover:bg-content-bg ${
+          className={`border-b border-bn-border hover:bg-content-bg ${
             onRowClick ? "cursor-pointer" : ""
           }`}
           onClick={onRowClick ? e => onRowClick(e, row) : undefined}
@@ -302,7 +302,7 @@ export default function Table<RowData extends object>(
                     return n
                   })
                 }
-                className="h-4 w-4 rounded border-gray-300 text-primary"
+                className="h-4 w-4 rounded border-bn-border text-primary"
               />
             </td>
           )}
@@ -332,7 +332,7 @@ export default function Table<RowData extends object>(
           )}
         </tr>
         {hasDetail && expanded === ri && (
-          <tr className="border-b border-gray-100 bg-content-bg/30">
+          <tr className="border-b border-bn-border bg-content-bg/30">
             <td colSpan={colSpan} className="px-4 py-2">
               {renderDetail(row)}
             </td>
@@ -412,7 +412,7 @@ export default function Table<RowData extends object>(
                   setPage(0)
                   setSearch(e.target.value)
                 }}
-                className="rounded border border-gray-300 px-2 py-1 text-sm focus:border-primary focus:outline-none"
+                className="rounded border border-bn-border px-2 py-1 text-sm focus:border-primary focus:outline-none"
               />
             )}
             {canAdd && (
@@ -448,7 +448,7 @@ export default function Table<RowData extends object>(
       <div className="overflow-x-auto">
         <table className="w-full border-collapse text-sm">
           <thead>
-            <tr className="border-b border-gray-200 text-left">
+            <tr className="border-b border-bn-border text-left">
               {hasDetail && <th className="w-8 px-4 py-2" />}
               {showSelection && (
                 <th className="w-8 px-4 py-2">
@@ -463,7 +463,7 @@ export default function Table<RowData extends object>(
                           : new Set(rows.map((_, i) => i))
                       )
                     }
-                    className="h-4 w-4 rounded border-gray-300 text-primary"
+                    className="h-4 w-4 rounded border-bn-border text-primary"
                   />
                 </th>
               )}
@@ -471,17 +471,17 @@ export default function Table<RowData extends object>(
                 <th
                   key={c.tableData!.id}
                   style={{ width: c.width }}
-                  className="cursor-pointer select-none px-4 py-2 font-semibold text-gray-600"
+                  className="cursor-pointer select-none px-4 py-2 font-semibold text-icon-muted"
                   onClick={() => toggleSort(c)}
                 >
                   {c.title}
                   {orderBy?.field === c.field && (orderDir === "asc" ? " ▲" : " ▼")}
                 </th>
               ))}
-              {hasRowActions && <th className="px-4 py-2 font-semibold text-gray-600">{t("actions")}</th>}
+              {hasRowActions && <th className="px-4 py-2 font-semibold text-icon-muted">{t("actions")}</th>}
             </tr>
             {showFiltering && (
-              <tr className="border-b border-gray-100">
+              <tr className="border-b border-bn-border">
                 {hasDetail && <td className="px-4 py-1" />}
                 {showSelection && <td className="px-4 py-1" />}
                 {cols.map(c => (
@@ -499,7 +499,7 @@ export default function Table<RowData extends object>(
                                 [c.tableData!.id]: e.target.value
                               }))
                             }
-                            className="rounded border border-gray-300 bg-content-bg px-1 py-1 text-xs text-gray-500 focus:border-primary focus:outline-none"
+                            className="rounded border border-bn-border bg-content-bg px-1 py-1 text-xs text-icon-muted focus:border-primary focus:outline-none"
                           >
                             {operatorOptions(c).map(o => (
                               <option key={o.v} value={o.v}>
@@ -510,7 +510,7 @@ export default function Table<RowData extends object>(
                         )}
                         <input
                           type={c.type === "numeric" ? "number" : "text"}
-                          className="w-full rounded border border-gray-300 px-2 py-1 text-xs focus:border-primary focus:outline-none"
+                          className="w-full rounded border border-bn-border px-2 py-1 text-xs focus:border-primary focus:outline-none"
                           onChange={e => {
                             setPage(0)
                             onFilterChanged(c.tableData!.id, e.target.value)
@@ -527,7 +527,7 @@ export default function Table<RowData extends object>(
           <tbody>
             {/* add row */}
             {editing?.mode === "add" && (
-              <tr className="border-b border-gray-100 bg-content-bg/50">
+              <tr className="border-b border-bn-border bg-content-bg/50">
                 {hasDetail && <td className="px-4 py-2" />}
                 {showSelection && <td className="px-4 py-2" />}
                 {cols.map(c => (

--- a/packages/bunadmin/src/components/TopBar/TopBarRightMenu/ThemeToggle.tsx
+++ b/packages/bunadmin/src/components/TopBar/TopBarRightMenu/ThemeToggle.tsx
@@ -1,0 +1,36 @@
+import React, { useEffect, useState } from "react"
+import { Sun, Moon } from "lucide-react"
+import { applyPreset, DEFAULT_PRESET } from "@/utils/themes/tokens"
+
+/**
+ * Light/dark theme toggle — calls applyPreset (the runtime token entrypoint).
+ * Persists the choice; the same applyPreset() a future `ai theme` result uses.
+ */
+const KEY = "bn-theme-mode"
+
+export default function ThemeToggle() {
+  const [mode, setMode] = useState<"light" | "dark">("light")
+
+  useEffect(() => {
+    const saved = (localStorage.getItem(KEY) as "light" | "dark") || "light"
+    setMode(saved)
+    applyPreset(DEFAULT_PRESET, saved)
+  }, [])
+
+  const toggle = () => {
+    const next = mode === "dark" ? "light" : "dark"
+    setMode(next)
+    localStorage.setItem(KEY, next)
+    applyPreset(DEFAULT_PRESET, next)
+  }
+
+  return (
+    <button
+      aria-label="toggle theme"
+      onClick={toggle}
+      className="inline-flex items-center justify-center rounded p-2 text-icon-muted hover:bg-primary/10"
+    >
+      {mode === "dark" ? <Moon size={18} /> : <Sun size={18} />}
+    </button>
+  )
+}

--- a/packages/bunadmin/src/components/TopBar/index.tsx
+++ b/packages/bunadmin/src/components/TopBar/index.tsx
@@ -7,6 +7,7 @@ import NoticeMenu from "./TopBarRightMenu/NoticeMenu"
 import I18nMenu from "@/components/TopBar/TopBarRightMenu/I18nMenu"
 import { ENV } from "@/utils/config"
 import DocMenu from "./TopBarRightMenu/DocMenu"
+import ThemeToggle from "./TopBarRightMenu/ThemeToggle"
 import { useRouter } from "@/router"
 import { DynamicDocRoute } from "@/utils/routes"
 import { NoticePlugin } from "@/utils"
@@ -40,7 +41,7 @@ export default function TopBar(props: TopBarProps) {
   const docsHome = props.docsHome || "/docs/getting-started/introduction"
 
   return (
-    <div className="relative z-[1201] border-b border-gray-200 bg-white">
+    <div className="relative z-[1201] border-b border-bn-border bg-sidebar">
       <div
         className="flex items-center justify-between pl-5"
         style={{ minHeight: HEADER_HEIGHT }}
@@ -51,7 +52,7 @@ export default function TopBar(props: TopBarProps) {
               <button
                 aria-label="open drawer"
                 onClick={menuClick}
-                className="inline-flex items-center justify-center rounded p-2 text-icon-muted hover:bg-gray-100"
+                className="inline-flex items-center justify-center rounded p-2 text-icon-muted hover:bg-primary/10"
               >
                 {/* menu-2-outline icon */}
                 <svg viewBox="0 0 24 24" className="h-5 w-5 fill-current">
@@ -79,6 +80,7 @@ export default function TopBar(props: TopBarProps) {
 
         <div className="flex items-center">
           {prependRight}
+          <ThemeToggle />
           {ENV.ON_I18N && <I18nMenu />}
           {ENV.ON_DOC && <DocMenu isDoc={isDoc} docsHome={docsHome} />}
           {!isDoc && (


### PR DESCRIPTION
Fixes "yarn dev looks the same as before": the token/preset engine from #62 was built but **nothing activated it**, and the dominant surfaces (TopBar, Table) still used hardcoded `bg-white`/`gray-*`.

## Changes
- **ThemeToggle** (sun/moon) in the TopBar → calls `applyPreset(DEFAULT_PRESET, mode)` and persists. This is the **live light↔dark switch** — the visible proof of the token system, and the exact `applyPreset` an `ai theme` result calls.
- **TopBar**: `bg-white`/`border-gray-200` → `bg-sidebar`/`border-bn-border` (was rendering white-on-dark).
- **Table + Pagination**: gray borders/text → token `border-bn-border`/`text-icon-muted` so the main content surface is correct in dark mode.

## Verify visually
`yarn dev` → click the sun/moon icon (top-right). The whole app flips to the modern dark preset (navy bg, indigo accent). That's the design system working end-to-end.

## Honest scope
Still hardcoded in ~20 smaller components (dialogs, some menus) — follow-up. This PR covers the high-visibility surfaces so the difference is actually visible.

Full suite 85; app vite build ok.