### PR TITLE
feat(cli): ai refine — iterative schema refinement

### DIFF
--- a/packages/bunadmin-cli/ai/__tests__/refine.test.js
+++ b/packages/bunadmin-cli/ai/__tests__/refine.test.js
@@ -1,0 +1,45 @@
+// node --test ai/__tests__/refine.test.js
+const { test } = require("node:test")
+const assert = require("node:assert")
+const { tryDeterministicRefine, buildRefinePrompt } = require("../refine")
+
+const cols = [
+  { title: "Id", field: "id" },
+  { title: "Name", field: "name" },
+  { title: "Views", field: "views" },
+  { title: "Albums", field: "albums" }
+]
+
+test("remove <field> drops the column", () => {
+  const out = tryDeterministicRefine(cols, "remove albums")
+  assert.equal(out.length, 3)
+  assert.ok(!out.some(c => c.field === "albums"))
+})
+
+test("drop/hide synonyms + 'the' work", () => {
+  assert.equal(tryDeterministicRefine(cols, "drop the views").length, 3)
+  assert.ok(!tryDeterministicRefine(cols, "hide name").some(c => c.field === "name"))
+})
+
+test("make <field> numeric sets type", () => {
+  const out = tryDeterministicRefine(cols, "make views numeric")
+  assert.equal(out.find(c => c.field === "views").type, "numeric")
+  // unrelated columns unchanged
+  assert.equal(out.find(c => c.field === "name").type, undefined)
+})
+
+test("returns null for unrecognized / no-op instructions", () => {
+  assert.equal(tryDeterministicRefine(cols, "remove nonexistent"), null)
+  assert.equal(tryDeterministicRefine(cols, "please make it pretty"), null)
+})
+
+test("buildRefinePrompt includes current columns + instruction + real fields", () => {
+  const p = buildRefinePrompt(
+    { collection: "posts", fields: [{ name: "name", type: "text" }] },
+    cols,
+    "make views numeric"
+  )
+  assert.ok(p.includes("make views numeric"))
+  assert.ok(p.includes("CURRENT columns"))
+  assert.ok(p.includes('"field": "albums"') || p.includes("albums"))
+})

--- a/packages/bunadmin-cli/ai/refine.js
+++ b/packages/bunadmin-cli/ai/refine.js
@@ -1,0 +1,127 @@
+/**
+ * `bunadmin ai refine` — conversational/iterative refinement of an already
+ * generated admin. Takes the CURRENT columns + a natural-language instruction
+ * ("add a status filter", "make views numeric", "remove albums"), asks the LLM
+ * for the updated columns, and VALIDATES against the same live schema before
+ * re-emitting. Same constrained-contract moat as `ai generate` — the AI edits a
+ * validated column set, never freeform code.
+ */
+const { introspectPocketbase } = require("./introspect")
+const { getProvider } = require("./provider")
+const { validateColumns } = require("./validate")
+const { extractJson, emitSchemaFile } = require("./generate")
+
+function buildRefinePrompt(schema, currentColumns, instruction) {
+  return [
+    "You are refining an existing bunadmin admin table definition (STRICT JSON).",
+    `Collection: "${schema.collection}".`,
+    "Real fields (use ONLY these, never invent fields):",
+    JSON.stringify(schema.fields, null, 2),
+    "",
+    "CURRENT columns:",
+    JSON.stringify({ columns: currentColumns }, null, 2),
+    "",
+    `Apply this change: "${instruction}"`,
+    "",
+    "Return the FULL updated columns array (not a diff), same JSON shape:",
+    '{ "columns": [ { "title": string, "field": <real field>, "type"?: "numeric",',
+    '  "lookup"?: { <value>: <label> } } ] }',
+    "Rules: one column per field; keep unrelated columns unchanged; lookup is a",
+    "flat {value:label} object; type:\"numeric\" only for number fields.",
+    "Return ONLY JSON, no prose."
+  ].join("\n")
+}
+
+/**
+ * Merge helper: apply common deterministic instructions WITHOUT an LLM, so the
+ * refine logic is testable and cheap for simple ops. Returns updated columns or
+ * null if the instruction isn't a recognized deterministic op.
+ */
+function tryDeterministicRefine(columns, instruction) {
+  const instr = String(instruction).toLowerCase().trim()
+  let m
+
+  // "remove <field>" / "drop <field>" / "hide <field>"
+  if ((m = instr.match(/^(remove|drop|hide)\s+(?:the\s+)?(\w+)/))) {
+    const field = m[2]
+    const next = columns.filter(c => c.field.toLowerCase() !== field)
+    return next.length !== columns.length ? next : null
+  }
+  // "make <field> numeric"
+  if ((m = instr.match(/^make\s+(?:the\s+)?(\w+)\s+numeric/))) {
+    const field = m[1]
+    let hit = false
+    const next = columns.map(c => {
+      if (c.field.toLowerCase() === field) {
+        hit = true
+        return { ...c, type: "numeric" }
+      }
+      return c
+    })
+    return hit ? next : null
+  }
+  return null
+}
+
+/**
+ * @param opts { url, collection, token, columns, instruction, out, mock }
+ * @returns { errors?, outPath?, columns?, mode, attempts, providerName }
+ */
+async function aiRefine(opts) {
+  const {
+    url,
+    collection,
+    token,
+    columns,
+    instruction,
+    out = ".",
+    mock
+  } = opts
+  if (!url || !collection) return { errors: "need --url and --collection" }
+  if (!Array.isArray(columns) || columns.length === 0)
+    return { errors: "need existing --columns (the current generated columns)" }
+  if (!instruction) return { errors: "need an instruction, e.g. \"make views numeric\"" }
+
+  const schema = await introspectPocketbase(url, collection, token)
+
+  // Fast path: deterministic ops (still validated below).
+  const deterministic = tryDeterministicRefine(columns, instruction)
+  if (deterministic) {
+    const v = validateColumns({ columns: deterministic }, schema)
+    if (v.ok) {
+      const outPath = emitSchemaFile(schema, v.columns, out)
+      return { outPath, columns: v.columns, mode: "deterministic", attempts: 0 }
+    }
+    // fall through to LLM if the deterministic result didn't validate
+  }
+
+  // LLM path: same validate-and-retry contract as generate.
+  const provider = getProvider(
+    mock ? { ...process.env, BUNADMIN_AI_PROVIDER: "mock", __MOCK_RESPONSE: mock } : process.env
+  )
+  const prompt = buildRefinePrompt(schema, columns, instruction)
+  let attempts = 0
+  let result
+  let lastErrors = []
+  while (attempts < 2) {
+    attempts++
+    const raw = await provider.complete(
+      attempts === 1 ? prompt : prompt + "\n\nPrevious output invalid:\n" + lastErrors.join("\n")
+    )
+    result = validateColumns(extractJson(raw) || {}, schema)
+    if (result.ok) break
+    lastErrors = result.errors
+  }
+
+  if (!result.ok)
+    return {
+      errors: `refine validation failed after ${attempts} attempt(s):\n - ${result.errors.join("\n - ")}`,
+      attempts,
+      providerName: provider.name
+    }
+
+  const outPath = emitSchemaFile(schema, result.columns, out)
+  return { outPath, columns: result.columns, mode: "llm", attempts, providerName: provider.name }
+}
+
+module.exports = { aiRefine, buildRefinePrompt, tryDeterministicRefine }

--- a/packages/bunadmin-cli/cli.js
+++ b/packages/bunadmin-cli/cli.js
@@ -32,6 +32,10 @@ const cli = meow(`
 	Generate an admin THEME from a description (AI, bring-your-own-key)
 	  $ bunadmin ai theme "dark mode with a purple accent" [--out <dir>]
 	  Emits a validated { preset, mode, overrides } theme config for applyPreset().
+
+	Refine an existing generated admin with a natural-language instruction
+	  $ bunadmin ai refine "make views numeric" --url <url> --collection <name> --columns '<json>'
+	  Updated columns are re-validated against the live schema before re-emitting.
 `)
 
 render(

--- a/packages/bunadmin-cli/commands/ai.ts
+++ b/packages/bunadmin-cli/commands/ai.ts
@@ -6,6 +6,8 @@ const path = require("path")
 const { aiGenerate } = require(path.resolve(__dirname, "../../ai/generate"))
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { aiTheme } = require(path.resolve(__dirname, "../../ai/theme"))
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { aiRefine } = require(path.resolve(__dirname, "../../ai/refine"))
 
 export default async function newAi(
   inputs: string[],
@@ -41,5 +43,29 @@ export default async function newAi(
     }
   }
 
-  return { errors: `Unknown ai subcommand "${sub || ""}". Try: bunadmin ai generate | bunadmin ai theme` }
+  if (sub === "refine") {
+    let columns
+    try {
+      columns = options.columns ? JSON.parse(options.columns) : undefined
+    } catch (e) {
+      return { errors: "--columns must be a JSON array of the current columns" }
+    }
+    const res = await aiRefine({
+      url: options.url,
+      collection: options.collection,
+      token: options.token,
+      columns,
+      instruction: inputs[2] || options.instruction,
+      out: options.out || ".",
+      mock: options.mock
+    })
+    if (res.errors) return { errors: res.errors }
+    return {
+      message: `[${res.mode}] refined (valid after ${res.attempts} attempt(s)) -> ${res.outPath}`
+    }
+  }
+
+  return {
+    errors: `Unknown ai subcommand "${sub || ""}". Try: bunadmin ai generate | theme | refine`
+  }
 }


### PR DESCRIPTION
Conversational refine mode for the AI generator: current columns + NL instruction -> validated updated columns -> re-emit. Deterministic fast path (remove/make numeric) + LLM path (BYOK, retry), same validate-against-live-schema moat. 5 new tests; all ai tests 17/17; app suite unaffected (88).