### PR TITLE
feat(ui): scope stat band to list views + tokenize remaining components

### DIFF
--- a/packages/bunadmin/src/components/Dialog/ConfirmDialog.tsx
+++ b/packages/bunadmin/src/components/Dialog/ConfirmDialog.tsx
@@ -39,11 +39,11 @@ export default function ConfirmDialog({
     <Dialog open={open} onClose={handleClose} className="relative z-[1300]">
       <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
       <div className="fixed inset-0 flex items-center justify-center p-4 max-sm:p-0 max-sm:items-stretch">
-        <Dialog.Panel className="w-full max-w-sm rounded bg-white shadow-xl max-sm:max-w-none max-sm:rounded-none">
+        <Dialog.Panel className="w-full max-w-sm rounded bg-content-box shadow-xl max-sm:max-w-none max-sm:rounded-none">
           <Dialog.Title className="px-6 pt-5 text-lg font-semibold">
             {title}
           </Dialog.Title>
-          <div className="px-6 py-4 text-sm text-gray-600">
+          <div className="px-6 py-4 text-sm text-icon-muted">
             {content || <p>{msg}</p>}
           </div>
           <div className="flex justify-end gap-2 px-4 pb-3">

--- a/packages/bunadmin/src/components/Dialog/UploadCustomDialog.tsx
+++ b/packages/bunadmin/src/components/Dialog/UploadCustomDialog.tsx
@@ -38,11 +38,11 @@ export default function UploadConfirmDialog({
     <Dialog open={open} onClose={handleClose} className="relative z-[1300]">
       <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
       <div className="fixed inset-0 flex items-center justify-center p-4 max-sm:p-0 max-sm:items-stretch">
-        <Dialog.Panel className="w-full max-w-sm rounded bg-white shadow-xl max-sm:max-w-none max-sm:rounded-none">
+        <Dialog.Panel className="w-full max-w-sm rounded bg-content-box shadow-xl max-sm:max-w-none max-sm:rounded-none">
           <Dialog.Title className="px-6 pt-5 text-lg font-semibold">
             {title}
           </Dialog.Title>
-          <div className="px-6 py-4 text-sm text-gray-600">
+          <div className="px-6 py-4 text-sm text-icon-muted">
             <p>{msg}</p>
           </div>
           <div className="flex justify-end gap-2 px-4 pb-3">

--- a/packages/bunadmin/src/components/Drawer/index.tsx
+++ b/packages/bunadmin/src/components/Drawer/index.tsx
@@ -102,7 +102,7 @@ export default function Drawer({
       )}
       {/* Drawer panel */}
       <aside
-        className={`fixed z-[1300] bg-white transition-transform duration-300 ease-in-out ${directionClasses[anchor]} ${state.open ? "translate-x-0 translate-y-0" : translateHidden[anchor]}`}
+        className={`fixed z-[1300] bg-content-box transition-transform duration-300 ease-in-out ${directionClasses[anchor]} ${state.open ? "translate-x-0 translate-y-0" : translateHidden[anchor]}`}
         style={{ width: width || "auto", height: height || "100%" }}
       >
         <div

--- a/packages/bunadmin/src/components/FileExplorer/BunadminFile/CardBottomArea.tsx
+++ b/packages/bunadmin/src/components/FileExplorer/BunadminFile/CardBottomArea.tsx
@@ -22,7 +22,7 @@ const CardBottomArea = ({
   })
 
   return <>
-    <div className="absolute bottom-0 z-[2] w-full h-9 bg-white/50">
+    <div className="absolute bottom-0 z-[2] w-full h-9 bg-content-box/50">
       <div className="flex justify-evenly w-full p-0">
         {!id ? (
           <button disabled className="text-primary text-sm opacity-50 cursor-not-allowed">

--- a/packages/bunadmin/src/components/FileExplorer/BunadminFile/index.tsx
+++ b/packages/bunadmin/src/components/FileExplorer/BunadminFile/index.tsx
@@ -130,7 +130,7 @@ export default function BunadminFile(props: BunadminFileProps) {
       />
 
       <div
-        className="relative border border-gray-200 rounded"
+        className="relative border border-bn-border rounded"
         style={{
           margin: id ? "20px 0" : "20px 5px 20px 0",
           ...(viewMode ? mediaStyle : {}),

--- a/packages/bunadmin/src/components/FileExplorer/FilePreview/index.tsx
+++ b/packages/bunadmin/src/components/FileExplorer/FilePreview/index.tsx
@@ -48,7 +48,7 @@ export default function FilePreview({
     <Dialog open={preview} onClose={handleClose} className="relative z-[1300]">
       <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
       <div className={`fixed inset-0 flex items-center justify-center ${state.fullScreen ? "" : "p-4"}`}>
-        <Dialog.Panel className={`bg-white shadow-xl flex flex-col ${state.fullScreen ? "w-full h-full" : "max-w-3xl max-h-[90vh] rounded"}`}>
+        <Dialog.Panel className={`bg-content-box shadow-xl flex flex-col ${state.fullScreen ? "w-full h-full" : "max-w-3xl max-h-[90vh] rounded"}`}>
           {/* Image area */}
           <div
             className="flex-1 flex items-center justify-center overflow-auto cursor-pointer"
@@ -62,7 +62,7 @@ export default function FilePreview({
             />
           </div>
           {/* Actions */}
-          <div className="flex items-center justify-center gap-2 p-2 border-t border-gray-100">
+          <div className="flex items-center justify-center gap-2 p-2 border-t border-bn-border">
             <button onClick={handleClose} className="text-primary text-sm px-2 py-1 hover:bg-primary/10 rounded">
               {display_name || created_at}
             </button>
@@ -71,7 +71,7 @@ export default function FilePreview({
               <button
                 aria-label="Preview"
                 onClick={handleFullWidthChange}
-                className="p-1 rounded hover:bg-gray-100"
+                className="p-1 rounded hover:bg-primary/10"
               >
                 {!state.fullScreen ? (
                   /* ZoomIn icon */
@@ -84,13 +84,13 @@ export default function FilePreview({
             )}
 
             <a href={url} target="_blank" rel="noopener noreferrer">
-              <button aria-label="Download" className="p-1 rounded hover:bg-gray-100">
+              <button aria-label="Download" className="p-1 rounded hover:bg-primary/10">
                 {/* Download icon */}
                 <svg className="h-5 w-5 fill-current" viewBox="0 0 24 24"><path d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"/></svg>
               </button>
             </a>
 
-            <button aria-label="Close" onClick={handleClose} className="p-1 rounded hover:bg-gray-100">
+            <button aria-label="Close" onClick={handleClose} className="p-1 rounded hover:bg-primary/10">
               {/* Close icon */}
               <svg className="h-5 w-5 fill-current" viewBox="0 0 24 24"><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/></svg>
             </button>

--- a/packages/bunadmin/src/components/Repeater/index.tsx
+++ b/packages/bunadmin/src/components/Repeater/index.tsx
@@ -48,7 +48,7 @@ export default function Repeater({
           >
             {deletable && (
               <button
-                className="p-1 text-gray-500 hover:text-danger"
+                className="p-1 text-icon-muted hover:text-danger"
                 aria-label="delete"
                 onClick={() => {
                   if (!onDelete) return
@@ -66,7 +66,7 @@ export default function Repeater({
               </button>
             )}
             {sortable && (
-              <button className="p-1 text-gray-500" aria-label="sort">
+              <button className="p-1 text-icon-muted" aria-label="sort">
                 {/* DragHandle icon */}
                 <svg className="h-5 w-5 fill-current" viewBox="0 0 24 24">
                   <path d="M20 9H4v2h16V9zM4 15h16v-2H4v2z" />
@@ -85,12 +85,12 @@ export default function Repeater({
                 ? handleKeyPoints(item, titleKey) || title || i + 1
                 : title || i + 1}
             </span>
-            <span className="flex-1 text-sm text-gray-500">
+            <span className="flex-1 text-sm text-icon-muted">
               {(summaryKey && handleKeyPoints(item, summaryKey)) || summary}
             </span>
             {/* ExpandMore icon */}
             <svg
-              className={`h-5 w-5 fill-current text-gray-400 transition-transform ${
+              className={`h-5 w-5 fill-current text-icon-muted transition-transform ${
                 expanded === i ? "rotate-180" : ""
               }`}
               viewBox="0 0 24 24"
@@ -107,7 +107,7 @@ export default function Repeater({
       ))}
 
       <button
-        className="mt-px w-full rounded bg-white pt-4 pb-3 text-sm font-medium uppercase text-primary hover:bg-primary/10"
+        className="mt-px w-full rounded bg-content-box pt-4 pb-3 text-sm font-medium uppercase text-primary hover:bg-primary/10"
         onClick={() => {
           if (!onCreate) return
           onCreate()

--- a/packages/bunadmin/src/components/Selector/FilterListSelector/index.tsx
+++ b/packages/bunadmin/src/components/Selector/FilterListSelector/index.tsx
@@ -103,7 +103,7 @@ export default function FilterListSelector({
       <Combobox value={selected || null} onChange={handleSelect}>
         <div className="relative">
           {label && (
-            <label className="absolute -top-2 left-2 bg-white px-1 text-xs text-gray-500">
+            <label className="absolute -top-2 left-2 bg-content-box px-1 text-xs text-icon-muted">
               {label}
             </label>
           )}
@@ -111,8 +111,8 @@ export default function FilterListSelector({
             <Combobox.Input
               className={`w-full py-2 pr-8 text-sm outline-none ${
                 variant === "outlined"
-                  ? "rounded border border-gray-300 px-3 focus:border-primary focus:ring-1 focus:ring-primary"
-                  : "border-b border-gray-300 bg-transparent focus:border-primary"
+                  ? "rounded border border-bn-border px-3 focus:border-primary focus:ring-1 focus:ring-primary"
+                  : "border-b border-bn-border bg-transparent focus:border-primary"
               }`}
               displayValue={displayValue}
               onChange={handleChange}
@@ -121,19 +121,19 @@ export default function FilterListSelector({
             />
             <span className="absolute inset-y-0 right-0 flex items-center pr-1">
               {loading ? (
-                <svg className="h-5 w-5 animate-spin text-gray-400" viewBox="0 0 24 24" fill="none">
+                <svg className="h-5 w-5 animate-spin text-icon-muted" viewBox="0 0 24 24" fill="none">
                   <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
                   <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
                 </svg>
               ) : (
-                <svg className="h-5 w-5 fill-current text-gray-400" viewBox="0 0 20 20">
+                <svg className="h-5 w-5 fill-current text-icon-muted" viewBox="0 0 20 20">
                   <path d="M7 7l3-3 3 3m0 6l-3 3-3-3" stroke="currentColor" strokeWidth="1.5" fill="none" strokeLinecap="round" strokeLinejoin="round" />
                 </svg>
               )}
             </span>
           </div>
           {open && options.length > 0 && (
-            <Combobox.Options static className="absolute z-10 mt-1 max-h-[230px] w-full overflow-auto rounded bg-white py-1 text-sm shadow-lg ring-1 ring-black/5 focus:outline-none">
+            <Combobox.Options static className="absolute z-10 mt-1 max-h-[230px] w-full overflow-auto rounded bg-content-box py-1 text-sm shadow-lg ring-1 ring-black/5 focus:outline-none">
               {options.map(option => (
                 <Combobox.Option
                   key={option.id}

--- a/packages/bunadmin/src/components/Selector/ListSelector/index.tsx
+++ b/packages/bunadmin/src/components/Selector/ListSelector/index.tsx
@@ -84,11 +84,11 @@ export function ListSelector({
   const inputClass = (() => {
     switch (variant) {
       case "outlined":
-        return "rounded border border-gray-300 px-3 py-2 focus:border-primary focus:ring-1 focus:ring-primary"
+        return "rounded border border-bn-border px-3 py-2 focus:border-primary focus:ring-1 focus:ring-primary"
       case "filled":
-        return "rounded-t border-b border-gray-300 bg-gray-100 px-3 py-2 focus:border-primary"
+        return "rounded-t border-b border-bn-border bg-content-bg px-3 py-2 focus:border-primary"
       default:
-        return "border-b border-gray-300 bg-transparent py-2 focus:border-primary"
+        return "border-b border-bn-border bg-transparent py-2 focus:border-primary"
     }
   })()
 
@@ -102,7 +102,7 @@ export function ListSelector({
       <Combobox value={selected || null} onChange={handleSelect} multiple={multiple as any}>
         <div className="relative">
           {label && (
-            <label className="absolute -top-2 left-2 z-10 bg-white px-1 text-xs text-gray-500">
+            <label className="absolute -top-2 left-2 z-10 bg-content-box px-1 text-xs text-icon-muted">
               {label}
             </label>
           )}
@@ -116,19 +116,19 @@ export function ListSelector({
             />
             <span className="absolute inset-y-0 right-0 flex items-center pr-1">
               {loading ? (
-                <svg className="h-5 w-5 animate-spin text-gray-400" viewBox="0 0 24 24" fill="none">
+                <svg className="h-5 w-5 animate-spin text-icon-muted" viewBox="0 0 24 24" fill="none">
                   <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
                   <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
                 </svg>
               ) : (
-                <svg className="h-5 w-5 fill-current text-gray-400" viewBox="0 0 20 20">
+                <svg className="h-5 w-5 fill-current text-icon-muted" viewBox="0 0 20 20">
                   <path d="M7 7l3-3 3 3m0 6l-3 3-3-3" stroke="currentColor" strokeWidth="1.5" fill="none" strokeLinecap="round" strokeLinejoin="round" />
                 </svg>
               )}
             </span>
           </div>
           {open && options.length > 0 && (
-            <Combobox.Options static className="absolute z-10 mt-1 max-h-[230px] w-full overflow-auto rounded bg-white py-1 text-sm shadow-lg ring-1 ring-black/5 focus:outline-none">
+            <Combobox.Options static className="absolute z-10 mt-1 max-h-[230px] w-full overflow-auto rounded bg-content-box py-1 text-sm shadow-lg ring-1 ring-black/5 focus:outline-none">
               {options.map(option => (
                 <Combobox.Option
                   key={option.id}

--- a/packages/bunadmin/src/components/Selector/MultipleSelector/index.tsx
+++ b/packages/bunadmin/src/components/Selector/MultipleSelector/index.tsx
@@ -47,17 +47,17 @@ export default function MultipleSelector(props: Props) {
       <div className="m-1 min-w-[120px] max-w-[200px]">
         <Listbox value={selectedName} onChange={handleChange} multiple>
           <div className="relative">
-            <Listbox.Button className="relative w-full cursor-pointer border-b border-gray-300 bg-transparent py-2 pr-8 text-left text-sm focus:border-primary focus:outline-none">
+            <Listbox.Button className="relative w-full cursor-pointer border-b border-bn-border bg-transparent py-2 pr-8 text-left text-sm focus:border-primary focus:outline-none">
               <span className="block truncate">
                 {selectedName.length > 0 ? selectedName.join(", ") : "\u00A0"}
               </span>
               <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-1">
-                <svg className="h-5 w-5 fill-current text-gray-400" viewBox="0 0 20 20">
+                <svg className="h-5 w-5 fill-current text-icon-muted" viewBox="0 0 20 20">
                   <path d="M7 7l3-3 3 3m0 6l-3 3-3-3" stroke="currentColor" strokeWidth="1.5" fill="none" strokeLinecap="round" strokeLinejoin="round" />
                 </svg>
               </span>
             </Listbox.Button>
-            <Listbox.Options className="absolute z-10 mt-1 max-h-[230px] w-[250px] overflow-auto rounded bg-white py-1 text-sm shadow-lg ring-1 ring-black/5 focus:outline-none">
+            <Listbox.Options className="absolute z-10 mt-1 max-h-[230px] w-[250px] overflow-auto rounded bg-content-box py-1 text-sm shadow-lg ring-1 ring-black/5 focus:outline-none">
               {names.map(name => (
                 <Listbox.Option
                   key={name}
@@ -73,7 +73,7 @@ export default function MultipleSelector(props: Props) {
                           type="checkbox"
                           checked={selected}
                           readOnly
-                          className="h-4 w-4 rounded border-gray-300 text-primary"
+                          className="h-4 w-4 rounded border-bn-border text-primary"
                         />
                       </span>
                       <span className={`block truncate ${selected ? "font-medium" : "font-normal"}`}>

--- a/packages/bunadmin/src/components/Selector/SingleSelector/index.tsx
+++ b/packages/bunadmin/src/components/Selector/SingleSelector/index.tsx
@@ -108,17 +108,17 @@ export default function SingleSelector<RowData extends object>(
       <div className="m-1 min-w-[100px]">
         <Listbox value={selectedName} onChange={handleChange}>
           <div className="relative">
-            <Listbox.Button className="relative w-full cursor-pointer border-b border-gray-300 bg-transparent py-2 pr-8 text-left text-sm focus:border-primary focus:outline-none">
+            <Listbox.Button className="relative w-full cursor-pointer border-b border-bn-border bg-transparent py-2 pr-8 text-left text-sm focus:border-primary focus:outline-none">
               <span className="block truncate">
                 {names[keys.indexOf(selectedName)] || "\u00A0"}
               </span>
               <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-1">
-                <svg className="h-5 w-5 fill-current text-gray-400" viewBox="0 0 20 20">
+                <svg className="h-5 w-5 fill-current text-icon-muted" viewBox="0 0 20 20">
                   <path d="M7 7l3-3 3 3m0 6l-3 3-3-3" stroke="currentColor" strokeWidth="1.5" fill="none" strokeLinecap="round" strokeLinejoin="round" />
                 </svg>
               </span>
             </Listbox.Button>
-            <Listbox.Options className="absolute z-10 mt-1 max-h-[230px] w-full overflow-auto rounded bg-white py-1 text-sm shadow-lg ring-1 ring-black/5 focus:outline-none">
+            <Listbox.Options className="absolute z-10 mt-1 max-h-[230px] w-full overflow-auto rounded bg-content-box py-1 text-sm shadow-lg ring-1 ring-black/5 focus:outline-none">
               {names.map((name, i) => (
                 <Listbox.Option
                   key={name}

--- a/packages/bunadmin/src/components/Snackbar/Message/index.tsx
+++ b/packages/bunadmin/src/components/Snackbar/Message/index.tsx
@@ -66,11 +66,11 @@ const SnackMessage = React.forwardRef<HTMLDivElement, Props>((props, ref) => {
         </div>
       </div>
       {expanded && state.content && (
-        <div className="bg-white p-4 text-gray-800">
+        <div className="bg-content-box p-4 text-foreground">
           <p className="mb-2">{state.content}</p>
           <button
             onClick={() => props.store.dispatch(toggleNotifyDrawer())}
-            className="flex items-center text-sm text-gray-400 hover:text-gray-600"
+            className="flex items-center text-sm text-icon-muted hover:text-icon-muted"
           >
             <span className="pr-1">↗</span>
             {t("Open List")}

--- a/packages/bunadmin/src/components/Table/components/TableSkeleton.tsx
+++ b/packages/bunadmin/src/components/Table/components/TableSkeleton.tsx
@@ -7,7 +7,7 @@ interface Props {
 
 const Bar = ({ w }: { w?: string }) => (
   <div
-    className="my-2 h-4 animate-pulse rounded bg-gray-200"
+    className="my-2 h-4 animate-pulse rounded bg-content-bg"
     style={{ width: w || "100%" }}
   />
 )

--- a/packages/bunadmin/src/components/TopBar/TopBarRightMenu/UserMenu.tsx
+++ b/packages/bunadmin/src/components/TopBar/TopBarRightMenu/UserMenu.tsx
@@ -112,16 +112,16 @@ export default function UserMenu(props: UserMenuProps) {
         )
       ) : (
         <Menu as="div" className="relative">
-          <Menu.Button className="inline-flex items-center justify-center rounded p-2 text-icon-muted hover:bg-gray-100">
+          <Menu.Button className="inline-flex items-center justify-center rounded p-2 text-icon-muted hover:bg-primary/10">
             {/* shield-outline */}
             <svg viewBox="0 0 24 24" className="h-5 w-5 fill-current">
               <path d="M12 1L3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5l-9-4zm0 10.99h7c-.53 4.12-3.28 7.79-7 8.94V12H5V6.3l7-3.11v8.8z" />
             </svg>
           </Menu.Button>
-          <Menu.Items className="absolute right-0 z-50 mt-1 w-56 origin-top-right rounded bg-white py-1 shadow-lg ring-1 ring-black/5 focus:outline-none">
+          <Menu.Items className="absolute right-0 z-50 mt-1 w-56 origin-top-right rounded bg-content-box py-1 shadow-lg ring-1 ring-black/5 focus:outline-none">
             <Menu.Item disabled>
               {({ active }) => (
-                <div className="px-4 py-2 text-sm text-gray-400">
+                <div className="px-4 py-2 text-sm text-icon-muted">
                   <Trans
                     i18nKey="Signed as $username"
                     values={{
@@ -136,19 +136,19 @@ export default function UserMenu(props: UserMenuProps) {
               {({ active }) => (
                 <button
                   onClick={onProfile}
-                  className={`${active ? "bg-gray-100" : ""} w-full px-4 py-2 text-left text-sm`}
+                  className={`${active ? "bg-content-bg" : ""} w-full px-4 py-2 text-left text-sm`}
                 >
                   {t("Profile")}
                 </button>
               )}
             </Menu.Item>
-            <div className="my-1 border-t border-gray-200" />
+            <div className="my-1 border-t border-bn-border" />
             {!props.disableSwitch && (
               <Menu.Item>
                 {({ active }) => (
                   <button
                     onClick={() => handleRoute(LocalDataRoute.auth)}
-                    className={`${active ? "bg-gray-100" : ""} w-full px-4 py-2 text-left text-sm`}
+                    className={`${active ? "bg-content-bg" : ""} w-full px-4 py-2 text-left text-sm`}
                   >
                     {t("Switch account")}
                   </button>
@@ -160,7 +160,7 @@ export default function UserMenu(props: UserMenuProps) {
                 {({ active }) => (
                   <button
                     onClick={onLogin}
-                    className={`${active ? "bg-gray-100" : ""} w-full px-4 py-2 text-left text-sm`}
+                    className={`${active ? "bg-content-bg" : ""} w-full px-4 py-2 text-left text-sm`}
                   >
                     {t("Add another account")}
                   </button>
@@ -168,14 +168,14 @@ export default function UserMenu(props: UserMenuProps) {
               </Menu.Item>
             )}
             {!props.disableSwitch && (
-              <div className="my-1 border-t border-gray-200" />
+              <div className="my-1 border-t border-bn-border" />
             )}
             {props.append}
             <Menu.Item>
               {({ active }) => (
                 <button
                   onClick={onLogout}
-                  className={`${active ? "bg-gray-100" : ""} w-full px-4 py-2 text-left text-sm`}
+                  className={`${active ? "bg-content-bg" : ""} w-full px-4 py-2 text-left text-sm`}
                 >
                   {t("Logout")}
                 </button>

--- a/packages/bunadmin/src/core/notice/components/NoticeTabs.tsx
+++ b/packages/bunadmin/src/core/notice/components/NoticeTabs.tsx
@@ -11,13 +11,13 @@ export default function NoticeTabs({
   setTab: Dispatch<number>
 }) {
   return (
-    <div className="bg-white shadow-sm">
+    <div className="bg-content-box shadow-sm">
       <div className="flex" role="tablist" aria-label="core notice tabs">
         <button
           className={`px-4 py-2 text-sm font-medium border-b-2 ${
             tab === 0
               ? "border-primary text-primary"
-              : "border-transparent text-gray-500 hover:text-gray-700"
+              : "border-transparent text-icon-muted hover:text-foreground"
           }`}
           onClick={() => setTab(0)}
           role="tab"
@@ -29,7 +29,7 @@ export default function NoticeTabs({
           className={`px-4 py-2 text-sm font-medium border-b-2 ${
             tab === 1
               ? "border-primary text-primary"
-              : "border-transparent text-gray-500 hover:text-gray-700"
+              : "border-transparent text-icon-muted hover:text-foreground"
           }`}
           onClick={() => setTab(1)}
           role="tab"
@@ -38,7 +38,7 @@ export default function NoticeTabs({
           {String(t("Online Notifications"))}
         </button>
       </div>
-      <hr className="border-gray-200" />
+      <hr className="border-bn-border" />
     </div>
   )
 }

--- a/packages/bunadmin/src/pages/[group]-[name].tsx
+++ b/packages/bunadmin/src/pages/[group]-[name].tsx
@@ -21,6 +21,11 @@ const DynamicGroupNamePage = ({
   const router = useRouter()
   const { group, name } = router.query as ParsedUrlQuery
 
+  // The KPI stat band + modern layout apply to schema/list views only —
+  // not the welcome page (group undefined), auth, or core pages.
+  const isListView =
+    group !== undefined && group !== "core" && group !== "auth"
+
   let render
   switch (group) {
     case "core":
@@ -51,19 +56,21 @@ const DynamicGroupNamePage = ({
 
   if (withoutLayout(group, name)) return render
 
-  // Modern layout (mockup-3): KPI stat band + stats sidebar footer + labeled buttons.
+  // Modern layout (mockup-3): KPI stat band on list views + upgrade footer.
   const layout = {
     ...LAYOUT_A,
-    statBand: true,
+    statBand: isListView,
     sidebarFooter: "upgrade" as const,
     buttons: "labeled" as const
   }
-  const stats = [
-    { label: "Total Posts", value: "128", delta: "All time posts", trend: "neutral" as const, spark: [4, 6, 5, 8, 7, 9, 11] },
-    { label: "Published", value: "45", delta: "35.2% of total", trend: "up" as const, spark: [2, 3, 5, 4, 6, 7, 8] },
-    { label: "Pending", value: "28", delta: "21.9% of total", trend: "neutral" as const, spark: [3, 2, 4, 3, 5, 4, 6] },
-    { label: "Rejected", value: "21", delta: "16.4% of total", trend: "down" as const, spark: [5, 4, 3, 4, 2, 3, 2] }
-  ]
+  const stats = isListView
+    ? [
+        { label: "Total Posts", value: "128", delta: "All time posts", trend: "neutral" as const, spark: [4, 6, 5, 8, 7, 9, 11] },
+        { label: "Published", value: "45", delta: "35.2% of total", trend: "up" as const, spark: [2, 3, 5, 4, 6, 7, 8] },
+        { label: "Pending", value: "28", delta: "21.9% of total", trend: "neutral" as const, spark: [3, 2, 4, 3, 5, 4, 6] },
+        { label: "Rejected", value: "21", delta: "16.4% of total", trend: "down" as const, spark: [5, 4, 3, 4, 2, 3, 2] }
+      ]
+    : undefined
 
   return (
     <DefaultLayout

--- a/packages/bunadmin/src/pages/index.tsx
+++ b/packages/bunadmin/src/pages/index.tsx
@@ -3,7 +3,7 @@ import { ENV, ProTip } from "@xbuilder/bunadmin"
 
 function Copyright() {
   return (
-    <p className="text-center text-sm text-gray-500">
+    <p className="text-center text-sm text-icon-muted">
       {"Copyright © "}
       <a href="#" className="text-inherit hover:underline">
         {ENV.SITE_NAME}


### PR DESCRIPTION
Post-merge polish (follow-up to #64).

## (a) Scope stat band to list views ✅ screenshot-verified
The KPI stat band + modern layout now render **only on schema list views** (`isListView` = group not undefined/core/auth) — not the welcome page or auth screens. Verified: on `/blog/post` the band shows and the Blog menu expands; the welcome page is clean.

## (c) Tokenize remaining components ✅
Migrated ~20 components off hardcoded colors for dark-mode completeness: dialogs, selectors, repeater, TopBar right-menus, drawer, file-explorer, snackbar, notice tabs, index, table skeleton. (`bg-white`→`content-box`, gray hovers→`primary/10`, gray bg→`content-bg`, `text-gray`→`icon-muted`/`foreground`, `border-gray`→`bn-border`.)

## (b) Posts data table — NOT verified (honest)
Could not screenshot-verify the logged-in table (rows + status pills + gradient New button): the demo backend `blog-service.eg.bunadmin.com` is **unreachable** and there's no auth session, so the table area is blank without data. Everything backend-independent (stat band, scoping, menu, chrome) is verified. The pill + gradient-button code is correct and unit-tested but not visually confirmed with real rows — needs a reachable backend or local PocketBase wired into `.env`.

85 tests; `lerna tsc:build` 12 projects; app build clean.