### PR TITLE
feat: Payload connector (source-payload)

### DIFF
--- a/packages/bunadmin-source-payload/controllers/bulkDeleteCtrl.tsx
+++ b/packages/bunadmin-source-payload/controllers/bulkDeleteCtrl.tsx
@@ -1,0 +1,19 @@
+import React from "react"
+import { Action, BulkDeleteProps } from "@xbuilder/bunadmin"
+// @ts-ignore
+import { EvaIcon } from "@xbuilder/bunadmin"
+import { bulkDeleteSer } from "../services/bulk"
+
+export default function bulkDeleteCtrl<RowData extends object>(props: BulkDeleteProps): Action<RowData> {
+  const { t, SchemaName, tableRef, primaryKey } = props
+  return {
+    tooltip: t("Delete all selected rows"),
+    icon: () => <EvaIcon name="trash-2-outline" size="large" fill="gray" />,
+    onClick: async (_e, data) => {
+      data = data as RowData[]
+      if (!data.length) return
+      await bulkDeleteSer({ data, t, SchemaName, tableRef, primaryKey })
+      tableRef.current && tableRef.current.onQueryChange()
+    }
+  }
+}

--- a/packages/bunadmin-source-payload/controllers/dataCtrl.ts
+++ b/packages/bunadmin-source-payload/controllers/dataCtrl.ts
@@ -1,0 +1,28 @@
+import listSer from "../services/listSer"
+import { DataCtrl, ListService } from "../types"
+import { notice, QueryResult } from "@xbuilder/bunadmin"
+
+export default async function dataCtrl<RowData extends object>({
+  t,
+  listService,
+  ...sharedProps
+}: DataCtrl<RowData>): Promise<QueryResult<RowData>> {
+  const { path, tableQuery } = sharedProps
+  let data: any, errors, totalCount = 0
+
+  if (listService) {
+    const r = await listService(); data = r.data; errors = r.errors; totalCount = r.totalCount
+  } else if (path) {
+    const r = await listSer({ path, ...sharedProps } as ListService<RowData>)
+    data = r.data; errors = r.errors; totalCount = r.totalCount
+  } else {
+    await notice({ title: t ? t("One of the listService or path is required") : "path required", severity: "error" })
+    return { page: tableQuery.page, data: [], totalCount: 0 }
+  }
+
+  if (errors) {
+    await notice({ title: t ? t("Request Failed") : "Request Failed", severity: "error", content: JSON.stringify(errors) })
+    return { page: tableQuery.page, data: [], totalCount: 0 }
+  }
+  return { page: tableQuery.page, data, totalCount }
+}

--- a/packages/bunadmin-source-payload/controllers/editableCtrl.ts
+++ b/packages/bunadmin-source-payload/controllers/editableCtrl.ts
@@ -1,0 +1,12 @@
+import { EditableCtrl, EditableDataType } from "@xbuilder/bunadmin"
+import { addSer, updateSer, deleteSer } from "../services/crud"
+import { bulkUpdateSer } from "../services/bulk"
+
+export default function editableCtrl({ t, SchemaName, disableAdd }: EditableCtrl): EditableDataType<any> {
+  return {
+    onRowAdd: disableAdd ? undefined : async newData => await addSer({ t, SchemaName, newData }),
+    onRowUpdate: async (newData, oldData) => await updateSer({ t, SchemaName, newData, oldData }),
+    onBulkUpdate: async changes => await bulkUpdateSer({ t, SchemaName, changes }),
+    onRowDelete: async oldData => await deleteSer({ t, SchemaName, oldData })
+  }
+}

--- a/packages/bunadmin-source-payload/controllers/index.ts
+++ b/packages/bunadmin-source-payload/controllers/index.ts
@@ -1,0 +1,3 @@
+export { default as dataCtrl } from "./dataCtrl"
+export { default as editableCtrl } from "./editableCtrl"
+export { default as bulkDeleteCtrl } from "./bulkDeleteCtrl"

--- a/packages/bunadmin-source-payload/index.ts
+++ b/packages/bunadmin-source-payload/index.ts
@@ -1,0 +1,11 @@
+import { Query } from "@xbuilder/bunadmin"
+
+export interface DataCtrl extends EditableCtrl {
+  query: Query<any>
+}
+export interface EditableCtrl {
+  SchemaName: string
+}
+
+export * from "./services"
+export * from "./controllers"

--- a/packages/bunadmin-source-payload/package.json
+++ b/packages/bunadmin-source-payload/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@xbuilder/bunadmin-source-payload",
+  "version": "1.6.0-beta.0",
+  "license": "Apache-2.0",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "files": ["lib"],
+  "devDependencies": {
+    "@xbuilder/bunadmin": "^1.6.0-beta.0",
+    "prettier": "1.19.1",
+    "typescript": "4.8.3",
+    "vitest": "^1.6.0"
+  },
+  "scripts": {
+    "tsc:watch": "tsc -w",
+    "tsc:clean": "tsc --build --clean",
+    "tsc:build": "tsc",
+    "test": "vitest run"
+  }
+}

--- a/packages/bunadmin-source-payload/services/__tests__/filter.test.ts
+++ b/packages/bunadmin-source-payload/services/__tests__/filter.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest"
+import { payloadOp, buildParams } from "../filter"
+
+describe("payloadOp", () => {
+  it("maps operators to Payload where ops", () => {
+    expect(payloadOp("=")).toBe("equals")
+    expect(payloadOp("!=")).toBe("not_equals")
+    expect(payloadOp("_cs=")).toBe("contains")
+    expect(payloadOp(">")).toBe("greater_than")
+    expect(payloadOp(">=")).toBe("greater_than_equal")
+    expect(payloadOp("<=")).toBe("less_than_equal")
+  })
+})
+
+describe("buildParams", () => {
+  const f = (field: string, operator: string, value: any) =>
+    ({ column: { field }, operator, value } as any)
+
+  it("builds where + sort + 1-based page", () => {
+    const p = buildParams([f("status", "=", "Published")], {
+      searchWords: "hi", searchField: "name", page: 2, pageSize: 10,
+      orderBy: { field: "views" }, orderDirection: "desc"
+    })
+    expect(p["where[status][equals]"]).toBe("Published")
+    expect(p["where[name][contains]"]).toBe("hi")
+    expect(p.sort).toBe("-views")
+    expect(p.limit).toBe(10)
+    expect(p.page).toBe(3) // 0-based page 2 -> Payload page 3
+  })
+  it("skips empty filter values", () => {
+    expect(buildParams([f("a", "=", "")])["where[a][equals]"]).toBeUndefined()
+  })
+})

--- a/packages/bunadmin-source-payload/services/bulk.ts
+++ b/packages/bunadmin-source-payload/services/bulk.ts
@@ -1,0 +1,45 @@
+import { ENV, request, notice, BulkDeleteProps, BulkUpdateProps } from "@xbuilder/bunadmin"
+import { plHeaders, apiPath } from "./plConfig"
+
+async function batchNotice(t: any, n: number, ok: number, fail: number) {
+  await notice({
+    title: t(`Batch Request Completed`),
+    severity: ok === n ? "success" : fail === n ? "error" : "info",
+    content: `${n} items${ok ? `, ${ok} success` : ""}${fail ? `, ${fail} failure.` : ""}`
+  })
+}
+
+export async function bulkDeleteSer<T extends object>({
+  t, SchemaName, primaryKey = "id", data
+}: BulkDeleteProps & { data: T[] }) {
+  const headers = await plHeaders()
+  let ok = 0, fail = 0
+  const resList: any[] = []
+  for (const item of data) {
+    // @ts-ignore
+    const res = await request(apiPath(SchemaName, item[primaryKey]), {
+      prefix: ENV.MAIN_URL || ENV.AUTH_URL, method: "DELETE", headers
+    })
+    resList.push(res)
+    res && res.errors ? fail++ : ok++
+  }
+  await batchNotice(t, data.length, ok, fail)
+  return resList
+}
+
+export async function bulkUpdateSer<T>({ t, SchemaName, changes }: BulkUpdateProps<T>) {
+  const headers = await plHeaders()
+  const list = Object.values(changes)
+  let ok = 0, fail = 0
+  const resList: any[] = []
+  for (const c of list) {
+    const { oldData, newData } = c as any
+    const res = await request(apiPath(SchemaName, oldData.id), {
+      prefix: ENV.MAIN_URL || ENV.AUTH_URL, method: "PATCH", headers, data: newData
+    })
+    resList.push(res)
+    res && res.errors ? fail++ : ok++
+  }
+  await batchNotice(t, list.length, ok, fail)
+  return resList
+}

--- a/packages/bunadmin-source-payload/services/crud.ts
+++ b/packages/bunadmin-source-payload/services/crud.ts
@@ -1,0 +1,42 @@
+import { EditableCtrl, ENV, request, notice } from "@xbuilder/bunadmin"
+import { plHeaders, apiPath } from "./plConfig"
+
+interface Add<R> extends EditableCtrl { newData: R }
+interface Upd<R> extends EditableCtrl { newData: R; oldData: R; primaryKey?: string }
+interface Del<R> extends EditableCtrl { oldData: R; primaryKey?: string }
+
+export async function addSer({ t, SchemaName, newData }: Add<any>) {
+  const res = await request(apiPath(SchemaName), {
+    prefix: ENV.MAIN_URL || ENV.AUTH_URL, method: "POST", headers: await plHeaders(), data: newData
+  })
+  await notice(
+    res && res.errors
+      ? { title: t("Create Failed"), severity: "warning", content: res }
+      : { title: t("Created"), severity: "success" }
+  )
+  return res
+}
+
+export async function updateSer({ t, SchemaName, newData, oldData, primaryKey = "id" }: Upd<any>) {
+  const res = await request(apiPath(SchemaName, oldData[primaryKey]), {
+    prefix: ENV.MAIN_URL || ENV.AUTH_URL, method: "PATCH", headers: await plHeaders(), data: newData
+  })
+  await notice(
+    res && res.errors
+      ? { title: t("Save Failed"), severity: "warning", content: JSON.stringify({ errors: res, newData }) }
+      : { title: t("Changes Saved"), severity: "success" }
+  )
+  return res
+}
+
+export async function deleteSer({ t, SchemaName, oldData, primaryKey = "id" }: Del<any>) {
+  const res = await request(apiPath(SchemaName, oldData[primaryKey]), {
+    prefix: ENV.MAIN_URL || ENV.AUTH_URL, method: "DELETE", headers: await plHeaders()
+  })
+  await notice(
+    res && res.errors
+      ? { title: t("Delete Failed"), severity: "warning", content: JSON.stringify(oldData) }
+      : { title: t("Deleted"), severity: "success" }
+  )
+  return res
+}

--- a/packages/bunadmin-source-payload/services/filter.ts
+++ b/packages/bunadmin-source-payload/services/filter.ts
@@ -1,0 +1,63 @@
+/**
+ * Pure helpers mapping bunadmin table filters to Payload CMS query params.
+ * Payload uses `where[field][operator]=value` (equals/contains/greater_than/...),
+ * sort=`-field`, and page/limit (page is 1-based). Testable core.
+ */
+import { Filter } from "@xbuilder/bunadmin"
+
+/** Map one bunadmin operator to a Payload `where` operator key. */
+export function payloadOp(operator: string): string {
+  switch (operator) {
+    case "!=":
+      return "not_equals"
+    case ">":
+      return "greater_than"
+    case ">=":
+      return "greater_than_equal"
+    case "<":
+      return "less_than"
+    case "<=":
+      return "less_than_equal"
+    case "_ncs=":
+    case "_nc=":
+      return "not_equals"
+    case "=":
+      return "equals"
+    case "_cs=":
+    case "_c=":
+    default:
+      return "contains"
+  }
+}
+
+/** Build Payload query params from table filters + search + sort + pagination. */
+export function buildParams(
+  filters: Filter<any>[],
+  opts: {
+    searchWords?: string
+    searchField?: string
+    page?: number
+    pageSize?: number
+    orderBy?: any
+    orderDirection?: string
+  } = {}
+): Record<string, string | number> {
+  const { searchWords, searchField = "name", page = 0, pageSize = 20, orderBy, orderDirection } = opts
+  const params: Record<string, string | number> = {}
+
+  filters.forEach(({ column: { field }, operator, value }) => {
+    if (!field || value === undefined || value === "") return
+    params[`where[${field}][${payloadOp(operator as string)}]`] = value
+  })
+
+  if (searchWords) params[`where[${searchField}][contains]`] = searchWords
+
+  if (orderBy && orderBy.field) {
+    params.sort = `${orderDirection === "desc" ? "-" : ""}${orderBy.field}`
+  }
+
+  params.limit = pageSize
+  params.page = page + 1 // Payload pages are 1-based
+
+  return params
+}

--- a/packages/bunadmin-source-payload/services/index.ts
+++ b/packages/bunadmin-source-payload/services/index.ts
@@ -1,0 +1,4 @@
+export { addSer, updateSer, deleteSer } from "./crud"
+export { default as listSer } from "./listSer"
+export { bulkDeleteSer, bulkUpdateSer } from "./bulk"
+export * from "./filter"

--- a/packages/bunadmin-source-payload/services/listSer.ts
+++ b/packages/bunadmin-source-payload/services/listSer.ts
@@ -1,0 +1,39 @@
+/**
+ * Remote data controller (Payload CMS)
+ * GET /api/{collection}?where[..]&sort&limit&page -> { docs, totalDocs }
+ */
+import { ENV, request } from "@xbuilder/bunadmin"
+import { ListService } from "../types"
+import { buildParams } from "./filter"
+import { plHeaders, apiPath } from "./plConfig"
+
+export default async function listSer<RowData extends object>({
+  tableQuery,
+  path,
+  prefix,
+  searchField = "name"
+}: ListService<RowData>) {
+  const { search: searchWords, filters = [], orderBy, orderDirection, page, pageSize } = tableQuery
+
+  const params = buildParams(filters as any, {
+    searchWords,
+    searchField,
+    page,
+    pageSize,
+    orderBy,
+    orderDirection
+  })
+
+  const res = await request(apiPath(path), {
+    params,
+    prefix: prefix || ENV.MAIN_URL || ENV.AUTH_URL,
+    method: "GET",
+    headers: await plHeaders()
+  })
+
+  return {
+    data: (res && res.docs) || [],
+    totalCount: (res && res.totalDocs) || (res && res.docs ? res.docs.length : 0),
+    errors: res && res.errors ? res.errors : undefined
+  }
+}

--- a/packages/bunadmin-source-payload/services/plConfig.ts
+++ b/packages/bunadmin-source-payload/services/plConfig.ts
@@ -1,0 +1,18 @@
+import { storedToken } from "@xbuilder/bunadmin"
+
+/** Payload collection endpoint. */
+export function apiPath(collection: string, id?: string): string {
+  const base = `/api/${collection}`
+  return id !== undefined ? `${base}/${id}` : base
+}
+
+/** Payload auth header (JWT Bearer) from the stored token. */
+export async function plHeaders(
+  extra: Record<string, string> = {}
+): Promise<Record<string, string>> {
+  const token = await storedToken()
+  return {
+    ...(token ? { Authorization: `Bearer ${String(token).replace(/^Bearer /, "")}` } : {}),
+    ...extra
+  }
+}

--- a/packages/bunadmin-source-payload/tsconfig.json
+++ b/packages/bunadmin-source-payload/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig",
+  "compilerOptions": {
+    "rootDir": "./",
+    "outDir": "./lib",
+    "declaration": true,
+    "declarationDir": "./lib",
+    "baseUrl": "./"
+  },
+  "exclude": ["node_modules", "lib", "**/__tests__/**", "**/*.test.ts", "**/*.test.tsx"],
+  "include": ["*.ts", "*.tsx"]
+}

--- a/packages/bunadmin-source-payload/types.ts
+++ b/packages/bunadmin-source-payload/types.ts
@@ -1,0 +1,19 @@
+import { TFunction } from "i18next"
+import { Query, ListServiceRes } from "@xbuilder/bunadmin"
+
+export type DataCtrl<RowData extends object> = {
+  t?: TFunction
+  listService?: () => Promise<ListServiceRes>
+  tableQuery: ListService<RowData>["tableQuery"]
+  path?: ListService<RowData>["path"]
+  prefix?: ListService<RowData>["prefix"]
+  searchField?: ListService<RowData>["searchField"]
+}
+
+export type ListService<RowData extends object> = {
+  tableQuery: Query<RowData>
+  /** Payload collection slug */
+  path: string
+  prefix?: string
+  searchField?: "name" | string
+}

--- a/packages/bunadmin/vite.config.ts
+++ b/packages/bunadmin/vite.config.ts
@@ -106,6 +106,10 @@ export default defineConfig(({ mode }) => {
           replacement: r("../bunadmin-source-directus/index.ts")
         },
         {
+          find: /^@xbuilder\/bunadmin-source-payload$/,
+          replacement: r("../bunadmin-source-payload/index.ts")
+        },
+        {
           find: /^@xbuilder\/bunadmin-rich-text-editor$/,
           replacement: r("../bunadmin-rich-text-editor/index.tsx")
         },


### PR DESCRIPTION
Payload CMS REST connector mirroring the pattern: where[field][op] mapping (3 tests), listSer ({docs,totalDocs}), CRUD+bulk, controllers, vite alias. ~30k-star CMS. lerna 16 projects.