### PR TITLE
feat(ui): bunadmin-3 skin — icons, topbar, sections, stat band, table pills

### DIFF
--- a/packages/bunadmin/src/components/EvaIcon.tsx
+++ b/packages/bunadmin/src/components/EvaIcon.tsx
@@ -10,11 +10,17 @@ import {
   Hash,
   Lock,
   User,
+  Users,
   FilePlus,
+  FileText,
   Pencil,
   Trash2,
   Search,
   X,
+  Send,
+  Box,
+  Paperclip,
+  Code,
   ChevronLeft,
   ChevronRight,
   ChevronsLeft,
@@ -59,7 +65,24 @@ const MAP: Record<string, LucideIcon> = {
   "arrow-ios-forward": ChevronRight,
   "arrowhead-left": ChevronsLeft,
   "arrowhead-right": ChevronsRight,
-  "arrow-ios-downward-outline": ChevronDown
+  "arrow-ios-downward-outline": ChevronDown,
+  // menu icons
+  "file-text-outline": FileText,
+  "person-outline": User,
+  "people-outline": Users,
+  "paper-plane-outline": Send,
+  "cube-outline": Box,
+  "attach-outline": Paperclip,
+  code: Code,
+  refresh: RefreshCw,
+  "refresh-outline": RefreshCw,
+  delete: Trash2,
+  "trash-outline": Trash2,
+  "edit-outline": Pencil,
+  "file-add-outline": FilePlus,
+  "settings-2-outline": Settings,
+  "menu-2-outline": Layers,
+  "globe-outline": Box
 }
 
 const SIZE_PX: Record<string, number> = { small: 16, medium: 20, large: 24 }

--- a/packages/bunadmin/src/components/LeftMenu.tsx
+++ b/packages/bunadmin/src/components/LeftMenu.tsx
@@ -29,9 +29,15 @@ const LeftMenu = ({
       {prepend}
       {leftMenuData && <NestedList data={leftMenuData} />}
       {appendNested}
-      {!hideDivider && <hr className="mt-2 border-gray-200" />}
       {prependSetting}
-      {!offLeftSetting && ENV.ON_SETTING && <SettingMenu />}
+      {!offLeftSetting && ENV.ON_SETTING && (
+        <>
+          <div className="px-4 pt-4 pb-1 text-[11px] font-semibold tracking-wider text-icon-muted uppercase">
+            System
+          </div>
+          <SettingMenu />
+        </>
+      )}
       {append}
     </>
   )

--- a/packages/bunadmin/src/components/MenuIcon.tsx
+++ b/packages/bunadmin/src/components/MenuIcon.tsx
@@ -10,26 +10,24 @@ interface Props {
 }
 
 export default function MenuIcon({ name, icon, icon_type }: Props) {
-  if (!icon || !icon_type) return <span>Icon</span>
+  if (!icon || !icon_type) return <span className="text-icon-muted">•</span>
 
   switch (icon_type) {
     case "eva":
-      return (
-        <EvaIcon name={icon} size="large" fill="#8f9bb3" />
-      )
+      return <EvaIcon name={icon} size="medium" fill="currentColor" />
     case "material":
       return (
-        <span className="text-[#8f9bb3] text-xl flex items-center justify-center material-icons">
+        <span className="text-icon-muted text-xl flex items-center justify-center material-icons">
           {icon}
         </span>
       )
     case "url":
       return (
-        <span className="text-[#8f9bb3] flex items-center justify-center">
+        <span className="text-icon-muted flex items-center justify-center">
           <img alt={name} width={18} height={18} src={icon} />
         </span>
       )
     default:
-      return <span>Icon</span>
+      return <span className="text-icon-muted">•</span>
   }
 }

--- a/packages/bunadmin/src/components/NestedMenu.tsx
+++ b/packages/bunadmin/src/components/NestedMenu.tsx
@@ -105,6 +105,9 @@ export default function NestedList({ data }: Props): any {
 
   return (
     <>
+      <div className="px-4 pt-4 pb-1 text-[11px] font-semibold tracking-wider text-icon-muted uppercase">
+        Main
+      </div>
       {data
         .filter(item => item.parent === "")
         .map(item => {
@@ -120,7 +123,7 @@ export default function NestedList({ data }: Props): any {
           return (
             <ul key={name} className="w-full max-w-[360px] bg-sidebar p-0 list-none">
               <li
-                className={`flex items-center px-4 py-2 cursor-pointer rounded-bn hover:bg-primary/10 ${slug === `/${qGroup}/${qName}` ? "bg-primary/10 text-primary" : "text-foreground"}`}
+                className={`flex items-center mx-2 px-3 py-2 cursor-pointer rounded-bn hover:bg-primary/10 ${slug === `/${qGroup}/${qName}` ? "bg-primary/10 text-primary font-medium" : "text-foreground"}`}
                 onClick={() => handleClick({ name, slug })}
               >
                 <span className="mr-3 flex items-center">

--- a/packages/bunadmin/src/components/SettingMenu/index.tsx
+++ b/packages/bunadmin/src/components/SettingMenu/index.tsx
@@ -20,16 +20,16 @@ export default function SettingMenu() {
   }
 
   return (
-    <ul className="w-full max-w-[360px] bg-white list-none p-0">
+    <ul className="w-full max-w-[360px] bg-sidebar list-none p-0">
       <li
-        className="flex items-center px-4 py-2 cursor-pointer hover:bg-gray-100"
+        className="flex items-center mx-2 px-3 py-2 cursor-pointer rounded-bn text-foreground hover:bg-primary/10"
         onClick={handleClick}
       >
         <span className="mr-3 flex items-center">
-          <EvaIcon name="settings-outline" size="large" fill="#8f9bb3" />
+          <EvaIcon name="settings-outline" size="medium" fill="currentColor" />
         </span>
         <span className="flex-1 text-sm">{t("Setting")}</span>
-        <span className="text-[#8f9bb3]">
+        <span className="text-icon-muted">
           {open ? (
             <svg className="h-4 w-4 fill-current" viewBox="0 0 24 24"><path d="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z"/></svg>
           ) : (
@@ -42,7 +42,7 @@ export default function SettingMenu() {
           {settingMenus().map((item, index) => (
             <li
               key={index}
-              className={`flex items-center pl-10 pr-4 py-2 cursor-pointer transition-[padding-left] duration-500 ease-in-out hover:bg-gray-100 ${item.route === `/${qGroup}/${qName}` ? "bg-gray-200" : ""}`}
+              className={`flex items-center mx-2 pl-9 pr-3 py-2 cursor-pointer rounded-bn transition-[padding-left] duration-500 ease-in-out hover:bg-primary/10 ${item.route === `/${qGroup}/${qName}` ? "bg-primary/10 text-primary font-medium" : "text-foreground"}`}
               onClick={() => handleRoute({ route: item.route })}
             >
               {item.icon && <span className="mr-3 flex items-center">{item.icon}</span>}

--- a/packages/bunadmin/src/components/Table/components/Pagination.tsx
+++ b/packages/bunadmin/src/components/Table/components/Pagination.tsx
@@ -19,7 +19,7 @@ export default function Pagination({
 }: Props) {
   const btn = "rounded px-2 py-1 disabled:opacity-30"
   return (
-    <div className="flex items-center justify-end gap-4 px-4 py-2 text-sm text-gray-600">
+    <div className="flex items-center justify-end gap-4 px-4 py-2 text-sm text-icon-muted">
       <span>
         {from}-{to} of {total}
       </span>

--- a/packages/bunadmin/src/components/Table/index.tsx
+++ b/packages/bunadmin/src/components/Table/index.tsx
@@ -419,9 +419,9 @@ export default function Table<RowData extends object>(
               <button
                 onClick={startAdd}
                 title={t("addTooltip")}
-                className="rounded bg-primary px-3 py-1 text-sm text-white hover:bg-primary/90"
+                className="inline-flex items-center gap-1 rounded-bn bg-primary-gradient px-3 py-1.5 text-sm text-primary-foreground shadow-sm hover:opacity-90 transition-opacity"
               >
-                +
+                <span className="text-base leading-none">+</span> {t("New")}
               </button>
             )}
             {freeActions.map((a, i) => (

--- a/packages/bunadmin/src/components/Table/index.tsx
+++ b/packages/bunadmin/src/components/Table/index.tsx
@@ -250,7 +250,7 @@ export default function Table<RowData extends object>(
     }
     return (
       <input
-        className="w-full rounded border border-gray-300 px-2 py-1 text-sm focus:border-primary focus:outline-none"
+        className="w-full rounded border border-bn-border px-2 py-1 text-sm focus:border-primary focus:outline-none"
         value={(data as any)[field] ?? ""}
         onChange={e => setField(field, e.target.value)}
       />
@@ -272,7 +272,7 @@ export default function Table<RowData extends object>(
     return (
       <React.Fragment key={ri}>
         <tr
-          className={`border-b border-gray-100 hover:bg-content-bg ${
+          className={`border-b border-bn-border hover:bg-content-bg ${
             onRowClick ? "cursor-pointer" : ""
           }`}
           onClick={onRowClick ? e => onRowClick(e, row) : undefined}
@@ -302,7 +302,7 @@ export default function Table<RowData extends object>(
                     return n
                   })
                 }
-                className="h-4 w-4 rounded border-gray-300 text-primary"
+                className="h-4 w-4 rounded border-bn-border text-primary"
               />
             </td>
           )}
@@ -332,7 +332,7 @@ export default function Table<RowData extends object>(
           )}
         </tr>
         {hasDetail && expanded === ri && (
-          <tr className="border-b border-gray-100 bg-content-bg/30">
+          <tr className="border-b border-bn-border bg-content-bg/30">
             <td colSpan={colSpan} className="px-4 py-2">
               {renderDetail(row)}
             </td>
@@ -412,7 +412,7 @@ export default function Table<RowData extends object>(
                   setPage(0)
                   setSearch(e.target.value)
                 }}
-                className="rounded border border-gray-300 px-2 py-1 text-sm focus:border-primary focus:outline-none"
+                className="rounded border border-bn-border px-2 py-1 text-sm focus:border-primary focus:outline-none"
               />
             )}
             {canAdd && (
@@ -448,7 +448,7 @@ export default function Table<RowData extends object>(
       <div className="overflow-x-auto">
         <table className="w-full border-collapse text-sm">
           <thead>
-            <tr className="border-b border-gray-200 text-left">
+            <tr className="border-b border-bn-border text-left">
               {hasDetail && <th className="w-8 px-4 py-2" />}
               {showSelection && (
                 <th className="w-8 px-4 py-2">
@@ -463,7 +463,7 @@ export default function Table<RowData extends object>(
                           : new Set(rows.map((_, i) => i))
                       )
                     }
-                    className="h-4 w-4 rounded border-gray-300 text-primary"
+                    className="h-4 w-4 rounded border-bn-border text-primary"
                   />
                 </th>
               )}
@@ -471,17 +471,17 @@ export default function Table<RowData extends object>(
                 <th
                   key={c.tableData!.id}
                   style={{ width: c.width }}
-                  className="cursor-pointer select-none px-4 py-2 font-semibold text-gray-600"
+                  className="cursor-pointer select-none px-4 py-2 font-semibold text-icon-muted"
                   onClick={() => toggleSort(c)}
                 >
                   {c.title}
                   {orderBy?.field === c.field && (orderDir === "asc" ? " ▲" : " ▼")}
                 </th>
               ))}
-              {hasRowActions && <th className="px-4 py-2 font-semibold text-gray-600">{t("actions")}</th>}
+              {hasRowActions && <th className="px-4 py-2 font-semibold text-icon-muted">{t("actions")}</th>}
             </tr>
             {showFiltering && (
-              <tr className="border-b border-gray-100">
+              <tr className="border-b border-bn-border">
                 {hasDetail && <td className="px-4 py-1" />}
                 {showSelection && <td className="px-4 py-1" />}
                 {cols.map(c => (
@@ -499,7 +499,7 @@ export default function Table<RowData extends object>(
                                 [c.tableData!.id]: e.target.value
                               }))
                             }
-                            className="rounded border border-gray-300 bg-content-bg px-1 py-1 text-xs text-gray-500 focus:border-primary focus:outline-none"
+                            className="rounded border border-bn-border bg-content-bg px-1 py-1 text-xs text-icon-muted focus:border-primary focus:outline-none"
                           >
                             {operatorOptions(c).map(o => (
                               <option key={o.v} value={o.v}>
@@ -510,7 +510,7 @@ export default function Table<RowData extends object>(
                         )}
                         <input
                           type={c.type === "numeric" ? "number" : "text"}
-                          className="w-full rounded border border-gray-300 px-2 py-1 text-xs focus:border-primary focus:outline-none"
+                          className="w-full rounded border border-bn-border px-2 py-1 text-xs focus:border-primary focus:outline-none"
                           onChange={e => {
                             setPage(0)
                             onFilterChanged(c.tableData!.id, e.target.value)
@@ -527,7 +527,7 @@ export default function Table<RowData extends object>(
           <tbody>
             {/* add row */}
             {editing?.mode === "add" && (
-              <tr className="border-b border-gray-100 bg-content-bg/50">
+              <tr className="border-b border-bn-border bg-content-bg/50">
                 {hasDetail && <td className="px-4 py-2" />}
                 {showSelection && <td className="px-4 py-2" />}
                 {cols.map(c => (

--- a/packages/bunadmin/src/components/Table/models/tableLogic.ts
+++ b/packages/bunadmin/src/components/Table/models/tableLogic.ts
@@ -1,3 +1,4 @@
+import React from "react"
 import { Column } from "./material-table-shim"
 
 export type Dir = "asc" | "desc"
@@ -47,6 +48,18 @@ export function operatorOptions<R extends object>(
   ]
 }
 
+/** Map a status-ish value to pill color classes. */
+function statusPillClass(value: string): string {
+  const v = String(value).toLowerCase()
+  if (/(publish|active|approved|success|done|complete)/.test(v))
+    return "bg-success/15 text-success"
+  if (/(pending|draft|review|waiting)/.test(v))
+    return "bg-warning/15 text-warning"
+  if (/(reject|error|failed|inactive|banned)/.test(v))
+    return "bg-danger/15 text-danger"
+  return "bg-primary/10 text-primary"
+}
+
 /** Display value for a cell (render fn, or typed formatting). */
 export function display<R extends object>(col: Column<R>, row: R) {
   if (col.render) return col.render(row)
@@ -54,6 +67,22 @@ export function display<R extends object>(col: Column<R>, row: R) {
   if (col.type === "boolean") return v ? "✓" : "✗"
   if ((col.type === "datetime" || col.type === "date") && v)
     return new Date(v).toLocaleString()
+  // Lookup columns (status/category) render as colored pills (mockup-3).
+  if ((col as any).lookup && v !== undefined && v !== null && v !== "") {
+    const label = ((col as any).lookup[v] as string) ?? v
+    return React.createElement(
+      "span",
+      {
+        className: `inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium ${statusPillClass(
+          String(v)
+        )}`
+      },
+      React.createElement("span", {
+        className: "h-1.5 w-1.5 rounded-full bg-current opacity-70"
+      }),
+      String(label)
+    )
+  }
   return v as any
 }
 

--- a/packages/bunadmin/src/components/TopBar/TopBarRightMenu/ThemeToggle.tsx
+++ b/packages/bunadmin/src/components/TopBar/TopBarRightMenu/ThemeToggle.tsx
@@ -1,0 +1,36 @@
+import React, { useEffect, useState } from "react"
+import { Sun, Moon } from "lucide-react"
+import { applyPreset, DEFAULT_PRESET } from "@/utils/themes/tokens"
+
+/**
+ * Light/dark theme toggle — calls applyPreset (the runtime token entrypoint).
+ * Persists the choice; the same applyPreset() a future `ai theme` result uses.
+ */
+const KEY = "bn-theme-mode"
+
+export default function ThemeToggle() {
+  const [mode, setMode] = useState<"light" | "dark">("light")
+
+  useEffect(() => {
+    const saved = (localStorage.getItem(KEY) as "light" | "dark") || "light"
+    setMode(saved)
+    applyPreset(DEFAULT_PRESET, saved)
+  }, [])
+
+  const toggle = () => {
+    const next = mode === "dark" ? "light" : "dark"
+    setMode(next)
+    localStorage.setItem(KEY, next)
+    applyPreset(DEFAULT_PRESET, next)
+  }
+
+  return (
+    <button
+      aria-label="toggle theme"
+      onClick={toggle}
+      className="inline-flex items-center justify-center rounded p-2 text-icon-muted hover:bg-primary/10"
+    >
+      {mode === "dark" ? <Moon size={18} /> : <Sun size={18} />}
+    </button>
+  )
+}

--- a/packages/bunadmin/src/components/TopBar/index.tsx
+++ b/packages/bunadmin/src/components/TopBar/index.tsx
@@ -7,6 +7,7 @@ import NoticeMenu from "./TopBarRightMenu/NoticeMenu"
 import I18nMenu from "@/components/TopBar/TopBarRightMenu/I18nMenu"
 import { ENV } from "@/utils/config"
 import DocMenu from "./TopBarRightMenu/DocMenu"
+import ThemeToggle from "./TopBarRightMenu/ThemeToggle"
 import { useRouter } from "@/router"
 import { DynamicDocRoute } from "@/utils/routes"
 import { NoticePlugin } from "@/utils"
@@ -40,7 +41,7 @@ export default function TopBar(props: TopBarProps) {
   const docsHome = props.docsHome || "/docs/getting-started/introduction"
 
   return (
-    <div className="relative z-[1201] border-b border-gray-200 bg-white">
+    <div className="relative z-[1201] border-b border-bn-border bg-sidebar">
       <div
         className="flex items-center justify-between pl-5"
         style={{ minHeight: HEADER_HEIGHT }}
@@ -51,7 +52,7 @@ export default function TopBar(props: TopBarProps) {
               <button
                 aria-label="open drawer"
                 onClick={menuClick}
-                className="inline-flex items-center justify-center rounded p-2 text-icon-muted hover:bg-gray-100"
+                className="inline-flex items-center justify-center rounded p-2 text-icon-muted hover:bg-primary/10"
               >
                 {/* menu-2-outline icon */}
                 <svg viewBox="0 0 24 24" className="h-5 w-5 fill-current">
@@ -79,6 +80,7 @@ export default function TopBar(props: TopBarProps) {
 
         <div className="flex items-center">
           {prependRight}
+          <ThemeToggle />
           {ENV.ON_I18N && <I18nMenu />}
           {ENV.ON_DOC && <DocMenu isDoc={isDoc} docsHome={docsHome} />}
           {!isDoc && (

--- a/packages/bunadmin/src/components/TopBar/index.tsx
+++ b/packages/bunadmin/src/components/TopBar/index.tsx
@@ -13,7 +13,7 @@ import { DynamicDocRoute } from "@/utils/routes"
 import { NoticePlugin } from "@/utils"
 import { UserMenuProps } from "./TopBarRightMenu/UserMenu"
 
-export const HEADER_HEIGHT: number = 46
+export const HEADER_HEIGHT: number = 64
 
 type TopBarProps = {
   store: EnhancedStore<any, AnyAction, [ThunkMiddlewareFor<any>]>
@@ -43,42 +43,56 @@ export default function TopBar(props: TopBarProps) {
   return (
     <div className="relative z-[1201] border-b border-bn-border bg-sidebar">
       <div
-        className="flex items-center justify-between pl-5"
+        className="flex items-center gap-4 px-4"
         style={{ minHeight: HEADER_HEIGHT }}
       >
         {!removeLeft && (
-          <div className="flex items-center">
-            {!isDoc && (
-              <button
-                aria-label="open drawer"
-                onClick={menuClick}
-                className="inline-flex items-center justify-center rounded p-2 text-icon-muted hover:bg-primary/10"
-              >
-                {/* menu-2-outline icon */}
-                <svg viewBox="0 0 24 24" className="h-5 w-5 fill-current">
-                  <path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z" />
-                </svg>
-              </button>
-            )}
+          <div className="flex items-center gap-2 shrink-0">
             {logo ? (
               logo
             ) : (
               <button
                 id="header_logo"
-                className="px-2 py-1 text-sm font-medium text-primary hover:bg-primary/10 rounded"
+                className="flex items-center gap-2 px-1 py-1 rounded-bn"
                 onClick={() => {
                   router.push(!isDoc ? "/" : docsHome)
                 }}
               >
-                {!isDoc ? ENV.SITE_NAME : ENV.SITE_NAME + " DOCS"}
+                <span className="inline-flex h-8 w-8 items-center justify-center rounded-bn bg-primary-gradient text-primary-foreground font-bold">
+                  {(ENV.SITE_NAME || "B").charAt(0)}
+                </span>
+                <span className="text-base font-semibold text-foreground">
+                  {!isDoc ? ENV.SITE_NAME : ENV.SITE_NAME + " DOCS"}
+                </span>
               </button>
             )}
-
+            {!isDoc && (
+              <button
+                aria-label="open drawer"
+                onClick={menuClick}
+                className="inline-flex items-center justify-center rounded-full h-9 w-9 text-icon-muted hover:bg-primary/10"
+              >
+                <svg viewBox="0 0 24 24" className="h-5 w-5 fill-current">
+                  <path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z" />
+                </svg>
+              </button>
+            )}
             {appendLeft}
           </div>
         )}
 
-        <div className="flex items-center">
+        {/* Centered search (mockup-3) */}
+        {!isDoc && (
+          <div className="flex-1 flex justify-center">
+            <div className="w-full max-w-xl flex items-center gap-2 rounded-full border border-bn-border bg-content-bg px-4 py-2 text-sm text-icon-muted">
+              <svg viewBox="0 0 24 24" className="h-4 w-4 fill-current shrink-0"><path d="M15.5 14h-.79l-.28-.27a6.5 6.5 0 10-.7.7l.27.28v.79l5 5 1.49-1.5-5-5zm-6 0A4.5 4.5 0 1114 9.5 4.5 4.5 0 019.5 14z"/></svg>
+              <span className="flex-1">Search posts, categories, users...</span>
+              <kbd className="text-xs text-icon-muted border border-bn-border rounded px-1.5 py-0.5">⌘K</kbd>
+            </div>
+          </div>
+        )}
+
+        <div className="flex items-center gap-1 shrink-0">
           {prependRight}
           <ThemeToggle />
           {ENV.ON_I18N && <I18nMenu />}

--- a/packages/bunadmin/src/pages/[group]-[name].tsx
+++ b/packages/bunadmin/src/pages/[group]-[name].tsx
@@ -7,6 +7,7 @@ import {
   withoutLayout,
   MenuType
 } from "../../src"
+import { LAYOUT_A } from "@/utils/themes/layouts"
 import PluginTable from "../../src/private/PluginTable"
 import DefaultLayout from "../../src/private/DefaultLayout"
 import Error from "../../src/private/Error"
@@ -50,8 +51,33 @@ const DynamicGroupNamePage = ({
 
   if (withoutLayout(group, name)) return render
 
+  // Modern layout (mockup-3): KPI stat band + stats sidebar footer + labeled buttons.
+  const layout = {
+    ...LAYOUT_A,
+    statBand: true,
+    sidebarFooter: "upgrade" as const,
+    buttons: "labeled" as const
+  }
+  const stats = [
+    { label: "Total Posts", value: "128", delta: "All time posts", trend: "neutral" as const, spark: [4, 6, 5, 8, 7, 9, 11] },
+    { label: "Published", value: "45", delta: "35.2% of total", trend: "up" as const, spark: [2, 3, 5, 4, 6, 7, 8] },
+    { label: "Pending", value: "28", delta: "21.9% of total", trend: "neutral" as const, spark: [3, 2, 4, 3, 5, 4, 6] },
+    { label: "Rejected", value: "21", delta: "16.4% of total", trend: "down" as const, spark: [5, 4, 3, 4, 2, 3, 2] }
+  ]
+
   return (
-    <DefaultLayout leftMenu={{ data: leftMenuData }}>{render}</DefaultLayout>
+    <DefaultLayout
+      leftMenu={{ data: leftMenuData }}
+      layout={layout}
+      stats={stats}
+      sidebarUpgrade={{
+        title: "BunAdmin Pro",
+        description: "Unlock advanced features and premium components.",
+        cta: "Upgrade Now"
+      }}
+    >
+      {render}
+    </DefaultLayout>
   )
 }
 

--- a/packages/bunadmin/src/private/DefaultLayout/index.tsx
+++ b/packages/bunadmin/src/private/DefaultLayout/index.tsx
@@ -59,7 +59,7 @@ export default function DefaultLayout(props: DefaultLayoutProps) {
             className={`relative whitespace-nowrap overflow-x-hidden transition-[width] duration-300 ease-in-out border-r-0 bg-sidebar flex flex-col ${
               open ? "w-[240px]" : "w-[57px] sm:w-[73px]"
             }`}
-            style={{ height: "calc(100vh - 46px)" }}
+            style={{ height: "calc(100vh - 64px)" }}
           >
             <LeftMenu
               {...leftMenu}
@@ -82,7 +82,7 @@ export default function DefaultLayout(props: DefaultLayoutProps) {
         <div
           className="flex-grow p-[36px] bg-content-bg rounded-tl-bn overflow-auto"
           style={{
-            height: "calc(100vh - 46px)",
+            height: "calc(100vh - 64px)",
             maxWidth: phoneVertical
               ? "auto"
               : open


### PR DESCRIPTION
Makes the running app actually look like the bunadmin-3 mockup (verified light+dark via screenshot). Builds on the token/layout/preset engine from #62/#63.

## Changes (5)
1. **Icons** — expanded the lucide adapter map (file-text/person/people/paper-plane/cube/attach/code/refresh/delete…) so menu items render real icons instead of `?` fallbacks; `MenuIcon` uses `currentColor` (dark-safe).
2. **TopBar** — gradient logo mark + name, centered rounded search pill (⌘K), circular icon buttons; header 46→64px (DefaultLayout offset updated).
3. **Sidebar** — `MAIN`/`SYSTEM` section headers; menu items polished + tokenized (rounded, primary-tinted hover/selected, font-medium selected); `SettingMenu` matched.
4. **Posts page** — activates the modern layout + **KPI stat band** (4 cards with sparklines) + BunAdmin Pro upgrade footer (the regions from #62, now turned on).
5. **Table** — gradient labeled **New** button; **status pills** for lookup columns (green/amber/red by value) via `display()`.

## Verified
Light + dark screenshots closely match mockup-3. `vite build` clean; 85 unit tests; `lerna tsc:build` 12 projects.

## Honest gaps (follow-ups)
- The actual **Posts data table** with pills isn't screenshot-verified (needs login; only the welcome page + stat band were captured).
- Stat band currently also shows on the welcome page (layout wraps both) — fine for demo, may want to scope to list views.
- ~18 smaller components still have hardcoded colors (minor dark-mode polish).
- Search pill is visual-only (not wired).