### PR TITLE
feat(ui): replace selector inline SVGs with lucide

### DIFF
--- a/packages/bunadmin/src/components/Selector/FilterListSelector/index.tsx
+++ b/packages/bunadmin/src/components/Selector/FilterListSelector/index.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react"
+import { ChevronsUpDown, Loader2 } from "lucide-react"
 import { Combobox } from "@headlessui/react"
 import { Column, Query } from "@/components/Table/models/material-table-shim"
 import { notice } from "@/core"
@@ -121,14 +122,9 @@ export default function FilterListSelector({
             />
             <span className="absolute inset-y-0 right-0 flex items-center pr-1">
               {loading ? (
-                <svg className="h-5 w-5 animate-spin text-icon-muted" viewBox="0 0 24 24" fill="none">
-                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
-                </svg>
+                <Loader2 className="h-5 w-5 animate-spin text-icon-muted" />
               ) : (
-                <svg className="h-5 w-5 fill-current text-icon-muted" viewBox="0 0 20 20">
-                  <path d="M7 7l3-3 3 3m0 6l-3 3-3-3" stroke="currentColor" strokeWidth="1.5" fill="none" strokeLinecap="round" strokeLinejoin="round" />
-                </svg>
+                <ChevronsUpDown className="h-5 w-5 text-icon-muted" />
               )}
             </span>
           </div>

--- a/packages/bunadmin/src/components/Selector/ListSelector/index.tsx
+++ b/packages/bunadmin/src/components/Selector/ListSelector/index.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react"
+import { ChevronsUpDown, Loader2 } from "lucide-react"
 import { Combobox } from "@headlessui/react"
 import { Column, EditComponentProps, Query } from "@/components/Table/models/material-table-shim"
 import { notice } from "@/core"
@@ -114,16 +115,11 @@ export function ListSelector({
               onClick={() => setOpen(true)}
               onBlur={() => setOpen(false)}
             />
-            <span className="absolute inset-y-0 right-0 flex items-center pr-1">
+            <span className="absolute inset-y-0 right-0 flex items-center pr-1 text-icon-muted">
               {loading ? (
-                <svg className="h-5 w-5 animate-spin text-icon-muted" viewBox="0 0 24 24" fill="none">
-                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
-                </svg>
+                <Loader2 className="h-5 w-5 animate-spin" />
               ) : (
-                <svg className="h-5 w-5 fill-current text-icon-muted" viewBox="0 0 20 20">
-                  <path d="M7 7l3-3 3 3m0 6l-3 3-3-3" stroke="currentColor" strokeWidth="1.5" fill="none" strokeLinecap="round" strokeLinejoin="round" />
-                </svg>
+                <ChevronsUpDown className="h-5 w-5" />
               )}
             </span>
           </div>

--- a/packages/bunadmin/src/components/Selector/MultipleSelector/index.tsx
+++ b/packages/bunadmin/src/components/Selector/MultipleSelector/index.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { ChevronsUpDown } from "lucide-react"
 import { Listbox } from "@headlessui/react"
 import { Column } from "@/components/Table/models/material-table-shim"
 
@@ -52,9 +53,7 @@ export default function MultipleSelector(props: Props) {
                 {selectedName.length > 0 ? selectedName.join(", ") : "\u00A0"}
               </span>
               <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-1">
-                <svg className="h-5 w-5 fill-current text-icon-muted" viewBox="0 0 20 20">
-                  <path d="M7 7l3-3 3 3m0 6l-3 3-3-3" stroke="currentColor" strokeWidth="1.5" fill="none" strokeLinecap="round" strokeLinejoin="round" />
-                </svg>
+                <ChevronsUpDown className="h-5 w-5 text-icon-muted" />
               </span>
             </Listbox.Button>
             <Listbox.Options className="absolute z-10 mt-1 max-h-[230px] w-[250px] overflow-auto rounded bg-content-box py-1 text-sm shadow-lg ring-1 ring-black/5 focus:outline-none">

--- a/packages/bunadmin/src/components/Selector/SingleSelector/index.tsx
+++ b/packages/bunadmin/src/components/Selector/SingleSelector/index.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { ChevronsUpDown } from "lucide-react"
 import { Listbox } from "@headlessui/react"
 import { Column, EditComponentProps } from "@/components/Table/models/material-table-shim"
 import { store } from "@/utils"
@@ -113,9 +114,7 @@ export default function SingleSelector<RowData extends object>(
                 {names[keys.indexOf(selectedName)] || "\u00A0"}
               </span>
               <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-1">
-                <svg className="h-5 w-5 fill-current text-icon-muted" viewBox="0 0 20 20">
-                  <path d="M7 7l3-3 3 3m0 6l-3 3-3-3" stroke="currentColor" strokeWidth="1.5" fill="none" strokeLinecap="round" strokeLinejoin="round" />
-                </svg>
+                <ChevronsUpDown className="h-5 w-5 text-icon-muted" />
               </span>
             </Listbox.Button>
             <Listbox.Options className="absolute z-10 mt-1 max-h-[230px] w-full overflow-auto rounded bg-content-box py-1 text-sm shadow-lg ring-1 ring-black/5 focus:outline-none">


### PR DESCRIPTION
Part of the UI follow-up (#3). The 4 Selector components (used in every dropdown + table filter) had hand-rolled chevron/spinner SVGs → swapped to lucide `ChevronsUpDown` + `Loader2` for consistency. Already token-colored, so dark mode unaffected. 85 tests; app build clean. Repeater/FileExplorer inline SVGs remain (lower-traffic, token-colored) as optional follow-up.