### PR TITLE
fix(vite): alias pocketbase source+auth plugins to TS source

### DIFF
--- a/packages/bunadmin/package.json
+++ b/packages/bunadmin/package.json
@@ -75,7 +75,9 @@
     "tailwindcss": "^3.4.4",
     "ttypescript": "^1.5.13",
     "typescript": "4.8.3",
-    "typescript-transform-paths": "^3.3.1"
+    "typescript-transform-paths": "^3.3.1",
+    "@xbuilder/bunadmin-source-pocketbase": "^1.6.0-beta.0",
+    "@xbuilder/bunadmin-auth-pocketbase": "^1.6.0-beta.0"
   },
   "husky": {
     "hooks": {

--- a/packages/bunadmin/vite.config.ts
+++ b/packages/bunadmin/vite.config.ts
@@ -90,6 +90,10 @@ export default defineConfig(({ mode }) => {
           replacement: r("../bunadmin-source-graphql/index.ts")
         },
         {
+          find: /^@xbuilder\/bunadmin-source-pocketbase$/,
+          replacement: r("../bunadmin-source-pocketbase/index.ts")
+        },
+        {
           find: /^@xbuilder\/bunadmin-rich-text-editor$/,
           replacement: r("../bunadmin-rich-text-editor/index.tsx")
         },
@@ -117,6 +121,14 @@ export default defineConfig(({ mode }) => {
         {
           find: /^@xbuilder\/bunadmin-auth-buncms$/,
           replacement: r("../../plugins/bunadmin-auth-buncms/index.ts")
+        },
+        {
+          find: /^@xbuilder\/bunadmin-auth-pocketbase\/(.*)/,
+          replacement: r("../../plugins/bunadmin-auth-pocketbase") + "/$1"
+        },
+        {
+          find: /^@xbuilder\/bunadmin-auth-pocketbase$/,
+          replacement: r("../../plugins/bunadmin-auth-pocketbase/index.ts")
         },
         {
           find: /^@xbuilder\/bunadmin-upload-strapi\/(.*)/,


### PR DESCRIPTION
While verifying (b) — the logged-in Posts table against PocketBase — I found a real bug: `source-pocketbase` / `auth-pocketbase` resolved to their **CJS `lib/`**, so Vite couldn't statically surface named exports (`import { bulkDeleteCtrl }` → *"does not provide an export named bulkDeleteCtrl"*). Every other source/auth plugin is already aliased to its `.ts` source for clean ESM; pocketbase was simply missing from `vite.config.ts`.

## Fix
- Add `source-pocketbase` + `auth-pocketbase` aliases (bare + subpath) mapping to TS source.
- Declare both as devDeps so they resolve.

## Verified
- `source-pocketbase` `listSer` query mapping returns **live PocketBase rows** (`status='Published'`, `sort=-views` → correct records). The data controller works end-to-end.
- App `vite build` + 85 tests green.

## Honest note on (b)
I could **not** screenshot the rendered logged-in table. The demo registers **both** auth-local and auth-pocketbase, and the `/auth/sign-in` route resolves to **auth-local's** form (first registered), so the PocketBase login didn't fire in headless automation. Verifying the *rendered* table needs the demo wired to a single auth plugin — a demo-config task, separate from this fix. The **data integration itself is proven** at the query layer.