### PR TITLE
test(core): authorization + addResource script tests

### DIFF
--- a/packages/bunadmin/src/utils/scripts/__tests__/addResource.test.ts
+++ b/packages/bunadmin/src/utils/scripts/__tests__/addResource.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+// i18nCodes drives the loop; mock to a single language for determinism.
+vi.mock("@/utils/i18n", () => ({ i18nCodes: { en: {} } }))
+
+import addResource from "../addResource"
+
+describe("addResource", () => {
+  let i18n: any
+  beforeEach(() => {
+    i18n = { addResourceBundle: vi.fn() }
+  })
+
+  it("resolves a normal plugin name as bunadmin-plugin-{team}-{group}", () => {
+    const requirePlugin = vi.fn(() => ({ plugins: { Hello: "Hi" } }))
+    addResource({ i18n, team: "myteam", group: "blog", requirePlugin })
+    expect(requirePlugin).toHaveBeenCalledWith("bunadmin-plugin-myteam-blog/utils/i18n/en")
+    expect(i18n.addResourceBundle).toHaveBeenCalledWith("en", "plugins", { Hello: "Hi" }, true, true)
+  })
+
+  it("special-cases auth/upload groups as bunadmin-{group}", () => {
+    const requirePlugin = vi.fn(() => null)
+    addResource({ i18n, team: "x", group: "auth-local", requirePlugin })
+    expect(requirePlugin).toHaveBeenCalledWith("bunadmin-auth-local/utils/i18n/en")
+  })
+
+  it("skips bundling when the plugin lang is missing", () => {
+    addResource({ i18n, team: "t", group: "g", requirePlugin: () => null })
+    expect(i18n.addResourceBundle).not.toHaveBeenCalled()
+  })
+
+  it("adds the table bundle when present", () => {
+    addResource({
+      i18n, team: "t", group: "g",
+      requirePlugin: () => ({ table: { Id: "ID" } })
+    })
+    expect(i18n.addResourceBundle).toHaveBeenCalledWith("en", "table", { Id: "ID" }, true, true)
+  })
+})

--- a/packages/bunadmin/src/utils/scripts/__tests__/authorization.test.ts
+++ b/packages/bunadmin/src/utils/scripts/__tests__/authorization.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+const request = vi.fn()
+let PATHS_WITHOUT_AUTH: string[] = []
+vi.mock("@/utils", () => ({
+  ENV: {
+    get PATHS_WITHOUT_AUTH() {
+      return PATHS_WITHOUT_AUTH
+    },
+    AUTH_URL: "http://auth.test"
+  },
+  request: (...a: any[]) => request(...a),
+  storedToken: async () => "tok"
+}))
+
+import authorization from "../authorization"
+
+describe("authorization", () => {
+  beforeEach(() => {
+    request.mockReset()
+    PATHS_WITHOUT_AUTH = []
+    // jsdom default path
+    window.history.pushState({}, "", "/blog/post")
+  })
+
+  it("bypasses auth for whitelisted paths (no request made)", async () => {
+    PATHS_WITHOUT_AUTH = ["/blog"]
+    const ok = await authorization({})
+    expect(ok).toBe(true)
+    expect(request).not.toHaveBeenCalled()
+  })
+
+  it("verifies via authResponseKey when the user resolves", async () => {
+    request.mockResolvedValue({ id: "u1" })
+    expect(await authorization({})).toBe(true)
+    // hits the auth endpoint with Bearer token
+    const [url, opts] = request.mock.calls[0]
+    expect(url).toBe("/auth/me")
+    expect(opts.headers.Authorization).toBe("Bearer tok")
+  })
+
+  it("fails when the response lacks the key", async () => {
+    request.mockResolvedValue({ error: "nope" })
+    expect(await authorization({})).toBe(false)
+  })
+
+  it("honors a custom authResponseKey + url", async () => {
+    request.mockResolvedValue({ uid: 7 })
+    expect(await authorization({ authResponseKey: "uid", authRequestUrl: "/me" })).toBe(true)
+    expect(request.mock.calls[0][0]).toBe("/me")
+  })
+})


### PR DESCRIPTION
Adds core (@xbuilder/bunadmin) unit tests: authorization (auth-bypass paths + token verification logic) and addResource (plugin-name resolution + i18n bundle registration). App suite 88 -> 96. All green.