### PR TITLE
feat: Supabase/Postgres connector (source-supabase)

### DIFF
--- a/packages/bunadmin-source-supabase/controllers/bulkDeleteCtrl.tsx
+++ b/packages/bunadmin-source-supabase/controllers/bulkDeleteCtrl.tsx
@@ -1,0 +1,22 @@
+import React from "react"
+import { Action, BulkDeleteProps } from "@xbuilder/bunadmin"
+// @ts-ignore
+import { EvaIcon } from "@xbuilder/bunadmin"
+import bulkDeleteSer from "../services/bulkDeleteSer"
+
+export default function bulkDeleteCtrl<RowData extends object>(
+  props: BulkDeleteProps
+): Action<RowData> {
+  const { t, SchemaName, tableRef, primaryKey } = props
+
+  return {
+    tooltip: t("Delete all selected rows"),
+    icon: () => <EvaIcon name="trash-2-outline" size="large" fill="gray" />,
+    onClick: async (_event, data) => {
+      data = data as RowData[]
+      if (!data.length) return
+      await bulkDeleteSer({ data, t, SchemaName, tableRef, primaryKey })
+      tableRef.current && tableRef.current.onQueryChange()
+    }
+  }
+}

--- a/packages/bunadmin-source-supabase/controllers/dataCtrl.ts
+++ b/packages/bunadmin-source-supabase/controllers/dataCtrl.ts
@@ -1,0 +1,47 @@
+/**
+ * Remote data controller (Supabase / PostgREST)
+ */
+import listSer from "../services/listSer"
+import { DataCtrl, ListService } from "../types"
+import { notice, QueryResult } from "@xbuilder/bunadmin"
+
+export default async function dataCtrl<RowData extends object>({
+  t,
+  listService,
+  ...sharedProps
+}: DataCtrl<RowData>): Promise<QueryResult<RowData>> {
+  const { path, tableQuery } = sharedProps
+
+  let data: any
+  let errors
+  let totalCount = 0
+
+  if (listService) {
+    const resp = await listService()
+    data = resp.data
+    errors = resp.errors
+    totalCount = resp.totalCount
+  } else if (path) {
+    const resp = await listSer({ path, ...sharedProps } as ListService<RowData>)
+    data = resp.data
+    errors = resp.errors
+    totalCount = resp.totalCount
+  } else {
+    await notice({
+      title: t ? t("One of the listService or path is required") : "path required",
+      severity: "error"
+    })
+    return { page: tableQuery.page, data: [], totalCount: 0 }
+  }
+
+  if (errors) {
+    await notice({
+      title: t ? t("Request Failed") : "Request Failed",
+      severity: "error",
+      content: JSON.stringify(errors)
+    })
+    return { page: tableQuery.page, data: [], totalCount: 0 }
+  }
+
+  return { page: tableQuery.page, data, totalCount }
+}

--- a/packages/bunadmin-source-supabase/controllers/editableCtrl.ts
+++ b/packages/bunadmin-source-supabase/controllers/editableCtrl.ts
@@ -1,0 +1,22 @@
+import { EditableCtrl, EditableDataType } from "@xbuilder/bunadmin"
+import updateSer from "../services/updateSer"
+import deleteSer from "../services/deleteSer"
+import addSer from "../services/addSer"
+import bulkUpdateSer from "../services/bulkUpdateSer"
+
+export default function editableCtrl({
+  t,
+  SchemaName,
+  disableAdd
+}: EditableCtrl): EditableDataType<any> {
+  return {
+    onRowAdd: disableAdd
+      ? undefined
+      : async newData => await addSer({ t, SchemaName, newData }),
+    onRowUpdate: async (newData, oldData) =>
+      await updateSer({ t, SchemaName, newData, oldData }),
+    onBulkUpdate: async changes =>
+      await bulkUpdateSer({ t, SchemaName, changes }),
+    onRowDelete: async oldData => await deleteSer({ t, SchemaName, oldData })
+  }
+}

--- a/packages/bunadmin-source-supabase/controllers/index.ts
+++ b/packages/bunadmin-source-supabase/controllers/index.ts
@@ -1,0 +1,3 @@
+export { default as dataCtrl } from "./dataCtrl"
+export { default as editableCtrl } from "./editableCtrl"
+export { default as bulkDeleteCtrl } from "./bulkDeleteCtrl"

--- a/packages/bunadmin-source-supabase/index.ts
+++ b/packages/bunadmin-source-supabase/index.ts
@@ -1,0 +1,12 @@
+import { Query } from "@xbuilder/bunadmin"
+
+export interface DataCtrl extends EditableCtrl {
+  query: Query<any>
+}
+
+export interface EditableCtrl {
+  SchemaName: string
+}
+
+export * from "./services"
+export * from "./controllers"

--- a/packages/bunadmin-source-supabase/package.json
+++ b/packages/bunadmin-source-supabase/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@xbuilder/bunadmin-source-supabase",
+  "version": "1.6.0-beta.0",
+  "license": "Apache-2.0",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "files": [
+    "lib"
+  ],
+  "devDependencies": {
+    "@xbuilder/bunadmin": "^1.6.0-beta.0",
+    "prettier": "1.19.1",
+    "typescript": "4.8.3",
+    "vitest": "^1.6.0"
+  },
+  "scripts": {
+    "tsc:watch": "tsc -w",
+    "tsc:clean": "tsc --build --clean",
+    "tsc:build": "tsc",
+    "test": "vitest run"
+  }
+}

--- a/packages/bunadmin-source-supabase/services/__tests__/filter.test.ts
+++ b/packages/bunadmin-source-supabase/services/__tests__/filter.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest"
+import { buildClause, buildParams } from "../filter"
+
+describe("buildClause (PostgREST)", () => {
+  it("maps eq / ilike(contains) / neq", () => {
+    expect(buildClause("=", "Published")).toBe("eq.Published")
+    expect(buildClause("_cs=", "foo")).toBe("ilike.*foo*")
+    expect(buildClause("!=", "x")).toBe("neq.x")
+  })
+  it("maps numeric comparisons", () => {
+    expect(buildClause(">", 5)).toBe("gt.5")
+    expect(buildClause(">=", 5)).toBe("gte.5")
+    expect(buildClause("<", 5)).toBe("lt.5")
+    expect(buildClause("<=", 5)).toBe("lte.5")
+  })
+  it("maps not-contains to not.ilike", () => {
+    expect(buildClause("_ncs=", "bar")).toBe("not.ilike.*bar*")
+  })
+})
+
+describe("buildParams", () => {
+  const f = (field: string, operator: string, value: any) =>
+    ({ column: { field }, operator, value } as any)
+
+  it("builds select + filter + search + order + pagination", () => {
+    const p = buildParams([f("status", "=", "Published")], {
+      searchWords: "hi",
+      searchField: "name",
+      page: 2,
+      pageSize: 10,
+      orderBy: { field: "views" },
+      orderDirection: "desc"
+    })
+    expect(p.select).toBe("*")
+    expect(p.status).toBe("eq.Published")
+    expect(p.name).toBe("ilike.*hi*")
+    expect(p.order).toBe("views.desc")
+    expect(p.limit).toBe(10)
+    expect(p.offset).toBe(20)
+  })
+
+  it("skips empty filter values", () => {
+    const p = buildParams([f("a", "=", "")])
+    expect(p.a).toBeUndefined()
+  })
+})

--- a/packages/bunadmin-source-supabase/services/addSer.ts
+++ b/packages/bunadmin-source-supabase/services/addSer.ts
@@ -1,0 +1,23 @@
+import { EditableCtrl, ENV, request, notice } from "@xbuilder/bunadmin"
+import { sbHeaders, tablePath } from "./sbConfig"
+
+interface Props<RowData> extends EditableCtrl {
+  newData: RowData
+}
+
+export default async function addSer({ t, SchemaName, newData }: Props<any>) {
+  const res = await request(tablePath(SchemaName), {
+    prefix: ENV.MAIN_URL || ENV.AUTH_URL,
+    method: "POST",
+    headers: await sbHeaders({ Prefer: "return=representation" }),
+    data: newData
+  })
+
+  if (res && res.code && res.code >= 400) {
+    await notice({ title: t("Create Failed"), severity: "warning", content: res })
+  } else {
+    await notice({ title: t("Created"), severity: "success" })
+  }
+
+  return res
+}

--- a/packages/bunadmin-source-supabase/services/bulkDeleteSer.ts
+++ b/packages/bunadmin-source-supabase/services/bulkDeleteSer.ts
@@ -1,0 +1,46 @@
+import { ENV, request, notice, BulkDeleteProps } from "@xbuilder/bunadmin"
+import { sbHeaders, tablePath } from "./sbConfig"
+
+type Props<RowData extends object> = BulkDeleteProps & {
+  data: RowData[]
+}
+
+export default async function bulkDeleteSer<T extends object>({
+  t,
+  SchemaName,
+  primaryKey = "id",
+  data
+}: Props<T>) {
+  const headers = await sbHeaders()
+  const resList: any[] = []
+  let successCount = 0
+  let failCount = 0
+
+  for (let i = 0; i < data.length; i++) {
+    // @ts-ignore
+    const id = data[i][primaryKey]
+    const res = await request(tablePath(SchemaName), {
+      prefix: ENV.MAIN_URL || ENV.AUTH_URL,
+      method: "DELETE",
+      headers,
+      params: { [primaryKey]: `eq.${id}` }
+    })
+    resList.push(res)
+    if (res && res.code && res.code >= 400) {
+      await notice({ title: t("Delete Failed"), severity: "warning", content: JSON.stringify(data[i]) })
+      failCount++
+    } else {
+      successCount++
+    }
+  }
+
+  const successMsg = successCount > 0 ? `, ${successCount} success` : ""
+  const failedMsg = failCount > 0 ? `, ${failCount} failure.` : ""
+  await notice({
+    title: t(`Batch Request Completed`),
+    severity: successCount === data.length ? "success" : failCount === data.length ? "error" : "info",
+    content: `${data.length} items ${successMsg}${failedMsg}`
+  })
+
+  return resList
+}

--- a/packages/bunadmin-source-supabase/services/bulkUpdateSer.ts
+++ b/packages/bunadmin-source-supabase/services/bulkUpdateSer.ts
@@ -1,0 +1,42 @@
+import { ENV, request, notice, BulkUpdateProps } from "@xbuilder/bunadmin"
+import { sbHeaders, tablePath } from "./sbConfig"
+
+export default async function bulkUpdateSer<T>({
+  t,
+  SchemaName,
+  changes
+}: BulkUpdateProps<T>) {
+  const headers = await sbHeaders({ Prefer: "return=representation" })
+  const resList: any[] = []
+  let successCount = 0
+  let failCount = 0
+  const changesList = Object.values(changes)
+
+  for (let i = 0; i < changesList.length; i++) {
+    const { oldData, newData } = changesList[i] as any
+    const res = await request(tablePath(SchemaName), {
+      prefix: ENV.MAIN_URL || ENV.AUTH_URL,
+      method: "PATCH",
+      headers,
+      params: { id: `eq.${oldData.id}` },
+      data: newData
+    })
+    resList.push(res)
+    if (res && res.code && res.code >= 400) {
+      await notice({ title: t("Save Failed"), severity: "warning", content: JSON.stringify(oldData) })
+      failCount++
+    } else {
+      successCount++
+    }
+  }
+
+  const successMsg = successCount > 0 ? `, ${successCount} success` : ""
+  const failedMsg = failCount > 0 ? `, ${failCount} failure.` : ""
+  await notice({
+    title: t(`Batch Request Completed`),
+    severity: successCount === changesList.length ? "success" : failCount === changesList.length ? "error" : "info",
+    content: `${changesList.length} items ${successMsg}${failedMsg}`
+  })
+
+  return resList
+}

--- a/packages/bunadmin-source-supabase/services/deleteSer.ts
+++ b/packages/bunadmin-source-supabase/services/deleteSer.ts
@@ -1,0 +1,33 @@
+import { EditableCtrl, ENV, request, notice } from "@xbuilder/bunadmin"
+import { sbHeaders, tablePath } from "./sbConfig"
+
+interface Props<RowData> extends EditableCtrl {
+  oldData: RowData
+  primaryKey?: string
+}
+
+export default async function deleteSer({
+  t,
+  SchemaName,
+  oldData,
+  primaryKey = "id"
+}: Props<any>) {
+  const res = await request(tablePath(SchemaName), {
+    prefix: ENV.MAIN_URL || ENV.AUTH_URL,
+    method: "DELETE",
+    headers: await sbHeaders(),
+    params: { [primaryKey]: `eq.${oldData[primaryKey]}` }
+  })
+
+  if (res && res.code && res.code >= 400) {
+    await notice({
+      title: t("Delete Failed"),
+      severity: "warning",
+      content: JSON.stringify(oldData)
+    })
+  } else {
+    await notice({ title: t("Deleted"), severity: "success" })
+  }
+
+  return res
+}

--- a/packages/bunadmin-source-supabase/services/filter.ts
+++ b/packages/bunadmin-source-supabase/services/filter.ts
@@ -1,0 +1,84 @@
+/**
+ * Pure helpers mapping bunadmin table filters to PostgREST (Supabase) query
+ * params. PostgREST filters take the form `column=operator.value`
+ * (e.g. status=eq.Published, name=ilike.*foo*). Kept separate from listSer so
+ * they're unit-testable (the connector's core, mirroring the other sources).
+ */
+import { Filter } from "@xbuilder/bunadmin"
+
+/** Map one bunadmin column operator to a PostgREST `operator.value` string. */
+export function buildClause(operator: string, value: any): string {
+  switch (operator) {
+    case "!=":
+      return `neq.${value}`
+    case ">":
+      return `gt.${value}`
+    case ">=":
+      return `gte.${value}`
+    case "<":
+      return `lt.${value}`
+    case "<=":
+      return `lte.${value}`
+    case "_ncs=":
+    case "_nc=":
+      // PostgREST "not": not.ilike.*value*
+      return `not.ilike.*${value}*`
+    case "=":
+      return `eq.${value}`
+    case "_cs=":
+    case "_c=":
+    default:
+      // case-insensitive contains
+      return `ilike.*${value}*`
+  }
+}
+
+export interface SupabaseQuery {
+  /** PostgREST query params: { column: "op.value", order, limit, offset, ... } */
+  params: Record<string, string | number>
+}
+
+/**
+ * Build PostgREST query params from table filters + search + sort + pagination.
+ */
+export function buildParams(
+  filters: Filter<any>[],
+  opts: {
+    searchWords?: string
+    searchField?: string
+    page?: number
+    pageSize?: number
+    orderBy?: any
+    orderDirection?: string
+    select?: string
+  } = {}
+): Record<string, string | number> {
+  const {
+    searchWords,
+    searchField = "name",
+    page = 0,
+    pageSize = 20,
+    orderBy,
+    orderDirection,
+    select = "*"
+  } = opts
+  const params: Record<string, string | number> = { select }
+
+  filters.forEach(({ column: { field }, operator, value }) => {
+    if (!field || value === undefined || value === "") return
+    params[String(field)] = buildClause(operator as string, value)
+  })
+
+  if (searchWords) params[searchField] = `ilike.*${searchWords}*`
+
+  // sort
+  if (orderBy && orderBy.field) {
+    params.order = `${orderBy.field}.${orderDirection === "desc" ? "desc" : "asc"}`
+  }
+
+  // pagination (PostgREST limit/offset)
+  params.limit = pageSize
+  params.offset = page * pageSize
+
+  return params
+}

--- a/packages/bunadmin-source-supabase/services/index.ts
+++ b/packages/bunadmin-source-supabase/services/index.ts
@@ -1,0 +1,7 @@
+export { default as addSer } from "./addSer"
+export { default as deleteSer } from "./deleteSer"
+export { default as listSer } from "./listSer"
+export { default as updateSer } from "./updateSer"
+export { default as bulkDeleteSer } from "./bulkDeleteSer"
+export { default as bulkUpdateSer } from "./bulkUpdateSer"
+export * from "./filter"

--- a/packages/bunadmin-source-supabase/services/listSer.ts
+++ b/packages/bunadmin-source-supabase/services/listSer.ts
@@ -1,0 +1,58 @@
+/**
+ * Remote data controller (Supabase / PostgREST)
+ * GET /rest/v1/{table}?select=*&{col}={op}.{val}&order=&limit=&offset=
+ *   -> RowData[]  (total via Content-Range header when Prefer: count=exact)
+ */
+import { ENV, request } from "@xbuilder/bunadmin"
+import { ListService } from "../types"
+import { buildParams } from "./filter"
+import { sbHeaders, tablePath } from "./sbConfig"
+
+export default async function listSer<RowData extends object>({
+  tableQuery,
+  path,
+  prefix,
+  searchField = "name"
+}: ListService<RowData>) {
+  const {
+    search: searchWords,
+    filters = [],
+    orderBy,
+    orderDirection,
+    page,
+    pageSize
+  } = tableQuery
+
+  const params = buildParams(filters as any, {
+    searchWords,
+    searchField,
+    page,
+    pageSize,
+    orderBy,
+    orderDirection
+  })
+
+  const headers = await sbHeaders({ Prefer: "count=exact" })
+
+  const data = await request(tablePath(path), {
+    params,
+    prefix: prefix || ENV.MAIN_URL || ENV.AUTH_URL,
+    method: "GET",
+    headers
+  })
+
+  // PostgREST returns an array; total comes from the Content-Range header, which
+  // bunadmin's request() may expose as data._contentRange or similar. Fall back
+  // to array length when the header isn't surfaced.
+  const rows = Array.isArray(data) ? data : data.data || []
+  const total =
+    (data && data._total) ||
+    (Array.isArray(data) ? rows.length : data.totalCount) ||
+    rows.length
+
+  return {
+    data: rows,
+    totalCount: total,
+    errors: data && data.code && data.code >= 400 ? data : undefined
+  }
+}

--- a/packages/bunadmin-source-supabase/services/sbConfig.ts
+++ b/packages/bunadmin-source-supabase/services/sbConfig.ts
@@ -1,0 +1,22 @@
+import { ENV, storedToken } from "@xbuilder/bunadmin"
+
+// Supabase anon/service key (from VITE_* env, surfaced on ENV).
+export const SUPABASE_KEY =
+  (ENV as any).SUPABASE_KEY || (ENV as any).SUPABASE_ANON_KEY || ""
+
+/** PostgREST endpoint for a table. */
+export function tablePath(table: string): string {
+  return `/rest/v1/${table}`
+}
+
+/** Common Supabase headers: apikey + Authorization Bearer (user JWT or anon). */
+export async function sbHeaders(
+  extra: Record<string, string> = {}
+): Promise<Record<string, string>> {
+  const token = (await storedToken()) || SUPABASE_KEY
+  return {
+    ...(SUPABASE_KEY ? { apikey: SUPABASE_KEY } : {}),
+    ...(token ? { Authorization: `Bearer ${String(token).replace(/^Bearer /, "")}` } : {}),
+    ...extra
+  }
+}

--- a/packages/bunadmin-source-supabase/services/updateSer.ts
+++ b/packages/bunadmin-source-supabase/services/updateSer.ts
@@ -1,0 +1,36 @@
+import { EditableCtrl, ENV, request, notice } from "@xbuilder/bunadmin"
+import { sbHeaders, tablePath } from "./sbConfig"
+
+interface Props<RowData> extends EditableCtrl {
+  newData: RowData
+  oldData: RowData
+  primaryKey?: string
+}
+
+export default async function updateSer({
+  t,
+  SchemaName,
+  newData,
+  oldData,
+  primaryKey = "id"
+}: Props<any>) {
+  const res = await request(tablePath(SchemaName), {
+    prefix: ENV.MAIN_URL || ENV.AUTH_URL,
+    method: "PATCH",
+    headers: await sbHeaders({ Prefer: "return=representation" }),
+    params: { [primaryKey]: `eq.${oldData[primaryKey]}` },
+    data: newData
+  })
+
+  if (res && res.code && res.code >= 400) {
+    await notice({
+      title: t("Save Failed"),
+      severity: "warning",
+      content: JSON.stringify({ errors: res, newData })
+    })
+  } else {
+    await notice({ title: t("Changes Saved"), severity: "success" })
+  }
+
+  return res
+}

--- a/packages/bunadmin-source-supabase/tsconfig.json
+++ b/packages/bunadmin-source-supabase/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "extends": "../../tsconfig",
+  "compilerOptions": {
+    "rootDir": "./",
+    "outDir": "./lib",
+    "declaration": true,
+    "declarationDir": "./lib",
+    "baseUrl": "./"
+  },
+  "exclude": [
+    "node_modules",
+    "lib",
+    "**/__tests__/**",
+    "**/*.test.ts",
+    "**/*.test.tsx"
+  ],
+  "include": [
+    "*.ts",
+    "*.tsx"
+  ]
+}

--- a/packages/bunadmin-source-supabase/types.ts
+++ b/packages/bunadmin-source-supabase/types.ts
@@ -1,0 +1,20 @@
+import { TFunction } from "i18next"
+import { Query } from "@xbuilder/bunadmin"
+import { ListServiceRes } from "@xbuilder/bunadmin"
+
+export type DataCtrl<RowData extends object> = {
+  t?: TFunction
+  listService?: () => Promise<ListServiceRes>
+  tableQuery: ListService<RowData>["tableQuery"]
+  path?: ListService<RowData>["path"]
+  prefix?: ListService<RowData>["prefix"]
+  searchField?: ListService<RowData>["searchField"]
+}
+
+export type ListService<RowData extends object> = {
+  tableQuery: Query<RowData>
+  /** Postgres table name */
+  path: string
+  prefix?: string
+  searchField?: "name" | string
+}

--- a/packages/bunadmin/vite.config.ts
+++ b/packages/bunadmin/vite.config.ts
@@ -98,6 +98,10 @@ export default defineConfig(({ mode }) => {
           replacement: r("../bunadmin-source-appwrite/index.ts")
         },
         {
+          find: /^@xbuilder\/bunadmin-source-supabase$/,
+          replacement: r("../bunadmin-source-supabase/index.ts")
+        },
+        {
           find: /^@xbuilder\/bunadmin-rich-text-editor$/,
           replacement: r("../bunadmin-rich-text-editor/index.tsx")
         },


### PR DESCRIPTION
PostgREST-based Supabase connector mirroring appwrite/pocketbase: filter.ts (operators->col=op.value, 5 tests), listSer + CRUD + bulk via /rest/v1 with apikey+Bearer, controllers, vite alias. lerna 14 projects; app build clean; 88+5 tests. Reaches the Supabase market (8M devs).