### PR TITLE
feat: Turso/libSQL SQLite connector

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -16,7 +16,8 @@ export default defineConfig({
     "appwrite/README.md": "appwrite/index.md",
     "supabase/README.md": "supabase/index.md",
     "directus/README.md": "directus/index.md",
-    "payload/README.md": "payload/index.md"
+    "payload/README.md": "payload/index.md",
+    "turso/README.md": "turso/index.md"
   },
 
   themeConfig: {
@@ -57,7 +58,8 @@ export default defineConfig({
           { text: "Appwrite", link: "/appwrite/" },
           { text: "Supabase / Postgres", link: "/supabase/" },
           { text: "Directus", link: "/directus/" },
-          { text: "Payload", link: "/payload/" }
+          { text: "Payload", link: "/payload/" },
+          { text: "Turso / libSQL", link: "/turso/" }
         ]
       },
       {

--- a/docs/connectors/index.md
+++ b/docs/connectors/index.md
@@ -13,6 +13,7 @@ Swap the connector import to change backends — the table UI is unchanged.
 | [Supabase / Postgres](/supabase/) | `@xbuilder/bunadmin-source-supabase` | PostgREST |
 | [Directus](/directus/) | `@xbuilder/bunadmin-source-directus` | REST `/items` |
 | [Payload](/payload/) | `@xbuilder/bunadmin-source-payload` | REST `/api` |
+| [Turso / libSQL](/turso/) | `@xbuilder/bunadmin-source-turso` | SQLite over HTTP (SQL) |
 | Strapi | `@xbuilder/bunadmin-source-strapi` | REST |
 | GraphQL | `@xbuilder/bunadmin-source-graphql` | any GraphQL API |
 

--- a/docs/turso/README.md
+++ b/docs/turso/README.md
@@ -1,0 +1,56 @@
+# Turso / libSQL Connector
+
+`@xbuilder/bunadmin-source-turso` — use [Turso](https://turso.tech) / libSQL
+(SQLite over HTTP) as the data source, with **full CRUD via SQL**.
+
+> SQLite has no native HTTP API; this connector targets the **libSQL HTTP
+> protocol** (`POST /v2/pipeline`), which Turso and self-hosted `sqld` expose.
+
+## Install
+
+```bash
+yarn add @xbuilder/bunadmin-source-turso
+```
+
+## Configure (`.env`)
+
+```
+VITE_MAIN_URL=https://<your-db>.turso.io
+```
+
+Auth uses the bunadmin stored token (a Turso DB auth token) as
+`Authorization: Bearer …`.
+
+## Use in a schema
+
+```tsx
+import { dataCtrl, editableCtrl, bulkDeleteCtrl } from "@xbuilder/bunadmin-source-turso"
+
+<Table
+  columns={columns}
+  data={query => dataCtrl({ t, tableQuery: query, path: "posts" })}  // table name
+  editable={editableCtrl({ t, SchemaName: "posts" })}
+  actions={[bulkDeleteCtrl({ t, SchemaName, tableRef })]}
+/>
+```
+
+## How it works
+
+The connector builds **parameterized SQL** and executes it over the libSQL HTTP
+pipeline:
+
+| Table action | SQL |
+| --- | --- |
+| list | `SELECT * FROM t WHERE … ORDER BY … LIMIT ? OFFSET ?` |
+| count | `SELECT COUNT(*) … ` (for total) |
+| filter `=` `!=` `> >= < <=` | bound `?` params |
+| contains / not contains | `LIKE ?` / `NOT LIKE ?` with `%value%` |
+| create / update / delete | `INSERT` / `UPDATE … WHERE id=?` / `DELETE … WHERE id=?` |
+
+::: tip Security
+Values are **always bound parameters** (never string-interpolated). Table/column
+identifiers are validated against `^[A-Za-z_][A-Za-z0-9_]*$` and quoted, so a
+malicious field name is rejected rather than injected.
+:::
+
+Primary key defaults to `id` (override via `primaryKey`).

--- a/packages/bunadmin-source-turso/controllers/bulkDeleteCtrl.tsx
+++ b/packages/bunadmin-source-turso/controllers/bulkDeleteCtrl.tsx
@@ -1,0 +1,19 @@
+import React from "react"
+import { Action, BulkDeleteProps } from "@xbuilder/bunadmin"
+// @ts-ignore
+import { EvaIcon } from "@xbuilder/bunadmin"
+import { bulkDeleteSer } from "../services/bulk"
+
+export default function bulkDeleteCtrl<RowData extends object>(props: BulkDeleteProps): Action<RowData> {
+  const { t, SchemaName, tableRef, primaryKey } = props
+  return {
+    tooltip: t("Delete all selected rows"),
+    icon: () => <EvaIcon name="trash-2-outline" size="large" fill="gray" />,
+    onClick: async (_e, data) => {
+      data = data as RowData[]
+      if (!data.length) return
+      await bulkDeleteSer({ data, t, SchemaName, tableRef, primaryKey })
+      tableRef.current && tableRef.current.onQueryChange()
+    }
+  }
+}

--- a/packages/bunadmin-source-turso/controllers/dataCtrl.ts
+++ b/packages/bunadmin-source-turso/controllers/dataCtrl.ts
@@ -1,0 +1,28 @@
+import listSer from "../services/listSer"
+import { DataCtrl, ListService } from "../types"
+import { notice, QueryResult } from "@xbuilder/bunadmin"
+
+export default async function dataCtrl<RowData extends object>({
+  t,
+  listService,
+  ...sharedProps
+}: DataCtrl<RowData>): Promise<QueryResult<RowData>> {
+  const { path, tableQuery } = sharedProps
+  let data: any, errors, totalCount = 0
+
+  if (listService) {
+    const r = await listService(); data = r.data; errors = r.errors; totalCount = r.totalCount
+  } else if (path) {
+    const r = await listSer({ path, ...sharedProps } as ListService<RowData>)
+    data = r.data; errors = r.errors; totalCount = r.totalCount
+  } else {
+    await notice({ title: t ? t("One of the listService or path is required") : "path required", severity: "error" })
+    return { page: tableQuery.page, data: [], totalCount: 0 }
+  }
+
+  if (errors) {
+    await notice({ title: t ? t("Request Failed") : "Request Failed", severity: "error", content: JSON.stringify(errors) })
+    return { page: tableQuery.page, data: [], totalCount: 0 }
+  }
+  return { page: tableQuery.page, data, totalCount }
+}

--- a/packages/bunadmin-source-turso/controllers/editableCtrl.ts
+++ b/packages/bunadmin-source-turso/controllers/editableCtrl.ts
@@ -1,0 +1,12 @@
+import { EditableCtrl, EditableDataType } from "@xbuilder/bunadmin"
+import { addSer, updateSer, deleteSer } from "../services/crud"
+import { bulkUpdateSer } from "../services/bulk"
+
+export default function editableCtrl({ t, SchemaName, disableAdd }: EditableCtrl): EditableDataType<any> {
+  return {
+    onRowAdd: disableAdd ? undefined : async newData => await addSer({ t, SchemaName, newData }),
+    onRowUpdate: async (newData, oldData) => await updateSer({ t, SchemaName, newData, oldData }),
+    onBulkUpdate: async changes => await bulkUpdateSer({ t, SchemaName, changes }),
+    onRowDelete: async oldData => await deleteSer({ t, SchemaName, oldData })
+  }
+}

--- a/packages/bunadmin-source-turso/controllers/index.ts
+++ b/packages/bunadmin-source-turso/controllers/index.ts
@@ -1,0 +1,3 @@
+export { default as dataCtrl } from "./dataCtrl"
+export { default as editableCtrl } from "./editableCtrl"
+export { default as bulkDeleteCtrl } from "./bulkDeleteCtrl"

--- a/packages/bunadmin-source-turso/index.ts
+++ b/packages/bunadmin-source-turso/index.ts
@@ -1,0 +1,11 @@
+import { Query } from "@xbuilder/bunadmin"
+
+export interface DataCtrl extends EditableCtrl {
+  query: Query<any>
+}
+export interface EditableCtrl {
+  SchemaName: string
+}
+
+export * from "./services"
+export * from "./controllers"

--- a/packages/bunadmin-source-turso/package.json
+++ b/packages/bunadmin-source-turso/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@xbuilder/bunadmin-source-turso",
+  "version": "1.6.0-beta.0",
+  "license": "Apache-2.0",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "files": ["lib"],
+  "devDependencies": {
+    "@xbuilder/bunadmin": "^1.6.0-beta.0",
+    "prettier": "1.19.1",
+    "typescript": "4.8.3",
+    "vitest": "^1.6.0"
+  },
+  "scripts": {
+    "tsc:watch": "tsc -w",
+    "tsc:clean": "tsc --build --clean",
+    "tsc:build": "tsc",
+    "test": "vitest run"
+  }
+}

--- a/packages/bunadmin-source-turso/services/__tests__/sql.test.ts
+++ b/packages/bunadmin-source-turso/services/__tests__/sql.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest"
+import {
+  ident,
+  buildWhere,
+  buildSelect,
+  buildCount,
+  buildInsert,
+  buildUpdate,
+  buildDelete
+} from "../sql"
+
+const f = (field: string, operator: string, value: any) =>
+  ({ column: { field }, operator, value } as any)
+
+describe("ident (injection guard)", () => {
+  it("quotes valid identifiers", () => {
+    expect(ident("status")).toBe('"status"')
+  })
+  it("rejects unsafe identifiers", () => {
+    expect(() => ident("a; DROP TABLE users")).toThrow()
+    expect(() => ident('a" OR 1=1')).toThrow()
+  })
+})
+
+describe("buildWhere", () => {
+  it("binds values as params, never interpolates", () => {
+    const { clause, args } = buildWhere([f("status", "=", "Published")])
+    expect(clause).toBe(' WHERE "status" = ?')
+    expect(args).toEqual(["Published"])
+  })
+  it("maps contains -> LIKE %v% and not-contains -> NOT LIKE", () => {
+    expect(buildWhere([f("name", "_cs=", "ab")]).args).toEqual(["%ab%"])
+    expect(buildWhere([f("name", "_ncs=", "ab")]).clause).toContain("NOT LIKE")
+  })
+  it("appends search on the search field", () => {
+    const { clause, args } = buildWhere([], "hi", "name")
+    expect(clause).toBe(' WHERE "name" LIKE ?')
+    expect(args).toEqual(["%hi%"])
+  })
+  it("skips empty values", () => {
+    expect(buildWhere([f("a", "=", "")]).clause).toBe("")
+  })
+})
+
+describe("buildSelect / buildCount", () => {
+  const q = {
+    search: "",
+    filters: [f("status", "=", "Published")],
+    orderBy: { field: "views" },
+    orderDirection: "desc",
+    page: 2,
+    pageSize: 10
+  }
+  it("select adds ORDER BY + LIMIT/OFFSET as params", () => {
+    const s = buildSelect("posts", q)
+    expect(s.sql).toBe(
+      'SELECT * FROM "posts" WHERE "status" = ? ORDER BY "views" DESC LIMIT ? OFFSET ?'
+    )
+    expect(s.args).toEqual(["Published", 10, 20])
+  })
+  it("count uses same filters, no limit", () => {
+    const c = buildCount("posts", q)
+    expect(c.sql).toBe('SELECT COUNT(*) AS c FROM "posts" WHERE "status" = ?')
+    expect(c.args).toEqual(["Published"])
+  })
+})
+
+describe("insert / update / delete", () => {
+  it("insert binds all columns", () => {
+    const s = buildInsert("posts", { name: "x", views: 3 })
+    expect(s.sql).toBe('INSERT INTO "posts" ("name", "views") VALUES (?, ?)')
+    expect(s.args).toEqual(["x", 3])
+  })
+  it("update excludes pk from SET, binds pk last", () => {
+    const s = buildUpdate("posts", { id: 9, name: "y" }, "id", 9)
+    expect(s.sql).toBe('UPDATE "posts" SET "name" = ? WHERE "id" = ?')
+    expect(s.args).toEqual(["y", 9])
+  })
+  it("delete by pk", () => {
+    const s = buildDelete("posts", "id", 9)
+    expect(s.sql).toBe('DELETE FROM "posts" WHERE "id" = ?')
+    expect(s.args).toEqual([9])
+  })
+})

--- a/packages/bunadmin-source-turso/services/bulk.ts
+++ b/packages/bunadmin-source-turso/services/bulk.ts
@@ -1,0 +1,40 @@
+import { notice, BulkDeleteProps, BulkUpdateProps } from "@xbuilder/bunadmin"
+import { buildDelete, buildUpdate } from "./sql"
+import { execute } from "./client"
+
+async function batchNotice(t: any, n: number, ok: number, fail: number) {
+  await notice({
+    title: t(`Batch Request Completed`),
+    severity: ok === n ? "success" : fail === n ? "error" : "info",
+    content: `${n} items${ok ? `, ${ok} success` : ""}${fail ? `, ${fail} failure.` : ""}`
+  })
+}
+
+export async function bulkDeleteSer<T extends object>({
+  t, SchemaName, primaryKey = "id", data
+}: BulkDeleteProps & { data: T[] }) {
+  let ok = 0, fail = 0
+  const resList: any[] = []
+  for (const item of data) {
+    // @ts-ignore
+    const res = await execute(buildDelete(SchemaName, primaryKey, item[primaryKey]))
+    resList.push(res)
+    res.error ? fail++ : ok++
+  }
+  await batchNotice(t, data.length, ok, fail)
+  return resList
+}
+
+export async function bulkUpdateSer<T>({ t, SchemaName, changes }: BulkUpdateProps<T>) {
+  const list = Object.values(changes)
+  let ok = 0, fail = 0
+  const resList: any[] = []
+  for (const c of list) {
+    const { oldData, newData } = c as any
+    const res = await execute(buildUpdate(SchemaName, newData, "id", oldData.id))
+    resList.push(res)
+    res.error ? fail++ : ok++
+  }
+  await batchNotice(t, list.length, ok, fail)
+  return resList
+}

--- a/packages/bunadmin-source-turso/services/client.ts
+++ b/packages/bunadmin-source-turso/services/client.ts
@@ -1,0 +1,58 @@
+/**
+ * libSQL/Turso HTTP client. Executes a statement via POST /v2/pipeline and
+ * decodes the {cols, rows} response into row objects.
+ * https://docs.turso.tech/sdk/http/reference
+ */
+import { ENV, request, storedToken } from "@xbuilder/bunadmin"
+import { Stmt } from "./sql"
+
+/** Encode a JS value into a libSQL arg ({ type, value }). */
+function encodeArg(v: any): { type: string; value: string } {
+  if (v === null || v === undefined) return { type: "null", value: "" } as any
+  if (typeof v === "number")
+    return Number.isInteger(v)
+      ? { type: "integer", value: String(v) }
+      : { type: "float", value: String(v) }
+  if (typeof v === "boolean") return { type: "integer", value: v ? "1" : "0" }
+  return { type: "text", value: String(v) }
+}
+
+/** Decode a libSQL result into { rows: object[], affectedRows }. */
+function decode(result: any): { rows: any[]; affectedRows: number } {
+  if (!result) return { rows: [], affectedRows: 0 }
+  const cols = (result.cols || []).map((c: any) => c.name)
+  const rows = (result.rows || []).map((row: any[]) => {
+    const o: Record<string, any> = {}
+    row.forEach((cell: any, i: number) => {
+      // cells are { type, value } | scalar depending on protocol version
+      o[cols[i]] = cell && typeof cell === "object" && "value" in cell ? cell.value : cell
+    })
+    return o
+  })
+  return { rows, affectedRows: result.affected_row_count || 0 }
+}
+
+/** Execute one SQL statement against the libSQL HTTP endpoint. */
+export async function execute(
+  stmt: Stmt,
+  prefix?: string
+): Promise<{ rows: any[]; affectedRows: number; error?: any }> {
+  const token = await storedToken()
+  const res = await request(`/v2/pipeline`, {
+    prefix: prefix || ENV.MAIN_URL || ENV.AUTH_URL,
+    method: "POST",
+    headers: token ? { Authorization: `Bearer ${String(token).replace(/^Bearer /, "")}` } : {},
+    data: {
+      requests: [
+        { type: "execute", stmt: { sql: stmt.sql, args: stmt.args.map(encodeArg) } },
+        { type: "close" }
+      ]
+    }
+  })
+
+  const first = res && res.results && res.results[0]
+  if (!first || first.type === "error" || (res && res.error)) {
+    return { rows: [], affectedRows: 0, error: (first && first.error) || res }
+  }
+  return decode(first.response && first.response.result)
+}

--- a/packages/bunadmin-source-turso/services/crud.ts
+++ b/packages/bunadmin-source-turso/services/crud.ts
@@ -1,0 +1,37 @@
+import { EditableCtrl, notice } from "@xbuilder/bunadmin"
+import { buildInsert, buildUpdate, buildDelete } from "./sql"
+import { execute } from "./client"
+
+interface Add<R> extends EditableCtrl { newData: R }
+interface Upd<R> extends EditableCtrl { newData: R; oldData: R; primaryKey?: string }
+interface Del<R> extends EditableCtrl { oldData: R; primaryKey?: string }
+
+export async function addSer({ t, SchemaName, newData }: Add<any>) {
+  const res = await execute(buildInsert(SchemaName, newData))
+  await notice(
+    res.error
+      ? { title: t("Create Failed"), severity: "warning", content: res.error }
+      : { title: t("Created"), severity: "success" }
+  )
+  return res
+}
+
+export async function updateSer({ t, SchemaName, newData, oldData, primaryKey = "id" }: Upd<any>) {
+  const res = await execute(buildUpdate(SchemaName, newData, primaryKey, oldData[primaryKey]))
+  await notice(
+    res.error
+      ? { title: t("Save Failed"), severity: "warning", content: JSON.stringify({ errors: res.error, newData }) }
+      : { title: t("Changes Saved"), severity: "success" }
+  )
+  return res
+}
+
+export async function deleteSer({ t, SchemaName, oldData, primaryKey = "id" }: Del<any>) {
+  const res = await execute(buildDelete(SchemaName, primaryKey, oldData[primaryKey]))
+  await notice(
+    res.error
+      ? { title: t("Delete Failed"), severity: "warning", content: JSON.stringify(oldData) }
+      : { title: t("Deleted"), severity: "success" }
+  )
+  return res
+}

--- a/packages/bunadmin-source-turso/services/index.ts
+++ b/packages/bunadmin-source-turso/services/index.ts
@@ -1,0 +1,5 @@
+export { addSer, updateSer, deleteSer } from "./crud"
+export { default as listSer } from "./listSer"
+export { bulkDeleteSer, bulkUpdateSer } from "./bulk"
+export * from "./sql"
+export { execute } from "./client"

--- a/packages/bunadmin-source-turso/services/listSer.ts
+++ b/packages/bunadmin-source-turso/services/listSer.ts
@@ -1,0 +1,25 @@
+/**
+ * Remote data controller (libSQL/Turso) — SELECT + COUNT via /v2/pipeline.
+ */
+import { ListService } from "../types"
+import { buildSelect, buildCount } from "./sql"
+import { execute } from "./client"
+
+export default async function listSer<RowData extends object>({
+  tableQuery,
+  path,
+  prefix,
+  searchField = "name"
+}: ListService<RowData>) {
+  const countRes = await execute(buildCount(path, tableQuery, searchField), prefix)
+  const listRes = await execute(buildSelect(path, tableQuery, searchField), prefix)
+
+  const errors = listRes.error || countRes.error
+  const total = countRes.rows[0] ? Number(countRes.rows[0].c) : listRes.rows.length
+
+  return {
+    data: listRes.rows || [],
+    totalCount: errors ? 0 : total,
+    errors
+  }
+}

--- a/packages/bunadmin-source-turso/services/sql.ts
+++ b/packages/bunadmin-source-turso/services/sql.ts
@@ -1,0 +1,118 @@
+/**
+ * Pure SQL builders for libSQL/Turso. VALUES are always bound parameters (`?`)
+ * — never string-interpolated — so this is injection-safe. Identifiers
+ * (table/column names) can't be parameters, so they're validated against a
+ * strict pattern and quoted. Testable core of the connector.
+ */
+import { Filter } from "@xbuilder/bunadmin"
+
+/** A SQL statement with bound args, in libSQL stmt shape. */
+export interface Stmt {
+  sql: string
+  args: any[]
+}
+
+const IDENT = /^[A-Za-z_][A-Za-z0-9_]*$/
+
+/** Validate + quote a SQL identifier (table/column). Throws on anything unsafe. */
+export function ident(name: string): string {
+  if (!IDENT.test(name)) throw new Error(`unsafe SQL identifier: ${JSON.stringify(name)}`)
+  return `"${name}"`
+}
+
+/** Map a bunadmin operator to a SQL operator + value transform (for LIKE). */
+function sqlOp(operator: string, value: any): { op: string; val: any } {
+  switch (operator) {
+    case "!=":
+      return { op: "!=", val: value }
+    case ">":
+      return { op: ">", val: value }
+    case ">=":
+      return { op: ">=", val: value }
+    case "<":
+      return { op: "<", val: value }
+    case "<=":
+      return { op: "<=", val: value }
+    case "_ncs=":
+    case "_nc=":
+      return { op: "NOT LIKE", val: `%${value}%` }
+    case "=":
+      return { op: "=", val: value }
+    case "_cs=":
+    case "_c=":
+    default:
+      return { op: "LIKE", val: `%${value}%` }
+  }
+}
+
+/** Build the WHERE clause (+ args) from table filters + optional search. */
+export function buildWhere(
+  filters: Filter<any>[],
+  searchWords?: string,
+  searchField = "name"
+): { clause: string; args: any[] } {
+  const parts: string[] = []
+  const args: any[] = []
+  filters.forEach(({ column: { field }, operator, value }) => {
+    if (!field || value === undefined || value === "") return
+    const { op, val } = sqlOp(operator as string, value)
+    parts.push(`${ident(String(field))} ${op} ?`)
+    args.push(val)
+  })
+  if (searchWords) {
+    parts.push(`${ident(searchField)} LIKE ?`)
+    args.push(`%${searchWords}%`)
+  }
+  return { clause: parts.length ? ` WHERE ${parts.join(" AND ")}` : "", args }
+}
+
+/** SELECT with filters, sort, pagination. */
+export function buildSelect(
+  table: string,
+  tableQuery: any,
+  searchField = "name"
+): Stmt {
+  const { search, filters = [], orderBy, orderDirection, page = 0, pageSize = 20 } = tableQuery
+  const { clause, args } = buildWhere(filters, search, searchField)
+  let sql = `SELECT * FROM ${ident(table)}${clause}`
+  if (orderBy && orderBy.field) {
+    sql += ` ORDER BY ${ident(String(orderBy.field))} ${orderDirection === "desc" ? "DESC" : "ASC"}`
+  }
+  sql += ` LIMIT ? OFFSET ?`
+  return { sql, args: [...args, pageSize, page * pageSize] }
+}
+
+/** COUNT(*) with the same filters (for totalCount). */
+export function buildCount(table: string, tableQuery: any, searchField = "name"): Stmt {
+  const { search, filters = [] } = tableQuery
+  const { clause, args } = buildWhere(filters, search, searchField)
+  return { sql: `SELECT COUNT(*) AS c FROM ${ident(table)}${clause}`, args }
+}
+
+/** INSERT from a row object. */
+export function buildInsert(table: string, data: Record<string, any>): Stmt {
+  const keys = Object.keys(data)
+  const cols = keys.map(ident).join(", ")
+  const ph = keys.map(() => "?").join(", ")
+  return { sql: `INSERT INTO ${ident(table)} (${cols}) VALUES (${ph})`, args: keys.map(k => data[k]) }
+}
+
+/** UPDATE by primary key. */
+export function buildUpdate(
+  table: string,
+  data: Record<string, any>,
+  pk: string,
+  pkValue: any
+): Stmt {
+  const keys = Object.keys(data).filter(k => k !== pk)
+  const set = keys.map(k => `${ident(k)} = ?`).join(", ")
+  return {
+    sql: `UPDATE ${ident(table)} SET ${set} WHERE ${ident(pk)} = ?`,
+    args: [...keys.map(k => data[k]), pkValue]
+  }
+}
+
+/** DELETE by primary key. */
+export function buildDelete(table: string, pk: string, pkValue: any): Stmt {
+  return { sql: `DELETE FROM ${ident(table)} WHERE ${ident(pk)} = ?`, args: [pkValue] }
+}

--- a/packages/bunadmin-source-turso/tsconfig.json
+++ b/packages/bunadmin-source-turso/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig",
+  "compilerOptions": {
+    "rootDir": "./",
+    "outDir": "./lib",
+    "declaration": true,
+    "declarationDir": "./lib",
+    "baseUrl": "./"
+  },
+  "exclude": ["node_modules", "lib", "**/__tests__/**", "**/*.test.ts", "**/*.test.tsx"],
+  "include": ["*.ts", "*.tsx"]
+}

--- a/packages/bunadmin-source-turso/types.ts
+++ b/packages/bunadmin-source-turso/types.ts
@@ -1,0 +1,19 @@
+import { TFunction } from "i18next"
+import { Query, ListServiceRes } from "@xbuilder/bunadmin"
+
+export type DataCtrl<RowData extends object> = {
+  t?: TFunction
+  listService?: () => Promise<ListServiceRes>
+  tableQuery: ListService<RowData>["tableQuery"]
+  path?: ListService<RowData>["path"]
+  prefix?: ListService<RowData>["prefix"]
+  searchField?: ListService<RowData>["searchField"]
+}
+
+export type ListService<RowData extends object> = {
+  tableQuery: Query<RowData>
+  /** SQLite table name */
+  path: string
+  prefix?: string
+  searchField?: "name" | string
+}

--- a/packages/bunadmin/vite.config.ts
+++ b/packages/bunadmin/vite.config.ts
@@ -110,6 +110,10 @@ export default defineConfig(({ mode }) => {
           replacement: r("../bunadmin-source-payload/index.ts")
         },
         {
+          find: /^@xbuilder\/bunadmin-source-turso$/,
+          replacement: r("../bunadmin-source-turso/index.ts")
+        },
+        {
           find: /^@xbuilder\/bunadmin-rich-text-editor$/,
           replacement: r("../bunadmin-rich-text-editor/index.tsx")
         },


### PR DESCRIPTION
Full-CRUD SQLite-over-HTTP connector (libSQL /v2/pipeline). Parameterized SQL builders (injection-safe: bound params + validated/quoted identifiers, 11 tests incl injection guards), client, listSer/CRUD/bulk, controllers, vite alias, docs page. lerna 17 projects; app+docs build clean. 8 connectors total.