### PR TITLE
fix(connectors)+docs: env wiring + full Appwrite/Supabase docs

### DIFF
--- a/docs/appwrite/README.md
+++ b/docs/appwrite/README.md
@@ -1,28 +1,62 @@
 # Appwrite Connector
 
-`@xbuilder/bunadmin-source-appwrite` — use Appwrite as the data source for any
-bunadmin schema (list/CRUD/bulk via Appwrite's Databases API).
+`@xbuilder/bunadmin-source-appwrite` — use [Appwrite](https://appwrite.io)
+Databases as the data source for any bunadmin schema (list / filter / sort /
+CRUD / bulk), reusing the same table UI.
+
+## Install
 
 ```bash
 yarn add @xbuilder/bunadmin-source-appwrite
 ```
 
-```tsx
-import { dataCtrl, editableCtrl } from "@xbuilder/bunadmin-source-appwrite"
+## Configure (`.env`)
 
-<Table
-  columns={columns}
-  data={query => dataCtrl({ t, tableQuery: query, path: "<collectionId>" })}
-  editable={editableCtrl({ t, SchemaName: "<collectionId>" })}
-/>
+```
+VITE_AUTH_URL=https://<region>.cloud.appwrite.io
+VITE_APPWRITE_PROJECT=<your-project-id>
+VITE_APPWRITE_DATABASE=<your-database-id>   # defaults to "default"
 ```
 
-Configure via `.env` (`VITE_*`): the Appwrite endpoint (`VITE_AUTH_URL`), project,
-and database id.
+These are surfaced on bunadmin's `ENV` (`ENV.APPWRITE_PROJECT`,
+`ENV.APPWRITE_DATABASE`) and sent as the `X-Appwrite-Project` header; the stored
+auth token is sent as `X-Appwrite-JWT`.
 
-::: warning
-Full environment-variable wiring + an end-to-end walkthrough are being finalized
-(verifying how `VITE_*` keys surface to the connector). See the
-[source-appwrite package](https://github.com/Chris533/bunadmin/tree/master/packages/bunadmin-source-appwrite)
-meanwhile.
-:::
+## Use in a schema
+
+```tsx
+import { Table, TableHead, tableIcons, TableDefaultProps as DP, useTranslation } from "@xbuilder/bunadmin"
+import { dataCtrl, editableCtrl, bulkDeleteCtrl } from "@xbuilder/bunadmin-source-appwrite"
+
+export default function Posts() {
+  const { t } = useTranslation("table")
+  const SchemaName = "posts" // Appwrite collectionId
+  return (
+    <Table
+      columns={columns}
+      data={query => dataCtrl({ t, tableQuery: query, path: SchemaName })}
+      editable={editableCtrl({ t, SchemaName })}
+      actions={[bulkDeleteCtrl({ t, SchemaName, tableRef })]}
+      options={{ ...DP.options, filtering: true }}
+    />
+  )
+}
+```
+
+## How filters map
+
+bunadmin table operators → Appwrite query JSON
+(`/v1/databases/{db}/collections/{col}/documents?queries[]=`):
+
+| Table operator | Appwrite query |
+| --- | --- |
+| `=` | `equal` |
+| `!=` | `notEqual` |
+| contains | `search` |
+| `>` `>=` `<` `<=` | `greaterThan` / `greaterThanEqual` / `lessThan` / `lessThanEqual` |
+| sort | `orderAsc` / `orderDesc` |
+| pagination | `limit` + `offset` |
+
+## Notes
+- Rows use Appwrite's `$id`; create wraps fields as `{ documentId: "unique()", data }`.
+- Collection permissions must allow the signed-in user to read/write.

--- a/docs/supabase/README.md
+++ b/docs/supabase/README.md
@@ -1,28 +1,63 @@
 # Supabase / Postgres Connector
 
-`@xbuilder/bunadmin-source-supabase` — use Supabase (PostgREST) as the data source
-for any bunadmin schema. Same table/CRUD UI, backed by your Postgres tables.
+`@xbuilder/bunadmin-source-supabase` — use [Supabase](https://supabase.com)
+(PostgREST) as the data source for any bunadmin schema. Same table UI, backed by
+your Postgres tables.
+
+## Install
 
 ```bash
 yarn add @xbuilder/bunadmin-source-supabase
 ```
 
-```tsx
-import { dataCtrl, editableCtrl } from "@xbuilder/bunadmin-source-supabase"
+## Configure (`.env`)
 
-<Table
-  columns={columns}
-  data={query => dataCtrl({ t, tableQuery: query, path: "<table>" })}
-  editable={editableCtrl({ t, SchemaName: "<table>" })}
-/>
+```
+VITE_MAIN_URL=https://<project-ref>.supabase.co
+VITE_SUPABASE_KEY=<anon-or-service-key>      # or VITE_SUPABASE_ANON_KEY
 ```
 
-Filters map to PostgREST (`col=eq.value`, `ilike`, comparisons), with `order`,
-`limit`/`offset`, and `apikey` + `Authorization: Bearer` headers.
+Surfaced on `ENV.SUPABASE_KEY` and sent as the `apikey` header; the stored auth
+token (or the key) is sent as `Authorization: Bearer …`. Requests go to
+`/rest/v1/{table}`.
 
-::: warning
-Full environment-variable wiring (`SUPABASE_KEY` etc.) + an end-to-end walkthrough
-are being finalized. See the
-[source-supabase package](https://github.com/Chris533/bunadmin/tree/master/packages/bunadmin-source-supabase)
-meanwhile.
-:::
+## Use in a schema
+
+```tsx
+import { dataCtrl, editableCtrl, bulkDeleteCtrl } from "@xbuilder/bunadmin-source-supabase"
+
+export default function Posts() {
+  const { t } = useTranslation("table")
+  const SchemaName = "posts" // Postgres table name
+  return (
+    <Table
+      columns={columns}
+      data={query => dataCtrl({ t, tableQuery: query, path: SchemaName })}
+      editable={editableCtrl({ t, SchemaName })}
+      actions={[bulkDeleteCtrl({ t, SchemaName, tableRef })]}
+      options={{ ...DP.options, filtering: true }}
+    />
+  )
+}
+```
+
+## How filters map
+
+bunadmin table operators → PostgREST `column=operator.value`:
+
+| Table operator | PostgREST |
+| --- | --- |
+| `=` | `eq.value` |
+| `!=` | `neq.value` |
+| contains | `ilike.*value*` |
+| not contains | `not.ilike.*value*` |
+| `>` `>=` `<` `<=` | `gt.` / `gte.` / `lt.` / `lte.` |
+| sort | `order=col.asc\|desc` |
+| pagination | `limit` + `offset` |
+
+Total count uses `Prefer: count=exact`. Row ops target `?id=eq.<id>`.
+
+## Notes
+- Row-Level Security must permit the key/user; the anon key + RLS policies is the
+  typical setup. A service key bypasses RLS — use only in trusted contexts.
+- Primary key assumed `id` (override via `primaryKey` in update/delete props).

--- a/packages/bunadmin-source-appwrite/services/awConfig.ts
+++ b/packages/bunadmin-source-appwrite/services/awConfig.ts
@@ -1,8 +1,8 @@
 import { ENV, storedToken } from "@xbuilder/bunadmin"
 
-export const PROJECT = (ENV as any).APPWRITE_PROJECT || (ENV as any).PROJECT_ID
+export const PROJECT = ENV.APPWRITE_PROJECT
 export const DATABASE =
-  (ENV as any).APPWRITE_DATABASE || (ENV as any).DATABASE_ID || "default"
+  ENV.APPWRITE_DATABASE || "default"
 
 /** Common Appwrite headers (project + JWT) for a request. */
 export async function awHeaders(): Promise<Record<string, string>> {

--- a/packages/bunadmin-source-appwrite/services/listSer.ts
+++ b/packages/bunadmin-source-appwrite/services/listSer.ts
@@ -8,8 +8,8 @@ import { ListService } from "../types"
 import { buildQueries } from "./filter"
 
 // Appwrite needs a project id + database id (from VITE_* env, surfaced on ENV).
-const PROJECT = (ENV as any).APPWRITE_PROJECT || (ENV as any).PROJECT_ID
-const DATABASE = (ENV as any).APPWRITE_DATABASE || (ENV as any).DATABASE_ID || "default"
+const PROJECT = ENV.APPWRITE_PROJECT
+const DATABASE = ENV.APPWRITE_DATABASE || "default"
 
 export default async function listSer<RowData extends object>({
   tableQuery,

--- a/packages/bunadmin-source-supabase/services/sbConfig.ts
+++ b/packages/bunadmin-source-supabase/services/sbConfig.ts
@@ -2,7 +2,7 @@ import { ENV, storedToken } from "@xbuilder/bunadmin"
 
 // Supabase anon/service key (from VITE_* env, surfaced on ENV).
 export const SUPABASE_KEY =
-  (ENV as any).SUPABASE_KEY || (ENV as any).SUPABASE_ANON_KEY || ""
+  ENV.SUPABASE_KEY || ""
 
 /** PostgREST endpoint for a table. */
 export function tablePath(table: string): string {

--- a/packages/bunadmin/src/utils/config/index.ts
+++ b/packages/bunadmin/src/utils/config/index.ts
@@ -25,6 +25,10 @@ type EnvTypes = {
   PATHS_WITHOUT_AUTH: string[]
   NOTIFICATION_PLUGIN?: string
   ON_NOTIFICATION_INTERVAL_COUNT: boolean
+  // Connector config (read by source-* plugins)
+  SUPABASE_KEY?: string
+  APPWRITE_PROJECT?: string
+  APPWRITE_DATABASE?: string
 }
 
 // VITE_* env. Read via process.env so this file also compiles to CJS lib/
@@ -52,7 +56,11 @@ export const ENV: EnvTypes = {
   PATHS_WITHOUT_AUTH: strToArr(v("PATHS_WITHOUT_AUTH")),
   NOTIFICATION_PLUGIN: v("NOTIFICATION_PLUGIN"),
   ON_NOTIFICATION_INTERVAL_COUNT:
-    v("OFF_NOTIFICATION_INTERVAL_COUNT") === "true"
+    v("OFF_NOTIFICATION_INTERVAL_COUNT") === "true",
+  // Connector config
+  SUPABASE_KEY: v("SUPABASE_KEY") || v("SUPABASE_ANON_KEY"),
+  APPWRITE_PROJECT: v("APPWRITE_PROJECT") || v("PROJECT_ID"),
+  APPWRITE_DATABASE: v("APPWRITE_DATABASE") || v("DATABASE_ID")
 }
 
 export const SETTING_NAMES = {


### PR DESCRIPTION
Fixes a real connector bug (env vars read off ENV that ENV never set -> connectors sent no apikey/project header) by adding SUPABASE_KEY/APPWRITE_PROJECT/APPWRITE_DATABASE to the typed ENV from VITE_*. Replaces the doc stubs with full verified setup guides. 14 projects build, app+config tests pass, VitePress builds clean.