### PR TITLE
docs: feature docs + Directus/Payload connector pages + GraphQL-CMS note

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -7,31 +7,25 @@ export default defineConfig({
   lastUpdated: true,
   cleanUrls: true,
 
-  // READMEs double as GitHub-browsable files and reference source files
-  // (e.g. ./example-posts.tsx) + localhost URLs; don't fail the build on those.
   ignoreDeadLinks: [/^http:\/\/localhost/, /\.tsx?$/, /\.js$/],
 
-  // Existing README.md files (kept for GitHub browsing) serve as section indexes.
+  // README.md files (kept for GitHub browsing) serve as section indexes.
   rewrites: {
     "ai/README.md": "ai/index.md",
     "pocketbase/README.md": "pocketbase/index.md",
     "appwrite/README.md": "appwrite/index.md",
-    "supabase/README.md": "supabase/index.md"
+    "supabase/README.md": "supabase/index.md",
+    "directus/README.md": "directus/index.md",
+    "payload/README.md": "payload/index.md"
   },
 
   themeConfig: {
     outline: "deep",
     nav: [
       { text: "Guide", link: "/guide/getting-started" },
+      { text: "Features", link: "/features/tables" },
       { text: "AI Generation", link: "/ai/" },
-      {
-        text: "Connectors",
-        items: [
-          { text: "PocketBase", link: "/pocketbase/" },
-          { text: "Appwrite", link: "/appwrite/" },
-          { text: "Supabase", link: "/supabase/" }
-        ]
-      },
+      { text: "Connectors", link: "/connectors/" },
       { text: "GitHub", link: "https://github.com/Chris533/bunadmin" }
     ],
     sidebar: [
@@ -43,15 +37,27 @@ export default defineConfig({
         ]
       },
       {
-        text: "AI-Assisted Generation",
-        items: [{ text: "ai generate / theme / refine", link: "/ai/" }]
+        text: "Features",
+        items: [
+          { text: "Tables & CRUD", link: "/features/tables" },
+          { text: "Theming", link: "/features/theming" },
+          { text: "Layout & regions", link: "/features/layout" },
+          { text: "Plugins & auth", link: "/features/plugins" }
+        ]
       },
       {
-        text: "Backend Connectors",
+        text: "AI-Assisted Generation",
+        items: [{ text: "generate / theme / refine", link: "/ai/" }]
+      },
+      {
+        text: "Connectors",
         items: [
+          { text: "Overview", link: "/connectors/" },
           { text: "PocketBase", link: "/pocketbase/" },
           { text: "Appwrite", link: "/appwrite/" },
-          { text: "Supabase", link: "/supabase/" }
+          { text: "Supabase / Postgres", link: "/supabase/" },
+          { text: "Directus", link: "/directus/" },
+          { text: "Payload", link: "/payload/" }
         ]
       },
       {

--- a/docs/connectors/index.md
+++ b/docs/connectors/index.md
@@ -1,0 +1,46 @@
+# Connectors
+
+A connector is a **data-source plugin** that maps bunadmin's table query
+(filter / sort / search / pagination / CRUD / bulk) to a specific backend's API.
+Swap the connector import to change backends — the table UI is unchanged.
+
+## Available connectors
+
+| Backend | Package | API |
+| --- | --- | --- |
+| [PocketBase](/pocketbase/) | `@xbuilder/bunadmin-source-pocketbase` | REST `/api/collections` |
+| [Appwrite](/appwrite/) | `@xbuilder/bunadmin-source-appwrite` | Databases REST |
+| [Supabase / Postgres](/supabase/) | `@xbuilder/bunadmin-source-supabase` | PostgREST |
+| [Directus](/directus/) | `@xbuilder/bunadmin-source-directus` | REST `/items` |
+| [Payload](/payload/) | `@xbuilder/bunadmin-source-payload` | REST `/api` |
+| Strapi | `@xbuilder/bunadmin-source-strapi` | REST |
+| GraphQL | `@xbuilder/bunadmin-source-graphql` | any GraphQL API |
+
+## Common shape
+
+Every connector exports `dataCtrl`, `editableCtrl`, and `bulkDeleteCtrl`:
+
+```tsx
+import { dataCtrl, editableCtrl, bulkDeleteCtrl } from "@xbuilder/bunadmin-source-<backend>"
+
+<Table
+  data={query => dataCtrl({ t, tableQuery: query, path: "<collection-or-table>" })}
+  editable={editableCtrl({ t, SchemaName: "<collection-or-table>" })}
+  actions={[bulkDeleteCtrl({ t, SchemaName, tableRef })]}
+/>
+```
+
+## GraphQL-native CMSes (Keystone, Hasura, …)
+
+CMSes and backends that expose a **GraphQL API** — including **KeystoneJS**,
+**Hasura**, and GraphQL-mode Strapi — are supported through the
+**`@xbuilder/bunadmin-source-graphql`** connector rather than a dedicated package.
+Point it at the GraphQL endpoint and map your query/mutations; no separate
+connector is needed.
+
+## Writing a connector
+
+Mirror an existing `source-*` package: a pure `filter` module (operators → the
+backend's query language, unit-tested), `listSer` + CRUD/bulk services, and the
+three controllers. Add a `vite.config.ts` alias to the `.ts` source (so Vite gets
+clean ESM rather than the CJS `lib/`).

--- a/docs/directus/README.md
+++ b/docs/directus/README.md
@@ -1,0 +1,46 @@
+# Directus Connector
+
+`@xbuilder/bunadmin-source-directus` — use [Directus](https://directus.io) as the
+data source (list / filter / sort / CRUD / bulk via the Items REST API).
+
+## Install
+
+```bash
+yarn add @xbuilder/bunadmin-source-directus
+```
+
+## Configure (`.env`)
+
+```
+VITE_MAIN_URL=https://your-directus-instance.example.com
+```
+
+Auth uses the bunadmin stored token as `Authorization: Bearer …`.
+
+## Use in a schema
+
+```tsx
+import { dataCtrl, editableCtrl, bulkDeleteCtrl } from "@xbuilder/bunadmin-source-directus"
+
+<Table
+  columns={columns}
+  data={query => dataCtrl({ t, tableQuery: query, path: "posts" })}  // collection
+  editable={editableCtrl({ t, SchemaName: "posts" })}
+  actions={[bulkDeleteCtrl({ t, SchemaName, tableRef })]}
+/>
+```
+
+## Filter mapping
+
+bunadmin operators → Directus `filter[field][_op]`:
+
+| Table operator | Directus |
+| --- | --- |
+| `=` `!=` | `_eq` `_neq` |
+| contains / not contains | `_contains` / `_ncontains` |
+| `>` `>=` `<` `<=` | `_gt` `_gte` `_lt` `_lte` |
+| sort | `sort=-field` |
+| pagination | `limit` + `offset` |
+
+Total count comes from `meta=filter_count`. Endpoints: `/items/{collection}` and
+`/items/{collection}/{id}`.

--- a/docs/features/layout.md
+++ b/docs/features/layout.md
@@ -1,0 +1,40 @@
+# Layout & Regions
+
+The admin shell (`DefaultLayout`) is configured through a **layout registry** — a
+constrained set of pre-designed options, so any combination looks professional by
+construction (and the AI can compose it).
+
+## LayoutConfig
+
+`src/utils/themes/layouts.ts` defines `LayoutConfig` + the `LAYOUT_A` baseline:
+
+| Option | Values | Effect |
+| --- | --- | --- |
+| `statBand` | `boolean` | KPI card band above content |
+| `sidebarFooter` | `none` / `upgrade` / `stats` | left-menu footer slot |
+| `buttons` | `icon` / `labeled` | action button style |
+| `density` | `comfortable` / `compact` | table row density |
+
+Pass a config (and optional region data) to `DefaultLayout`:
+
+```tsx
+<DefaultLayout
+  layout={{ ...LAYOUT_A, statBand: true, sidebarFooter: "upgrade" }}
+  stats={[{ label: "Total Posts", value: "128", delta: "+12%", trend: "up", spark: [4,6,5,8,9] }]}
+  sidebarUpgrade={{ title: "Pro", description: "Unlock more", cta: "Upgrade" }}
+>
+  {children}
+</DefaultLayout>
+```
+
+## Regions
+
+- **StatBand** — KPI cards with optional sparklines; renders only when
+  `layout.statBand` and `stats` are provided (scoped to list views by default).
+- **SidebarFooter** — renders an `upgrade` card or a `stats` overview per
+  `layout.sidebarFooter`.
+
+`resolveLayout()` validates a (partial) config against the registry — the same
+constrained-contract pattern the AI uses, so future `ai`-driven layout selection
+is always valid. New layouts can be added to the registry without touching the
+renderer.

--- a/docs/features/plugins.md
+++ b/docs/features/plugins.md
@@ -1,0 +1,44 @@
+# Plugins & Auth
+
+bunadmin is plugin-driven: schemas, data sources, auth, and uploads are all
+plugins, discovered by the generator and loaded dynamically.
+
+## Plugin types
+
+| Kind | Example | Role |
+| --- | --- | --- |
+| **Schema/feature** | `bunadmin-plugin-[team]-[group]` | menus + schemas (tables) |
+| **Data source** | `bunadmin-source-*` | list/CRUD against a backend ([Connectors](/connectors/)) |
+| **Auth** | `bunadmin-auth-*` | sign-in + token handling |
+| **Upload** | `bunadmin-upload-*` | file storage |
+
+Create one with the CLI:
+
+```bash
+bunadmin plugin myteam-blog     # in plugins/
+bunadmin schema post            # in the plugin dir
+```
+
+The generator scans your `dependencies` + `devDependencies` for bunadmin plugins
+and emits `.bunadmin/dynamic/` (menus, schema data, an import map) consumed at
+runtime via the plugin registry (`import.meta.glob`).
+
+## Auth
+
+Set the active auth plugin in `.env`:
+
+```
+VITE_AUTH_PLUGIN=@xbuilder/bunadmin-auth-pocketbase
+VITE_AUTH_URL=http://127.0.0.1:8090
+```
+
+Available: `auth-local`, `auth-pocketbase`, `auth-strapi`, `auth-buncms`. The
+sign-in component is resolved dynamically from the configured plugin (no hardcoded
+import) — switching auth backends is a `.env` change. After sign-in the token is
+stored (IndexedDB) and read by connectors via `storedToken()`.
+
+## Backend-agnostic by design
+
+Because data access goes through a connector and auth through a plugin, the same
+schema/table UI runs on PocketBase, Appwrite, Supabase, Strapi, Directus, Payload,
+or GraphQL — swap the plugin, keep the UI.

--- a/docs/features/tables.md
+++ b/docs/features/tables.md
@@ -1,0 +1,61 @@
+# Tables & CRUD
+
+The `Table` component is the core of a bunadmin admin: a data grid with filtering,
+sorting, search, pagination, inline editing, bulk actions, grouping, and row
+detail — backed by any [connector](/connectors/).
+
+## Minimal example
+
+```tsx
+import { Table, TableHead, tableIcons, TableDefaultProps as DP, useTranslation } from "@xbuilder/bunadmin"
+import { dataCtrl, editableCtrl, bulkDeleteCtrl } from "@xbuilder/bunadmin-source-pocketbase"
+
+export default function Posts() {
+  const { t } = useTranslation("table")
+  const SchemaName = "posts"
+  const columns = [
+    { title: t("Id"), field: "id", editable: "never" },
+    { title: t("Name"), field: "name" },
+    { title: t("Status"), field: "status", lookup: { Draft: "Draft", Published: "Published" } },
+    { title: t("Views"), field: "views", type: "numeric" }
+  ]
+  return (
+    <Table
+      columns={columns}
+      data={query => dataCtrl({ t, tableQuery: query, path: SchemaName })}
+      editable={editableCtrl({ t, SchemaName })}
+      actions={[bulkDeleteCtrl({ t, SchemaName, tableRef })]}
+      options={{ ...DP.options, filtering: true }}
+    />
+  )
+}
+```
+
+## Columns
+
+| Field | Purpose |
+| --- | --- |
+| `title` | header label (wrap in `t()` for i18n) |
+| `field` | data key |
+| `type` | `numeric` / `boolean` / `date` / `datetime` |
+| `lookup` | `{ value: label }` → renders a **status pill** |
+| `editable: "never"` | read-only cell |
+| `render` | custom cell renderer |
+
+## Filtering & search
+
+Set `filtering: true` in `options` to show a per-column filter row. Operators (eq,
+contains, not-contains, `> >= < <=`) are translated to each backend's query
+language by the connector. The toolbar search box maps to the connector's
+`searchField` (default `name`).
+
+## Inline CRUD & bulk
+
+`editable={editableCtrl(...)}` wires inline add/edit/delete; `onBulkUpdate`
+handles multi-row edits. `bulkDeleteCtrl` adds a "delete selected" toolbar action.
+All map to the connector's CRUD services.
+
+## Data sources
+
+The `data` and `editable` props come from a connector — swap the import to change
+backends with no UI change. See [Connectors](/connectors/).

--- a/docs/features/theming.md
+++ b/docs/features/theming.md
@@ -1,0 +1,46 @@
+# Theming
+
+bunadmin's look is driven by **design tokens** — CSS variables for color, surface,
+border, radius, and a gradient brand accent. Themes are **named presets** (each
+with light + dark), and the AI can compose them ([`ai theme`](/ai/)).
+
+## Tokens
+
+Defined in `src/utils/themes/tokens.ts` and mirrored as CSS variables
+(`:root` = light, `.dark` = dark), mapped into Tailwind utilities:
+
+| Token | Utility | Meaning |
+| --- | --- | --- |
+| `--bn-bg` | `bg-content-bg` | app background |
+| `--bn-surface` | `bg-content-box` | cards / content |
+| `--bn-sidebar` | `bg-sidebar` | left menu / topbar |
+| `--bn-foreground` | `text-foreground` | primary text |
+| `--bn-muted` | `text-icon-muted` | muted text/icons |
+| `--bn-border` | `border-bn-border` | hairlines |
+| `--bn-primary` | `text/bg-primary` | brand accent |
+| `--bn-primary-gradient` | `bg-primary-gradient` | gradient buttons/logo |
+| `--bn-radius` | `rounded-bn` | corner radius |
+
+## Presets & dark mode
+
+Two built-in presets: `classic` (flat) and `modern` (default — softer surfaces,
+indigo→violet gradient, glow-friendly dark). Switch at runtime:
+
+```ts
+import { applyPreset } from "@xbuilder/bunadmin"
+applyPreset("modern", "dark")              // preset + mode
+applyPreset("modern", "light", { primary: "#7c3aed", radius: "16px" }) // + overrides
+```
+
+`applyPreset` writes the `--bn-*` variables and toggles the `.dark` class. The
+TopBar theme toggle and `ai theme` both call it.
+
+## AI theming
+
+```bash
+bunadmin ai theme "dark mode with a purple accent and rounded corners"
+```
+
+Emits a validated `{ preset, mode, overrides }` config for `applyPreset` — the AI
+can only choose known presets/modes and override known tokens with valid CSS, so
+the result is always on-brand. See [AI generation](/ai/).

--- a/docs/payload/README.md
+++ b/docs/payload/README.md
@@ -1,0 +1,46 @@
+# Payload Connector
+
+`@xbuilder/bunadmin-source-payload` — use [Payload CMS](https://payloadcms.com) as
+the data source (list / filter / sort / CRUD / bulk via the REST API).
+
+## Install
+
+```bash
+yarn add @xbuilder/bunadmin-source-payload
+```
+
+## Configure (`.env`)
+
+```
+VITE_MAIN_URL=https://your-payload-app.example.com
+```
+
+Auth uses the bunadmin stored token as `Authorization: Bearer …`.
+
+## Use in a schema
+
+```tsx
+import { dataCtrl, editableCtrl, bulkDeleteCtrl } from "@xbuilder/bunadmin-source-payload"
+
+<Table
+  columns={columns}
+  data={query => dataCtrl({ t, tableQuery: query, path: "posts" })}  // collection slug
+  editable={editableCtrl({ t, SchemaName: "posts" })}
+  actions={[bulkDeleteCtrl({ t, SchemaName, tableRef })]}
+/>
+```
+
+## Filter mapping
+
+bunadmin operators → Payload `where[field][operator]`:
+
+| Table operator | Payload |
+| --- | --- |
+| `=` `!=` | `equals` `not_equals` |
+| contains | `contains` |
+| `>` `>=` `<` `<=` | `greater_than` `greater_than_equal` `less_than` `less_than_equal` |
+| sort | `sort=-field` |
+| pagination | `limit` + `page` (1-based) |
+
+Responses are `{ docs, totalDocs }`. Endpoints: `/api/{collection}` and
+`/api/{collection}/{id}`.


### PR DESCRIPTION
Expands the docs site: Features (tables/theming/layout/plugins), Connectors overview (7 connectors + GraphQL-native-CMS note for Keystone/Hasura), Directus + Payload setup pages. VitePress build clean.