### PR TITLE
feat(demo): one-command flagship demo (PocketBase)

### DIFF
--- a/examples/pocketbase-demo/README.md
+++ b/examples/pocketbase-demo/README.md
@@ -1,0 +1,52 @@
+# bunadmin Flagship Demo (PocketBase)
+
+Boot a real backend + seed data + generate a working admin — in minutes.
+
+## One command (no Docker)
+
+```bash
+./start.sh
+```
+
+Downloads PocketBase, creates an admin, serves it on `http://127.0.0.1:8090`, and
+seeds demo collections (`posts`, `products`, `customers`) + a `demo` user. The
+script prints the exact next steps. Ctrl-C stops it.
+
+> Linux x64 by default. For macOS/Windows, set `PB_VERSION` and edit the download
+> URL in `start.sh` (or use the Docker path below).
+
+## Docker alternative
+
+```bash
+docker compose up -d
+node ../../docs/pocketbase/seed.js   # PB_URL defaults to http://127.0.0.1:8090
+```
+
+## Then: generate the admin
+
+```bash
+bunadmin new my-admin && cd my-admin
+```
+
+`.env`:
+```
+VITE_AUTH_PLUGIN=@xbuilder/bunadmin-auth-pocketbase
+VITE_AUTH_URL=http://127.0.0.1:8090
+```
+
+Generate a validated admin table from the live `posts` collection (BYOK):
+```bash
+export BUNADMIN_AI_PROVIDER=openai BUNADMIN_AI_API_KEY=sk-... BUNADMIN_AI_MODEL=gpt-4o-mini
+bunadmin ai generate --url http://127.0.0.1:8090 --collection posts \
+  --token <admin-token> --out src/plugins/blog/post
+yarn dev
+```
+
+Sign in as `demo` / `bunadmin123`. You now have a themed, validated admin for real
+PocketBase data — see [`../../docs/ai/README.md`](../../docs/ai/README.md) for the
+full AI walkthrough and [`example-admin.tsx`](./example-admin.tsx) for a
+pre-generated table you can drop in without an API key.
+
+## Credentials
+- PocketBase admin: `admin@bunadmin.test` / `bunadmin123`
+- Demo user (app login): `demo` / `bunadmin123`

--- a/examples/pocketbase-demo/docker-compose.yml
+++ b/examples/pocketbase-demo/docker-compose.yml
@@ -1,0 +1,21 @@
+# bunadmin flagship demo — PocketBase backend (docker alternative to start.sh).
+#   docker compose up        # serves PocketBase on :8090
+#   then: node ../../docs/pocketbase/seed.js   (PB_URL=http://127.0.0.1:8090)
+# Uses a community PocketBase image; pin a digest for production use.
+services:
+  pocketbase:
+    image: ghcr.io/muchobien/pocketbase:0.22.21
+    container_name: bunadmin-demo-pb
+    ports:
+      - "8090:8090"
+    volumes:
+      - pb_data:/pb_data
+    command: ["serve", "--http=0.0.0.0:8090"]
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:8090/api/health"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+volumes:
+  pb_data:

--- a/examples/pocketbase-demo/example-admin.tsx
+++ b/examples/pocketbase-demo/example-admin.tsx
@@ -1,0 +1,62 @@
+/**
+ * Worked example: a `posts` page backed by PocketBase via
+ * @xbuilder/bunadmin-source-pocketbase.
+ *
+ * Drop this into a bunadmin project's plugin (e.g. src/plugins/bunadmin-plugin-
+ * myteam-blog/posts/index.tsx) and register it like any other schema plugin.
+ * Requires a PocketBase `posts` collection (see docs/pocketbase/seed.js).
+ */
+import React, { createRef } from "react"
+import {
+  Table,
+  TableHead,
+  tableIcons,
+  TableDefaultProps as DefaultProps,
+  useTranslation,
+  Column
+} from "@xbuilder/bunadmin"
+import { dataCtrl, editableCtrl } from "@xbuilder/bunadmin-source-pocketbase"
+
+const theme = { bunadmin: { iconColor: "#8f9bb3" } }
+
+interface Post {
+  id: string
+  name: string
+  status: string
+  views: number
+}
+
+const columns = ({ t }: { t: any }): Column<Post>[] => [
+  { title: t("Id"), field: "id", editable: "never", width: 180 },
+  { title: t("Name"), field: "name" },
+  {
+    title: t("Status"),
+    field: "status",
+    lookup: { Draft: "Draft", Published: "Published" }
+  },
+  { title: t("Views"), field: "views", type: "numeric" }
+]
+
+export default function Posts() {
+  const { t } = useTranslation("table")
+  const tableRef = createRef()
+  const SchemaName = "posts" // PocketBase collection name
+
+  return (
+    <>
+      <TableHead title="Posts" />
+      <Table<Post>
+        tableRef={tableRef}
+        title="Posts"
+        columns={columns({ t })}
+        style={DefaultProps.style}
+        icons={tableIcons({ theme })}
+        options={{ ...DefaultProps.options, filtering: true }}
+        // Remote data via PocketBase
+        data={query => dataCtrl({ t, tableQuery: query, path: SchemaName })}
+        // Inline create / update / delete via PocketBase
+        editable={editableCtrl({ t, SchemaName })}
+      />
+    </>
+  )
+}

--- a/examples/pocketbase-demo/start.sh
+++ b/examples/pocketbase-demo/start.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# One-command bunadmin flagship demo: PocketBase + seed + a generated admin.
+#
+#   ./start.sh            # downloads PocketBase, seeds it, serves on :8090
+#
+# Then in another terminal, scaffold + run the admin (see README.md).
+set -euo pipefail
+
+PB_VERSION="${PB_VERSION:-0.22.21}"
+PB_PORT="${PB_PORT:-8090}"
+DIR="$(cd "$(dirname "$0")" && pwd)"
+PB_DIR="$DIR/.pb"
+ADMIN_EMAIL="${PB_ADMIN:-admin@bunadmin.test}"
+ADMIN_PW="${PB_ADMIN_PW:-bunadmin123}"
+
+mkdir -p "$PB_DIR"
+cd "$PB_DIR"
+
+# 1. Download PocketBase binary if missing (Linux x64; see README for other OS).
+if [ ! -x "./pocketbase" ]; then
+  echo "→ downloading PocketBase $PB_VERSION ..."
+  url="https://github.com/pocketbase/pocketbase/releases/download/v${PB_VERSION}/pocketbase_${PB_VERSION}_linux_amd64.zip"
+  curl -fsSL "$url" -o pb.zip
+  unzip -o pb.zip pocketbase >/dev/null
+  rm -f pb.zip
+fi
+
+# 2. Create the admin account (idempotent — ignores "already exists").
+./pocketbase admin create "$ADMIN_EMAIL" "$ADMIN_PW" 2>/dev/null || true
+
+# 3. Serve in the background, wait for health.
+echo "→ starting PocketBase on http://127.0.0.1:${PB_PORT} ..."
+./pocketbase serve --http="127.0.0.1:${PB_PORT}" >pb.log 2>&1 &
+PB_PID=$!
+trap 'kill $PB_PID 2>/dev/null || true' EXIT
+for i in $(seq 1 30); do
+  curl -fsS "http://127.0.0.1:${PB_PORT}/api/health" >/dev/null 2>&1 && break
+  sleep 0.5
+done
+
+# 4. Seed demo collections + records + a demo user.
+echo "→ seeding demo data ..."
+PB_URL="http://127.0.0.1:${PB_PORT}" PB_ADMIN="$ADMIN_EMAIL" PB_ADMIN_PW="$ADMIN_PW" \
+  node "$DIR/../../docs/pocketbase/seed.js"
+
+cat <<EOF
+
+✓ Demo backend ready: http://127.0.0.1:${PB_PORT}  (admin UI: /_/)
+  admin: ${ADMIN_EMAIL} / ${ADMIN_PW}   demo user: demo / bunadmin123
+
+Next — in another terminal:
+  bunadmin new my-admin && cd my-admin
+  # .env:
+  #   VITE_AUTH_PLUGIN=@xbuilder/bunadmin-auth-pocketbase
+  #   VITE_AUTH_URL=http://127.0.0.1:${PB_PORT}
+  bunadmin ai generate --url http://127.0.0.1:${PB_PORT} --collection posts \\
+    --token \$(curl -s -X POST http://127.0.0.1:${PB_PORT}/api/admins/auth-with-password \\
+      -H 'Content-Type: application/json' \\
+      -d '{"identity":"${ADMIN_EMAIL}","password":"${ADMIN_PW}"}' | sed -n 's/.*"token":"\\([^"]*\\)".*/\\1/p')
+  yarn dev
+
+(Ctrl-C here stops PocketBase.)
+EOF
+
+wait $PB_PID


### PR DESCRIPTION
Runnable launch artifact in examples/pocketbase-demo: start.sh (download PB + seed + print wiring), docker-compose alternative, README walkthrough, pre-generated example-admin.tsx (no API key needed). Reproducible replacement for the deleted throwaway PB. bash -n verified; full PB download not run here (disk-constrained) but script logic/paths verified.