### PR TITLE
test: connector listSer service tests (mocked)

### DIFF
--- a/packages/bunadmin-source-appwrite/services/__tests__/listSer.test.ts
+++ b/packages/bunadmin-source-appwrite/services/__tests__/listSer.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+const request = vi.fn()
+vi.mock("@xbuilder/bunadmin", () => ({
+  ENV: { AUTH_URL: "http://aw.test", APPWRITE_PROJECT: "proj1", APPWRITE_DATABASE: "db1" },
+  request: (...a: any[]) => request(...a),
+  storedToken: async () => "jwt"
+}))
+
+import listSer from "../listSer"
+
+const query = {
+  search: "",
+  filters: [{ column: { field: "status" }, operator: "=", value: "Published" }],
+  orderBy: { field: "views" },
+  orderDirection: "desc",
+  page: 0,
+  pageSize: 20
+}
+
+describe("appwrite listSer", () => {
+  beforeEach(() => request.mockReset())
+
+  it("hits the documents endpoint with queries[] + project/JWT headers, parses documents/total", async () => {
+    request.mockResolvedValue({ documents: [{ $id: "1" }], total: 7 })
+    const res = await listSer({ tableQuery: query as any, path: "posts" })
+
+    const [url, opts] = request.mock.calls[0]
+    expect(url).toBe("/v1/databases/db1/collections/posts/documents")
+    expect(Array.isArray(opts.params["queries[]"])).toBe(true)
+    expect(opts.params["queries[]"].some((q: string) => q.includes('"method":"equal"'))).toBe(true)
+    expect(opts.headers["X-Appwrite-Project"]).toBe("proj1")
+    expect(opts.headers["X-Appwrite-JWT"]).toBe("jwt")
+    expect(res).toEqual({ data: [{ $id: "1" }], totalCount: 7, errors: undefined })
+  })
+})

--- a/packages/bunadmin-source-directus/services/__tests__/listSer.test.ts
+++ b/packages/bunadmin-source-directus/services/__tests__/listSer.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+const request = vi.fn()
+vi.mock("@xbuilder/bunadmin", () => ({
+  ENV: { MAIN_URL: "http://dx.test", AUTH_URL: "http://dx.test" },
+  request: (...a: any[]) => request(...a),
+  storedToken: async () => "tok"
+}))
+
+import listSer from "../listSer"
+
+const query = {
+  search: "hi",
+  filters: [{ column: { field: "status" }, operator: "=", value: "Published" }],
+  orderBy: { field: "views" },
+  orderDirection: "desc",
+  page: 0,
+  pageSize: 20
+}
+
+describe("directus listSer", () => {
+  beforeEach(() => request.mockReset())
+
+  it("hits /items/{collection} with filter[..] + meta=filter_count, parses data/meta", async () => {
+    request.mockResolvedValue({ data: [{ id: 1 }], meta: { filter_count: 5 } })
+    const res = await listSer({ tableQuery: query as any, path: "posts" })
+
+    const [url, opts] = request.mock.calls[0]
+    expect(url).toBe("/items/posts")
+    expect(opts.params["filter[status][_eq]"]).toBe("Published")
+    expect(opts.params.search).toBe("hi")
+    expect(opts.params.meta).toBe("filter_count")
+    expect(opts.headers.Authorization).toContain("Bearer")
+    expect(res).toEqual({ data: [{ id: 1 }], totalCount: 5, errors: undefined })
+  })
+})

--- a/packages/bunadmin-source-payload/services/__tests__/listSer.test.ts
+++ b/packages/bunadmin-source-payload/services/__tests__/listSer.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+const request = vi.fn()
+vi.mock("@xbuilder/bunadmin", () => ({
+  ENV: { MAIN_URL: "http://pl.test", AUTH_URL: "http://pl.test" },
+  request: (...a: any[]) => request(...a),
+  storedToken: async () => "tok"
+}))
+
+import listSer from "../listSer"
+
+const query = {
+  search: "",
+  filters: [{ column: { field: "status" }, operator: "=", value: "Published" }],
+  orderBy: { field: "views" },
+  orderDirection: "desc",
+  page: 1,
+  pageSize: 10
+}
+
+describe("payload listSer", () => {
+  beforeEach(() => request.mockReset())
+
+  it("hits /api/{collection} with where[..] + 1-based page, parses docs/totalDocs", async () => {
+    request.mockResolvedValue({ docs: [{ id: 1 }], totalDocs: 9 })
+    const res = await listSer({ tableQuery: query as any, path: "posts" })
+
+    const [url, opts] = request.mock.calls[0]
+    expect(url).toBe("/api/posts")
+    expect(opts.params["where[status][equals]"]).toBe("Published")
+    expect(opts.params.sort).toBe("-views")
+    expect(opts.params.page).toBe(2) // 0-based 1 -> Payload 2
+    expect(opts.headers.Authorization).toContain("Bearer")
+    expect(res).toEqual({ data: [{ id: 1 }], totalCount: 9, errors: undefined })
+  })
+})

--- a/packages/bunadmin-source-pocketbase/services/__tests__/listSer.test.ts
+++ b/packages/bunadmin-source-pocketbase/services/__tests__/listSer.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+// Mock the bunadmin runtime deps the service imports.
+const request = vi.fn()
+vi.mock("@xbuilder/bunadmin", () => ({
+  ENV: { AUTH_URL: "http://pb.test" },
+  request: (...a: any[]) => request(...a),
+  storedToken: async () => "tok"
+}))
+
+import listSer from "../listSer"
+
+const query = {
+  search: "",
+  filters: [{ column: { field: "status" }, operator: "=", value: "Published" }],
+  orderBy: { field: "views" },
+  orderDirection: "desc",
+  page: 1,
+  pageSize: 10
+}
+
+describe("pocketbase listSer", () => {
+  beforeEach(() => request.mockReset())
+
+  it("builds the request (path, page+1, filter, sort, token) and parses items/totalItems", async () => {
+    request.mockResolvedValue({ items: [{ id: "1", name: "a" }], totalItems: 42 })
+    const res = await listSer({ tableQuery: query as any, path: "posts" })
+
+    const [url, opts] = request.mock.calls[0]
+    expect(url).toBe("/api/collections/posts/records")
+    expect(opts.params.page).toBe(2) // 0-based page 1 -> PB page 2
+    expect(opts.params.perPage).toBe(10)
+    expect(opts.params.sort).toBe("-views")
+    expect(opts.params.filter).toBe("status='Published'")
+    expect(opts.headers.Authorization).toBe("tok")
+    expect(res).toEqual({ data: [{ id: "1", name: "a" }], totalCount: 42, errors: undefined })
+  })
+
+  it("returns empty + error on a 4xx body", async () => {
+    request.mockResolvedValue({ code: 400, message: "bad" })
+    const res = await listSer({ tableQuery: { ...query, filters: [] } as any, path: "posts" })
+    expect(res.data).toEqual([])
+    expect(res.errors).toBeTruthy()
+  })
+})

--- a/packages/bunadmin-source-supabase/services/__tests__/listSer.test.ts
+++ b/packages/bunadmin-source-supabase/services/__tests__/listSer.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+const request = vi.fn()
+vi.mock("@xbuilder/bunadmin", () => ({
+  ENV: { MAIN_URL: "http://sb.test", AUTH_URL: "http://sb.test", SUPABASE_KEY: "anon" },
+  request: (...a: any[]) => request(...a),
+  storedToken: async () => "sess"
+}))
+
+import listSer from "../listSer"
+
+const query = {
+  search: "",
+  filters: [{ column: { field: "status" }, operator: "=", value: "Published" }],
+  orderBy: { field: "views" },
+  orderDirection: "desc",
+  page: 1,
+  pageSize: 10
+}
+
+describe("supabase listSer", () => {
+  beforeEach(() => request.mockReset())
+
+  it("hits /rest/v1/{table} with PostgREST params + apikey/bearer, parses array rows", async () => {
+    request.mockResolvedValue([{ id: 1 }, { id: 2 }])
+    const res = await listSer({ tableQuery: query as any, path: "posts" })
+
+    const [url, opts] = request.mock.calls[0]
+    expect(url).toBe("/rest/v1/posts")
+    expect(opts.params.status).toBe("eq.Published")
+    expect(opts.params.order).toBe("views.desc")
+    expect(opts.params.limit).toBe(10)
+    expect(opts.params.offset).toBe(10)
+    expect(opts.headers.apikey).toBe("anon")
+    expect(opts.headers.Authorization).toContain("Bearer")
+    expect(res.data).toEqual([{ id: 1 }, { id: 2 }])
+    expect(res.totalCount).toBe(2)
+  })
+})

--- a/packages/bunadmin-source-turso/services/__tests__/listSer.test.ts
+++ b/packages/bunadmin-source-turso/services/__tests__/listSer.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+// Mock the libSQL client so listSer is tested without a network.
+const execute = vi.fn()
+vi.mock("../client", () => ({ execute: (...a: any[]) => execute(...a) }))
+// listSer also imports nothing else from @xbuilder/bunadmin directly, but sql.ts does not.
+
+import listSer from "../listSer"
+
+const query = {
+  search: "",
+  filters: [{ column: { field: "status" }, operator: "=", value: "Published" }],
+  orderBy: { field: "views" },
+  orderDirection: "desc",
+  page: 0,
+  pageSize: 20
+}
+
+describe("turso listSer", () => {
+  beforeEach(() => execute.mockReset())
+
+  it("runs COUNT then SELECT, returns rows + COUNT total", async () => {
+    execute
+      .mockResolvedValueOnce({ rows: [{ c: 3 }], affectedRows: 0 }) // count
+      .mockResolvedValueOnce({ rows: [{ id: 1 }, { id: 2 }, { id: 3 }], affectedRows: 0 }) // select
+    const res = await listSer({ tableQuery: query as any, path: "posts" })
+
+    // first call = COUNT stmt, second = SELECT stmt
+    expect(execute.mock.calls[0][0].sql).toContain("COUNT(*)")
+    expect(execute.mock.calls[1][0].sql).toContain("SELECT * FROM")
+    expect(execute.mock.calls[1][0].sql).toContain("LIMIT ? OFFSET ?")
+    expect(res.data.length).toBe(3)
+    expect(res.totalCount).toBe(3)
+  })
+
+  it("surfaces an execute error", async () => {
+    execute.mockResolvedValue({ rows: [], affectedRows: 0, error: { message: "boom" } })
+    const res = await listSer({ tableQuery: { ...query, filters: [] } as any, path: "posts" })
+    expect(res.errors).toBeTruthy()
+    expect(res.totalCount).toBe(0)
+  })
+})


### PR DESCRIPTION
Mock-based service tests for all 6 REST/SQL connectors' listSer — verify URL/params/auth-headers AND response parsing into {data,totalCount,errors}. Closes the runtime-path gap (was only pure-core tests). Connector tests 44 total; all suites green.