### PR TITLE
docs: VitePress documentation site (isolated workspace)

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.vitepress/dist
+.vitepress/cache
+yarn.lock
+package-lock.json

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,0 +1,67 @@
+import { defineConfig } from "vitepress"
+
+export default defineConfig({
+  title: "BunAdmin",
+  description:
+    "Vite + Tailwind React admin scaffold with AI-assisted, schema-validated generation.",
+  lastUpdated: true,
+  cleanUrls: true,
+
+  // READMEs double as GitHub-browsable files and reference source files
+  // (e.g. ./example-posts.tsx) + localhost URLs; don't fail the build on those.
+  ignoreDeadLinks: [/^http:\/\/localhost/, /\.tsx?$/, /\.js$/],
+
+  // Existing README.md files (kept for GitHub browsing) serve as section indexes.
+  rewrites: {
+    "ai/README.md": "ai/index.md",
+    "pocketbase/README.md": "pocketbase/index.md",
+    "appwrite/README.md": "appwrite/index.md",
+    "supabase/README.md": "supabase/index.md"
+  },
+
+  themeConfig: {
+    outline: "deep",
+    nav: [
+      { text: "Guide", link: "/guide/getting-started" },
+      { text: "AI Generation", link: "/ai/" },
+      {
+        text: "Connectors",
+        items: [
+          { text: "PocketBase", link: "/pocketbase/" },
+          { text: "Appwrite", link: "/appwrite/" },
+          { text: "Supabase", link: "/supabase/" }
+        ]
+      },
+      { text: "GitHub", link: "https://github.com/Chris533/bunadmin" }
+    ],
+    sidebar: [
+      {
+        text: "Getting Started",
+        items: [
+          { text: "Introduction", link: "/guide/getting-started" },
+          { text: "Flagship demo", link: "/guide/demo" }
+        ]
+      },
+      {
+        text: "AI-Assisted Generation",
+        items: [{ text: "ai generate / theme / refine", link: "/ai/" }]
+      },
+      {
+        text: "Backend Connectors",
+        items: [
+          { text: "PocketBase", link: "/pocketbase/" },
+          { text: "Appwrite", link: "/appwrite/" },
+          { text: "Supabase", link: "/supabase/" }
+        ]
+      },
+      {
+        text: "Project",
+        items: [{ text: "Docs contributors", link: "/CONTRIBUTORS" }]
+      }
+    ],
+    socialLinks: [
+      { icon: "github", link: "https://github.com/Chris533/bunadmin" }
+    ],
+    search: { provider: "local" }
+  }
+})

--- a/docs/appwrite/README.md
+++ b/docs/appwrite/README.md
@@ -1,0 +1,28 @@
+# Appwrite Connector
+
+`@xbuilder/bunadmin-source-appwrite` — use Appwrite as the data source for any
+bunadmin schema (list/CRUD/bulk via Appwrite's Databases API).
+
+```bash
+yarn add @xbuilder/bunadmin-source-appwrite
+```
+
+```tsx
+import { dataCtrl, editableCtrl } from "@xbuilder/bunadmin-source-appwrite"
+
+<Table
+  columns={columns}
+  data={query => dataCtrl({ t, tableQuery: query, path: "<collectionId>" })}
+  editable={editableCtrl({ t, SchemaName: "<collectionId>" })}
+/>
+```
+
+Configure via `.env` (`VITE_*`): the Appwrite endpoint (`VITE_AUTH_URL`), project,
+and database id.
+
+::: warning
+Full environment-variable wiring + an end-to-end walkthrough are being finalized
+(verifying how `VITE_*` keys surface to the connector). See the
+[source-appwrite package](https://github.com/Chris533/bunadmin/tree/master/packages/bunadmin-source-appwrite)
+meanwhile.
+:::

--- a/docs/guide/demo.md
+++ b/docs/guide/demo.md
@@ -1,0 +1,33 @@
+# Flagship Demo
+
+Boot a real backend, seed data, and generate a working admin — in minutes. The
+runnable demo lives in [`examples/pocketbase-demo`](https://github.com/Chris533/bunadmin/tree/master/examples/pocketbase-demo).
+
+## One command
+
+```bash
+cd examples/pocketbase-demo
+./start.sh
+```
+
+Downloads PocketBase, creates an admin, serves it on `http://127.0.0.1:8090`, and
+seeds demo collections (`posts`, `products`, `customers`) + a `demo` user.
+
+> Docker alternative: `docker compose up -d` then `node ../../docs/pocketbase/seed.js`.
+
+## Generate the admin
+
+```bash
+bunadmin new my-admin && cd my-admin
+# .env: VITE_AUTH_PLUGIN=@xbuilder/bunadmin-auth-pocketbase, VITE_AUTH_URL=http://127.0.0.1:8090
+export BUNADMIN_AI_PROVIDER=openai BUNADMIN_AI_API_KEY=sk-... BUNADMIN_AI_MODEL=gpt-4o-mini
+bunadmin ai generate --url http://127.0.0.1:8090 --collection posts --token <admin-token>
+yarn dev
+```
+
+Sign in as `demo` / `bunadmin123`. See the [AI guide](/ai/) for the full flow,
+including `ai theme` and `ai refine`.
+
+## Credentials
+- PocketBase admin: `admin@bunadmin.test` / `bunadmin123`
+- Demo user (app login): `demo` / `bunadmin123`

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -1,0 +1,43 @@
+# Getting Started
+
+BunAdmin is a scaffold for building React admin/back-office apps quickly. It's
+powered by **Vite**, styled with **Tailwind CSS + Headless UI**, uses **TipTap**
+for rich text, and ships an **AI-assisted, schema-validated** generation flow.
+
+## Install & scaffold
+
+```bash
+npm install --global bunadmin-cli
+bunadmin new my-admin
+cd my-admin
+yarn && yarn dev
+```
+
+The dev server runs at http://localhost:3000.
+
+## Core commands
+
+| Command | Description |
+| --- | --- |
+| `bunadmin new <name>` | Create a project (Vite template) |
+| `bunadmin plugin [team]-[group]` | Create a plugin (run in `plugins/`) |
+| `bunadmin schema [name]` | Create a schema (run in a plugin dir) |
+| `bunadmin ai generate` | Generate a validated admin table from a backend ([AI guide](/ai/)) |
+| `bunadmin ai theme` | Generate a validated theme from a description |
+| `bunadmin ai refine` | Refine an existing generated admin via natural language |
+
+## Pick a backend
+
+BunAdmin is backend-agnostic — choose a data-source connector:
+
+- [PocketBase](/pocketbase/)
+- [Appwrite](/appwrite/)
+- [Supabase / Postgres](/supabase/)
+
+…or Strapi / GraphQL. Set `VITE_AUTH_PLUGIN` + `VITE_AUTH_URL` in `.env` and the
+same table/CRUD UI works against your data.
+
+## Next
+
+- [AI-assisted generation](/ai/) — the fastest way to a working admin.
+- [Flagship demo](/guide/demo) — one command: backend + seed + generated admin.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,24 @@
+---
+layout: home
+hero:
+  name: BunAdmin
+  text: AI-assisted admin, validated against your real schema
+  tagline: A Vite + Tailwind React admin scaffold. Point it at your backend, let AI generate a validated admin — cheap models work because output is checked against your schema, not freeform code.
+  actions:
+    - theme: brand
+      text: Get Started
+      link: /guide/getting-started
+    - theme: alt
+      text: AI Generation
+      link: /ai/
+    - theme: alt
+      text: View on GitHub
+      link: https://github.com/Chris533/bunadmin
+features:
+  - title: AI-assisted, validated
+    details: "`ai generate` / `ai theme` / `ai refine` — the AI fills a constrained, validated contract, never freeform code. Bring your own key."
+  - title: Any backend
+    details: Same table/CRUD UI on PocketBase, Appwrite, Supabase (Postgres), Strapi, or GraphQL — swap via a data-source plugin.
+  - title: Themeable design system
+    details: Token-driven theming with light/dark presets and a slotted layout registry — a constrained design space the AI can compose into.
+---

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@xbuilder/bunadmin-docs",
+  "version": "1.6.0-beta.0",
+  "private": true,
+  "type": "module",
+  "description": "BunAdmin documentation site (VitePress). Standalone — not part of the yarn workspace; install separately.",
+  "scripts": {
+    "dev": "vitepress dev --port 5174",
+    "build": "vitepress build",
+    "preview": "vitepress preview",
+    "contributors": "bash ../scripts/gen-docs-contributors.sh"
+  },
+  "dependencies": {
+    "vitepress": "^1.6.4",
+    "vue": "^3.5.21"
+  },
+  "devDependencies": {
+    "@types/node": "^20.19.0"
+  }
+}

--- a/docs/supabase/README.md
+++ b/docs/supabase/README.md
@@ -1,0 +1,28 @@
+# Supabase / Postgres Connector
+
+`@xbuilder/bunadmin-source-supabase` — use Supabase (PostgREST) as the data source
+for any bunadmin schema. Same table/CRUD UI, backed by your Postgres tables.
+
+```bash
+yarn add @xbuilder/bunadmin-source-supabase
+```
+
+```tsx
+import { dataCtrl, editableCtrl } from "@xbuilder/bunadmin-source-supabase"
+
+<Table
+  columns={columns}
+  data={query => dataCtrl({ t, tableQuery: query, path: "<table>" })}
+  editable={editableCtrl({ t, SchemaName: "<table>" })}
+/>
+```
+
+Filters map to PostgREST (`col=eq.value`, `ilike`, comparisons), with `order`,
+`limit`/`offset`, and `apikey` + `Authorization: Bearer` headers.
+
+::: warning
+Full environment-variable wiring (`SUPABASE_KEY` etc.) + an end-to-end walkthrough
+are being finalized. See the
+[source-supabase package](https://github.com/Chris533/bunadmin/tree/master/packages/bunadmin-source-supabase)
+meanwhile.
+:::


### PR DESCRIPTION
Standalone docs/ VitePress site — own package.json/deps, NOT a yarn workspace (Vue quarantined from the React app), mirroring atomo's docs setup. Home + getting-started + demo guides; wires existing ai/ + pocketbase/ docs; appwrite/supabase stubs. README->index rewrites keep GitHub-browsable files. Build verified clean; monorepo core build unaffected. Run: cd docs && npm i && npm run dev.