### PR TITLE
test: connector CRUD service tests

### DIFF
--- a/packages/bunadmin-source-appwrite/services/__tests__/crud.test.ts
+++ b/packages/bunadmin-source-appwrite/services/__tests__/crud.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+const request = vi.fn()
+vi.mock("@xbuilder/bunadmin", () => ({
+  EditableCtrl: {},
+  ENV: { AUTH_URL: "http://aw.test", APPWRITE_PROJECT: "p1", APPWRITE_DATABASE: "db1" },
+  request: (...a: any[]) => request(...a),
+  storedToken: async () => "jwt",
+  notice: vi.fn()
+}))
+
+import addSer from "../addSer"
+import updateSer from "../updateSer"
+import deleteSer from "../deleteSer"
+
+const t = (s: string) => s
+const base = "/v1/databases/db1/collections/posts/documents"
+
+describe("appwrite CRUD services", () => {
+  beforeEach(() => request.mockReset())
+
+  it("add POSTs documents with { documentId, data } + project header", async () => {
+    request.mockResolvedValue({ $id: "1" })
+    await addSer({ t, SchemaName: "posts", newData: { name: "a" } } as any)
+    const [url, opts] = request.mock.calls[0]
+    expect(url).toBe(base)
+    expect(opts.method).toBe("POST")
+    expect(opts.data).toEqual({ documentId: "unique()", data: { name: "a" } })
+    expect(opts.headers["X-Appwrite-Project"]).toBe("p1")
+  })
+
+  it("update PATCHes /{ $id } with { data }", async () => {
+    request.mockResolvedValue({ $id: "9" })
+    await updateSer({ t, SchemaName: "posts", newData: { name: "b" }, oldData: { $id: "9" } } as any)
+    const [url, opts] = request.mock.calls[0]
+    expect(url).toBe(`${base}/9`)
+    expect(opts.method).toBe("PATCH")
+    expect(opts.data).toEqual({ data: { name: "b" } })
+  })
+
+  it("delete DELETEs /{ $id }", async () => {
+    request.mockResolvedValue({})
+    await deleteSer({ t, SchemaName: "posts", oldData: { $id: "9" } } as any)
+    const [url, opts] = request.mock.calls[0]
+    expect(url).toBe(`${base}/9`)
+    expect(opts.method).toBe("DELETE")
+  })
+})

--- a/packages/bunadmin-source-directus/services/__tests__/crud.test.ts
+++ b/packages/bunadmin-source-directus/services/__tests__/crud.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+const request = vi.fn()
+vi.mock("@xbuilder/bunadmin", () => ({
+  EditableCtrl: {},
+  ENV: { MAIN_URL: "http://dx.test", AUTH_URL: "http://dx.test" },
+  request: (...a: any[]) => request(...a),
+  storedToken: async () => "tok",
+  notice: vi.fn()
+}))
+
+import { addSer, updateSer, deleteSer } from "../crud"
+
+const t = (s: string) => s
+
+describe("directus CRUD services", () => {
+  beforeEach(() => request.mockReset())
+
+  it("add POSTs to /items/{collection}", async () => {
+    request.mockResolvedValue({ data: { id: 1 } })
+    await addSer({ t, SchemaName: "posts", newData: { name: "a" } } as any)
+    const [url, opts] = request.mock.calls[0]
+    expect(url).toBe("/items/posts")
+    expect(opts.method).toBe("POST")
+    expect(opts.data).toEqual({ name: "a" })
+  })
+
+  it("update PATCHes /items/{collection}/{id}", async () => {
+    request.mockResolvedValue({ data: { id: 9 } })
+    await updateSer({ t, SchemaName: "posts", newData: { name: "b" }, oldData: { id: 9 } } as any)
+    const [url, opts] = request.mock.calls[0]
+    expect(url).toBe("/items/posts/9")
+    expect(opts.method).toBe("PATCH")
+  })
+
+  it("delete DELETEs /items/{collection}/{id}", async () => {
+    request.mockResolvedValue({})
+    await deleteSer({ t, SchemaName: "posts", oldData: { id: 9 } } as any)
+    const [url, opts] = request.mock.calls[0]
+    expect(url).toBe("/items/posts/9")
+    expect(opts.method).toBe("DELETE")
+  })
+})

--- a/packages/bunadmin-source-payload/services/__tests__/crud.test.ts
+++ b/packages/bunadmin-source-payload/services/__tests__/crud.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+const request = vi.fn()
+vi.mock("@xbuilder/bunadmin", () => ({
+  EditableCtrl: {},
+  ENV: { MAIN_URL: "http://pl.test", AUTH_URL: "http://pl.test" },
+  request: (...a: any[]) => request(...a),
+  storedToken: async () => "tok",
+  notice: vi.fn()
+}))
+
+import { addSer, updateSer, deleteSer } from "../crud"
+
+const t = (s: string) => s
+
+describe("payload CRUD services", () => {
+  beforeEach(() => request.mockReset())
+
+  it("add POSTs to /api/{collection}", async () => {
+    request.mockResolvedValue({ doc: { id: 1 } })
+    await addSer({ t, SchemaName: "posts", newData: { name: "a" } } as any)
+    const [url, opts] = request.mock.calls[0]
+    expect(url).toBe("/api/posts")
+    expect(opts.method).toBe("POST")
+  })
+
+  it("update PATCHes /api/{collection}/{id}", async () => {
+    request.mockResolvedValue({ doc: { id: 9 } })
+    await updateSer({ t, SchemaName: "posts", newData: { name: "b" }, oldData: { id: 9 } } as any)
+    const [url, opts] = request.mock.calls[0]
+    expect(url).toBe("/api/posts/9")
+    expect(opts.method).toBe("PATCH")
+  })
+
+  it("delete DELETEs /api/{collection}/{id}", async () => {
+    request.mockResolvedValue({})
+    await deleteSer({ t, SchemaName: "posts", oldData: { id: 9 } } as any)
+    const [url, opts] = request.mock.calls[0]
+    expect(url).toBe("/api/posts/9")
+    expect(opts.method).toBe("DELETE")
+  })
+})

--- a/packages/bunadmin-source-pocketbase/services/__tests__/crud.test.ts
+++ b/packages/bunadmin-source-pocketbase/services/__tests__/crud.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+const request = vi.fn()
+vi.mock("@xbuilder/bunadmin", () => ({
+  EditableCtrl: {},
+  ENV: { AUTH_URL: "http://pb.test" },
+  request: (...a: any[]) => request(...a),
+  storedToken: async () => "tok",
+  notice: vi.fn()
+}))
+
+import addSer from "../addSer"
+import updateSer from "../updateSer"
+import deleteSer from "../deleteSer"
+
+const t = (s: string) => s
+
+describe("pocketbase CRUD services", () => {
+  beforeEach(() => request.mockReset())
+
+  it("add POSTs to the collection with the new row", async () => {
+    request.mockResolvedValue({ id: "1" })
+    await addSer({ t, SchemaName: "posts", newData: { name: "a" } } as any)
+    const [url, opts] = request.mock.calls[0]
+    expect(url).toBe("/api/collections/posts/records")
+    expect(opts.method).toBe("POST")
+    expect(opts.data).toEqual({ name: "a" })
+  })
+
+  it("update PATCHes /records/{id}", async () => {
+    request.mockResolvedValue({ id: "9" })
+    await updateSer({ t, SchemaName: "posts", newData: { name: "b" }, oldData: { id: "9" } } as any)
+    const [url, opts] = request.mock.calls[0]
+    expect(url).toBe("/api/collections/posts/records/9")
+    expect(opts.method).toBe("PATCH")
+    expect(opts.data).toEqual({ name: "b" })
+  })
+
+  it("delete DELETEs /records/{id}", async () => {
+    request.mockResolvedValue({})
+    await deleteSer({ t, SchemaName: "posts", oldData: { id: "9" } } as any)
+    const [url, opts] = request.mock.calls[0]
+    expect(url).toBe("/api/collections/posts/records/9")
+    expect(opts.method).toBe("DELETE")
+  })
+})

--- a/packages/bunadmin-source-supabase/services/__tests__/crud.test.ts
+++ b/packages/bunadmin-source-supabase/services/__tests__/crud.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+const request = vi.fn()
+vi.mock("@xbuilder/bunadmin", () => ({
+  EditableCtrl: {},
+  ENV: { MAIN_URL: "http://sb.test", AUTH_URL: "http://sb.test", SUPABASE_KEY: "anon" },
+  request: (...a: any[]) => request(...a),
+  storedToken: async () => "sess",
+  notice: vi.fn()
+}))
+
+import addSer from "../addSer"
+import updateSer from "../updateSer"
+import deleteSer from "../deleteSer"
+
+const t = (s: string) => s
+
+describe("supabase CRUD services", () => {
+  beforeEach(() => request.mockReset())
+
+  it("add POSTs /rest/v1/{table} with apikey", async () => {
+    request.mockResolvedValue([{ id: 1 }])
+    await addSer({ t, SchemaName: "posts", newData: { name: "a" } } as any)
+    const [url, opts] = request.mock.calls[0]
+    expect(url).toBe("/rest/v1/posts")
+    expect(opts.method).toBe("POST")
+    expect(opts.headers.apikey).toBe("anon")
+  })
+
+  it("update PATCHes with ?id=eq.{id}", async () => {
+    request.mockResolvedValue([{ id: 9 }])
+    await updateSer({ t, SchemaName: "posts", newData: { name: "b" }, oldData: { id: 9 } } as any)
+    const [url, opts] = request.mock.calls[0]
+    expect(url).toBe("/rest/v1/posts")
+    expect(opts.method).toBe("PATCH")
+    expect(opts.params.id).toBe("eq.9")
+  })
+
+  it("delete DELETEs with ?id=eq.{id}", async () => {
+    request.mockResolvedValue([])
+    await deleteSer({ t, SchemaName: "posts", oldData: { id: 9 } } as any)
+    const [url, opts] = request.mock.calls[0]
+    expect(opts.method).toBe("DELETE")
+    expect(opts.params.id).toBe("eq.9")
+  })
+})

--- a/packages/bunadmin-source-turso/services/__tests__/crud.test.ts
+++ b/packages/bunadmin-source-turso/services/__tests__/crud.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+const execute = vi.fn()
+vi.mock("../client", () => ({ execute: (...a: any[]) => execute(...a) }))
+vi.mock("@xbuilder/bunadmin", () => ({ EditableCtrl: {}, notice: vi.fn() }))
+
+import { addSer, updateSer, deleteSer } from "../crud"
+
+const t = (s: string) => s
+
+describe("turso CRUD services", () => {
+  beforeEach(() => execute.mockReset().mockResolvedValue({ rows: [], affectedRows: 1 }))
+
+  it("add builds INSERT", async () => {
+    await addSer({ t, SchemaName: "posts", newData: { name: "a", views: 3 } } as any)
+    const stmt = execute.mock.calls[0][0]
+    expect(stmt.sql).toBe('INSERT INTO "posts" ("name", "views") VALUES (?, ?)')
+    expect(stmt.args).toEqual(["a", 3])
+  })
+
+  it("update builds UPDATE ... WHERE id=?", async () => {
+    await updateSer({ t, SchemaName: "posts", newData: { name: "b" }, oldData: { id: 9 } } as any)
+    const stmt = execute.mock.calls[0][0]
+    expect(stmt.sql).toBe('UPDATE "posts" SET "name" = ? WHERE "id" = ?')
+    expect(stmt.args).toEqual(["b", 9])
+  })
+
+  it("delete builds DELETE ... WHERE id=?", async () => {
+    await deleteSer({ t, SchemaName: "posts", oldData: { id: 9 } } as any)
+    const stmt = execute.mock.calls[0][0]
+    expect(stmt.sql).toBe('DELETE FROM "posts" WHERE "id" = ?')
+    expect(stmt.args).toEqual([9])
+  })
+})


### PR DESCRIPTION
Mock-based add/update/delete tests for all 6 connectors — verify HTTP method + URL + body/SQL. Completes the connector runtime coverage started by the listSer tests. Connector tests 44 -> 62.