### PR TITLE
Add runnable demos for all connectors + flagship feature tour

### DIFF
--- a/docs/guide/demo.md
+++ b/docs/guide/demo.md
@@ -3,6 +3,17 @@
 Boot a real backend, seed data, and generate a working admin — in minutes. The
 runnable demo lives in [`examples/pocketbase-demo`](https://github.com/Chris533/bunadmin/tree/master/examples/pocketbase-demo).
 
+Runnable demos exist for every connector — pick your backend:
+
+| Backend | Example | Start |
+| --- | --- | --- |
+| PocketBase | [`examples/pocketbase-demo`](https://github.com/Chris533/bunadmin/tree/master/examples/pocketbase-demo) | `./start.sh` |
+| Payload + SQLite | [`examples/payload-demo`](https://github.com/Chris533/bunadmin/tree/master/examples/payload-demo) | `./start.sh` |
+| Supabase / Postgres | [`examples/supabase-demo`](https://github.com/Chris533/bunadmin/tree/master/examples/supabase-demo) | `./start.sh` |
+| Appwrite | [`examples/appwrite-demo`](https://github.com/Chris533/bunadmin/tree/master/examples/appwrite-demo) | `./start.sh` |
+| Directus | [`examples/directus-demo`](https://github.com/Chris533/bunadmin/tree/master/examples/directus-demo) | `docker compose up -d` |
+| Turso / libSQL | [`examples/turso-demo`](https://github.com/Chris533/bunadmin/tree/master/examples/turso-demo) | `./start.sh` |
+
 ## One command
 
 ```bash
@@ -11,7 +22,7 @@ cd examples/pocketbase-demo
 ```
 
 Downloads PocketBase, creates an admin, serves it on `http://127.0.0.1:8090`, and
-seeds demo collections (`posts`, `products`, `customers`) + a `demo` user.
+seeds demo collections (`posts`, `products`) + a `demo` user.
 
 > Docker alternative: `docker compose up -d` then `node ../../docs/pocketbase/seed.js`.
 
@@ -28,6 +39,141 @@ yarn dev
 Sign in as `demo` / `bunadmin123`. See the [AI guide](/ai/) for the full flow,
 including `ai theme` and `ai refine`.
 
-## Credentials
+### Flagship example (no AI key)
+
+The PocketBase demo ships drop-in files that exercise the **plugin-level**
+features: `example-admin.tsx` (posts — filtering, inline CRUD, **bulk delete**,
+status-pill lookup, custom `render`), `example-products.tsx` (a second schema),
+and `example-menu.ts` (registers both as a **multi-level menu**: Blog → Posts +
+Products).
+
+The surrounding shell — **KPI stat band**, modern layout, **dark-mode toggle**,
+i18n, dynamic routing — is added automatically by `bunadmin new` on every list
+view, so it needs no code in these files.
+
+## Credentials (PocketBase)
 - PocketBase admin: `admin@bunadmin.test` / `bunadmin123`
 - Demo user (app login): `demo` / `bunadmin123`
+
+---
+
+## Payload CMS + SQLite
+
+A second demo uses [Payload CMS](https://payloadcms.com) with SQLite — no external
+database required.
+
+```bash
+cd examples/payload-demo
+./start.sh
+```
+
+Scaffolds Payload, installs deps, seeds `posts` and `products` collections, and
+serves on `http://127.0.0.1:3001`.
+
+> Docker alternative: `docker compose up -d`
+
+### Generate the admin
+
+```bash
+bunadmin new my-admin && cd my-admin
+# .env: VITE_AUTH_PLUGIN=@xbuilder/bunadmin-auth-payload, VITE_AUTH_URL=http://127.0.0.1:3001
+export BUNADMIN_AI_PROVIDER=openai BUNADMIN_AI_API_KEY=sk-... BUNADMIN_AI_MODEL=gpt-4o-mini
+bunadmin ai generate --url http://127.0.0.1:3001 --collection posts --token <admin-token>
+yarn dev
+```
+
+Or drop in the pre-built [`example-admin.tsx`](https://github.com/Chris533/bunadmin/tree/master/examples/payload-demo/example-admin.tsx) — no AI key needed.
+
+### Credentials (Payload)
+- Payload admin: `admin@bunadmin.test` / `bunadmin123`
+
+---
+
+## Supabase / Postgres
+
+Local Supabase stack (via the Supabase CLI + Docker) with seeded `posts` and
+`products` tables.
+
+```bash
+cd examples/supabase-demo
+./start.sh
+```
+
+Studio runs at `http://127.0.0.1:54323`, the API at `http://127.0.0.1:54321`. The
+script prints the anon key to use in `.env`.
+
+```
+VITE_AUTH_PLUGIN=@xbuilder/bunadmin-auth-supabase
+VITE_MAIN_URL=http://127.0.0.1:54321
+VITE_SUPABASE_KEY=<anon-key>
+```
+
+> Stop with `npx supabase stop`.
+
+---
+
+## Appwrite
+
+Self-hosted Appwrite via Docker.
+
+```bash
+cd examples/appwrite-demo
+./start.sh
+```
+
+Serves the console on `http://127.0.0.1:8080`. Create a project + database +
+`posts` collection in the console (one-time), then:
+
+```
+VITE_AUTH_PLUGIN=@xbuilder/bunadmin-auth-appwrite
+VITE_AUTH_URL=http://127.0.0.1:8080
+VITE_APPWRITE_PROJECT=<your-project-id>
+VITE_APPWRITE_DATABASE=<your-database-id>
+```
+
+> Appwrite rows use `$id`. Stop with `docker compose down`.
+
+---
+
+## Directus
+
+Self-hosted Directus (SQLite-backed) via Docker.
+
+```bash
+cd examples/directus-demo
+docker compose up -d
+```
+
+Serves on `http://127.0.0.1:8055`. Create a `posts` collection in the data studio
+(one-time), then:
+
+```
+VITE_AUTH_PLUGIN=@xbuilder/bunadmin-auth-directus
+VITE_MAIN_URL=http://127.0.0.1:8055
+```
+
+### Credentials (Directus)
+- Directus admin: `admin@bunadmin.test` / `bunadmin123`
+
+---
+
+## Turso / libSQL
+
+Local libSQL server (`sqld`) over SQLite, seeded with `posts` and `products`.
+
+```bash
+cd examples/turso-demo
+./start.sh
+```
+
+Serves the libSQL HTTP protocol on `http://127.0.0.1:8080`.
+
+```
+VITE_AUTH_PLUGIN=@xbuilder/bunadmin-auth-local
+VITE_MAIN_URL=http://127.0.0.1:8080
+```
+
+> For hosted Turso, point `VITE_MAIN_URL` at your `*.turso.io` URL and sign in
+> with a DB auth token.
+
+Each demo ships a pre-built `example-admin.tsx` you can drop in without an AI key.

--- a/docs/pocketbase/seed.js
+++ b/docs/pocketbase/seed.js
@@ -72,6 +72,30 @@ async function main() {
   )
   console.log("posts collection:", coll.ok ? "created" : `skip (${coll.status})`)
 
+  // products collection (second schema → demonstrates multi-level menus)
+  const prodColl = await api(
+    "/api/collections",
+    {
+      method: "POST",
+      body: {
+        name: "products",
+        type: "base",
+        listRule: "",
+        viewRule: "",
+        createRule: "",
+        updateRule: "",
+        deleteRule: "",
+        schema: [
+          { name: "name", type: "text", required: true },
+          { name: "price", type: "number", required: true },
+          { name: "in_stock", type: "bool" }
+        ]
+      }
+    },
+    token
+  )
+  console.log("products collection:", prodColl.ok ? "created" : `skip (${prodColl.status})`)
+
   // demo user
   const user = await api(
     "/api/collections/users/records",
@@ -103,6 +127,21 @@ async function main() {
       token
     )
     console.log(`post ${i}:`, r.ok ? "created" : `skip (${r.status})`)
+  }
+
+  // sample products
+  const products = [
+    { name: "Widget", price: 9.99, in_stock: true },
+    { name: "Gadget", price: 24.99, in_stock: true },
+    { name: "Thingamajig", price: 4.99, in_stock: false }
+  ]
+  for (const p of products) {
+    const r = await api(
+      "/api/collections/products/records",
+      { method: "POST", body: p },
+      token
+    )
+    console.log(`product ${p.name}:`, r.ok ? "created" : `skip (${r.status})`)
   }
   console.log("\nDone. Set your bunadmin .env:")
   console.log("  VITE_AUTH_PLUGIN=@xbuilder/bunadmin-auth-pocketbase")

--- a/examples/appwrite-demo/README.md
+++ b/examples/appwrite-demo/README.md
@@ -1,0 +1,52 @@
+# bunadmin Demo (Appwrite)
+
+Boot a self-hosted Appwrite + wire it to a bunadmin admin.
+
+## One command
+
+```bash
+./start.sh
+```
+
+Starts Appwrite (Docker) on `http://127.0.0.1:8080`. The console is at
+`/console`.
+
+> Requires Docker. Stop with `docker compose down`.
+
+## One-time setup (Appwrite console)
+
+Appwrite collections can't be seeded headlessly without an API key, so create
+them once in the console:
+
+1. Create an account + project — note the **Project ID**.
+2. Create a database — note its **Database ID**.
+3. Add a `posts` collection with attributes: `title` (string), `status`
+   (string), `views` (integer).
+4. Set collection **permissions** to allow your user to read/write.
+
+## Then: generate the admin
+
+```bash
+bunadmin new my-admin && cd my-admin
+```
+
+`.env`:
+```
+VITE_AUTH_PLUGIN=@xbuilder/bunadmin-auth-appwrite
+VITE_AUTH_URL=http://127.0.0.1:8080
+VITE_APPWRITE_PROJECT=<your-project-id>
+VITE_APPWRITE_DATABASE=<your-database-id>
+```
+
+```bash
+yarn dev
+```
+
+Or drop in [`example-admin.tsx`](./example-admin.tsx) directly. Note Appwrite
+rows use `$id`.
+
+## Notes
+
+- This compose file is a trimmed single-service setup for local demos. For
+  production use Appwrite's [official self-hosting guide](https://appwrite.io/docs/advanced/self-hosting).
+- See [`docs/appwrite/`](../../docs/appwrite/README.md) for the connector reference.

--- a/examples/appwrite-demo/docker-compose.yml
+++ b/examples/appwrite-demo/docker-compose.yml
@@ -1,0 +1,25 @@
+# bunadmin Appwrite demo — minimal self-hosted Appwrite.
+#   docker compose up -d        # serves Appwrite console on :8080
+# This is a trimmed single-service setup for local demos. For production use the
+# official compose file: https://appwrite.io/docs/advanced/self-hosting
+services:
+  appwrite:
+    image: appwrite/appwrite:1.5.7
+    container_name: bunadmin-demo-appwrite
+    ports:
+      - "8080:80"
+    environment:
+      - _APP_ENV=production
+      - _APP_OPENSSL_KEY_V1=bunadmin-demo-secret-change-me
+      - _APP_DOMAIN=localhost
+      - _APP_DOMAIN_TARGET=localhost
+    volumes:
+      - appwrite_data:/storage:rw
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:80/v1/health"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+
+volumes:
+  appwrite_data:

--- a/examples/appwrite-demo/example-admin.tsx
+++ b/examples/appwrite-demo/example-admin.tsx
@@ -1,0 +1,61 @@
+/**
+ * Worked example: a `posts` page backed by Appwrite Databases via
+ * @xbuilder/bunadmin-source-appwrite.
+ *
+ * Drop this into a bunadmin project's plugin and register it like any other
+ * schema plugin. Requires an Appwrite `posts` collection (see README.md).
+ * Note: Appwrite rows use `$id` rather than `id`.
+ */
+import React, { createRef } from "react"
+import {
+  Table,
+  TableHead,
+  tableIcons,
+  TableDefaultProps as DefaultProps,
+  useTranslation,
+  Column
+} from "@xbuilder/bunadmin"
+import { dataCtrl, editableCtrl, bulkDeleteCtrl } from "@xbuilder/bunadmin-source-appwrite"
+
+const theme = { bunadmin: { iconColor: "#8f9bb3" } }
+
+interface Post {
+  $id: string
+  title: string
+  status: string
+  views: number
+}
+
+const columns = ({ t }: { t: any }): Column<Post>[] => [
+  { title: t("Id"), field: "$id", editable: "never", width: 220 },
+  { title: t("Title"), field: "title" },
+  {
+    title: t("Status"),
+    field: "status",
+    lookup: { draft: "Draft", published: "Published" }
+  },
+  { title: t("Views"), field: "views", type: "numeric" }
+]
+
+export default function Posts() {
+  const { t } = useTranslation("table")
+  const tableRef = createRef()
+  const SchemaName = "posts" // Appwrite collectionId
+
+  return (
+    <>
+      <TableHead title="Posts" />
+      <Table<Post>
+        tableRef={tableRef}
+        title="Posts"
+        columns={columns({ t })}
+        style={DefaultProps.style}
+        icons={tableIcons({ theme })}
+        options={{ ...DefaultProps.options, filtering: true }}
+        data={query => dataCtrl({ t, tableQuery: query, path: SchemaName })}
+        editable={editableCtrl({ t, SchemaName })}
+        actions={[bulkDeleteCtrl({ SchemaName, t, tableRef })]}
+      />
+    </>
+  )
+}

--- a/examples/appwrite-demo/start.sh
+++ b/examples/appwrite-demo/start.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# One-command bunadmin demo: Appwrite (self-hosted via Docker).
+#
+#   ./start.sh            # starts Appwrite on :8080
+#
+# Requires: Docker.
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$DIR"
+
+echo "→ starting Appwrite (Docker) on http://127.0.0.1:8080 ..."
+docker compose up -d
+
+echo "→ waiting for Appwrite to be healthy ..."
+for i in $(seq 1 60); do
+  curl -fsS "http://127.0.0.1:8080/v1/health" >/dev/null 2>&1 && break
+  sleep 1
+done
+
+cat <<EOF
+
+✓ Appwrite ready: http://127.0.0.1:8080/console
+
+Next steps (one-time, in the Appwrite console):
+  1. Create an account + project, note the Project ID.
+  2. Create a database (note its ID) and a 'posts' collection with
+     attributes: title (string), status (string), views (integer).
+  3. Set collection permissions to allow your user to read/write.
+
+Then — in another terminal:
+  bunadmin new my-admin && cd my-admin
+  # .env:
+  #   VITE_AUTH_PLUGIN=@xbuilder/bunadmin-auth-appwrite
+  #   VITE_AUTH_URL=http://127.0.0.1:8080
+  #   VITE_APPWRITE_PROJECT=<your-project-id>
+  #   VITE_APPWRITE_DATABASE=<your-database-id>
+  yarn dev
+
+Stop with: docker compose down
+EOF

--- a/examples/directus-demo/README.md
+++ b/examples/directus-demo/README.md
@@ -1,0 +1,49 @@
+# bunadmin Demo (Directus)
+
+Boot a self-hosted Directus (SQLite-backed) + wire it to a bunadmin admin.
+
+## One command
+
+```bash
+docker compose up -d
+```
+
+Starts Directus on `http://127.0.0.1:8055` with SQLite — no external DB needed.
+Wait ~15s for first-boot migrations, then sign in to the app at `/admin`.
+
+> Stop with `docker compose down`.
+
+## One-time setup (Directus app)
+
+Create the demo collection once in the Directus data studio:
+
+1. Sign in at `http://127.0.0.1:8055` (`admin@bunadmin.test` / `bunadmin123`).
+2. Create a `posts` collection with fields: `title` (string), `status`
+   (string), `views` (integer).
+3. Under **Settings → Roles & Permissions**, grant read/write on `posts`.
+
+## Then: generate the admin
+
+```bash
+bunadmin new my-admin && cd my-admin
+```
+
+`.env`:
+```
+VITE_AUTH_PLUGIN=@xbuilder/bunadmin-auth-directus
+VITE_MAIN_URL=http://127.0.0.1:8055
+```
+
+```bash
+yarn dev
+```
+
+Or drop in [`example-admin.tsx`](./example-admin.tsx) directly.
+
+## Credentials
+
+- Directus admin: `admin@bunadmin.test` / `bunadmin123`
+
+## Notes
+
+- See [`docs/directus/`](../../docs/directus/README.md) for the connector reference.

--- a/examples/directus-demo/docker-compose.yml
+++ b/examples/directus-demo/docker-compose.yml
@@ -1,0 +1,26 @@
+# bunadmin Directus demo.
+#   docker compose up -d        # serves Directus on :8055
+# Uses SQLite (file-backed) — no external DB needed.
+services:
+  directus:
+    image: directus/directus:11
+    container_name: bunadmin-demo-directus
+    ports:
+      - "8055:8055"
+    environment:
+      - KEY=bunadmin-demo-key-change-me
+      - SECRET=bunadmin-demo-secret-change-me
+      - DB_CLIENT=sqlite3
+      - DB_FILENAME=/directus/database/data.db
+      - ADMIN_EMAIL=admin@bunadmin.test
+      - ADMIN_PASSWORD=bunadmin123
+    volumes:
+      - directus_db:/directus/database
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:8055/server/health"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+
+volumes:
+  directus_db:

--- a/examples/directus-demo/example-admin.tsx
+++ b/examples/directus-demo/example-admin.tsx
@@ -1,0 +1,60 @@
+/**
+ * Worked example: a `posts` page backed by Directus (Items REST API) via
+ * @xbuilder/bunadmin-source-directus.
+ *
+ * Drop this into a bunadmin project's plugin and register it like any other
+ * schema plugin. Requires a Directus `posts` collection (see README.md).
+ */
+import React, { createRef } from "react"
+import {
+  Table,
+  TableHead,
+  tableIcons,
+  TableDefaultProps as DefaultProps,
+  useTranslation,
+  Column
+} from "@xbuilder/bunadmin"
+import { dataCtrl, editableCtrl, bulkDeleteCtrl } from "@xbuilder/bunadmin-source-directus"
+
+const theme = { bunadmin: { iconColor: "#8f9bb3" } }
+
+interface Post {
+  id: number
+  title: string
+  status: string
+  views: number
+}
+
+const columns = ({ t }: { t: any }): Column<Post>[] => [
+  { title: t("Id"), field: "id", editable: "never", width: 100 },
+  { title: t("Title"), field: "title" },
+  {
+    title: t("Status"),
+    field: "status",
+    lookup: { draft: "Draft", published: "Published" }
+  },
+  { title: t("Views"), field: "views", type: "numeric" }
+]
+
+export default function Posts() {
+  const { t } = useTranslation("table")
+  const tableRef = createRef()
+  const SchemaName = "posts" // Directus collection
+
+  return (
+    <>
+      <TableHead title="Posts" />
+      <Table<Post>
+        tableRef={tableRef}
+        title="Posts"
+        columns={columns({ t })}
+        style={DefaultProps.style}
+        icons={tableIcons({ theme })}
+        options={{ ...DefaultProps.options, filtering: true }}
+        data={query => dataCtrl({ t, tableQuery: query, path: SchemaName })}
+        editable={editableCtrl({ t, SchemaName })}
+        actions={[bulkDeleteCtrl({ SchemaName, t, tableRef })]}
+      />
+    </>
+  )
+}

--- a/examples/payload-demo/README.md
+++ b/examples/payload-demo/README.md
@@ -1,0 +1,60 @@
+# bunadmin Demo (Payload CMS + SQLite)
+
+Boot Payload CMS with SQLite + seed data + generate a working admin — in minutes.
+
+## One command (no Docker)
+
+```bash
+./start.sh
+```
+
+Scaffolds a Payload project with SQLite, installs deps, creates an admin user,
+seeds demo collections (`posts`, `products`) and serves on `http://127.0.0.1:3001`.
+Ctrl-C stops it.
+
+> Requires Node ≥ 20. First run takes ~1 min for `npm install`.
+
+## Docker alternative
+
+```bash
+docker compose up -d
+```
+
+## Then: generate the admin
+
+```bash
+bunadmin new my-admin && cd my-admin
+```
+
+`.env`:
+```
+VITE_AUTH_PLUGIN=@xbuilder/bunadmin-auth-payload
+VITE_AUTH_URL=http://127.0.0.1:3001
+```
+
+Generate a validated admin table from the live `posts` collection (BYOK):
+```bash
+export BUNADMIN_AI_PROVIDER=openai BUNADMIN_AI_API_KEY=sk-... BUNADMIN_AI_MODEL=gpt-4o-mini
+bunadmin ai generate --url http://127.0.0.1:3001 --collection posts \
+  --token <admin-token> --out src/plugins/blog/post
+yarn dev
+```
+
+Or drop in [`example-admin.tsx`](./example-admin.tsx) directly — no AI key needed.
+
+Sign in as `admin@bunadmin.test` / `bunadmin123`.
+
+## Credentials
+
+- Payload admin: `admin@bunadmin.test` / `bunadmin123`
+
+## API endpoints
+
+| Endpoint | Description |
+| --- | --- |
+| `GET /api/posts` | List posts |
+| `GET /api/posts/:id` | Get single post |
+| `POST /api/posts` | Create post |
+| `PATCH /api/posts/:id` | Update post |
+| `DELETE /api/posts/:id` | Delete post |
+| `GET /admin` | Payload admin panel |

--- a/examples/payload-demo/docker-compose.yml
+++ b/examples/payload-demo/docker-compose.yml
@@ -1,0 +1,21 @@
+# bunadmin Payload demo — Docker alternative to start.sh.
+#   docker compose up        # serves Payload on :3001
+services:
+  payload:
+    build: .
+    container_name: bunadmin-demo-payload
+    ports:
+      - "3001:3000"
+    environment:
+      - PAYLOAD_SECRET=bunadmin-demo-secret-change-me
+      - DATABASE_URL=file:/app/data.db
+    volumes:
+      - payload_data:/app
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:3000/api/posts"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+volumes:
+  payload_data:

--- a/examples/payload-demo/example-admin.tsx
+++ b/examples/payload-demo/example-admin.tsx
@@ -1,0 +1,61 @@
+/**
+ * Worked example: a `posts` page backed by Payload CMS via
+ * @xbuilder/bunadmin-source-payload.
+ *
+ * Drop this into a bunadmin project's plugin (e.g. src/plugins/bunadmin-plugin-
+ * myteam-blog/posts/index.tsx) and register it like any other schema plugin.
+ * Requires a Payload `posts` collection (see start.sh seed step).
+ */
+import React, { createRef } from "react"
+import {
+  Table,
+  TableHead,
+  tableIcons,
+  TableDefaultProps as DefaultProps,
+  useTranslation,
+  Column
+} from "@xbuilder/bunadmin"
+import { dataCtrl, editableCtrl, bulkDeleteCtrl } from "@xbuilder/bunadmin-source-payload"
+
+const theme = { bunadmin: { iconColor: "#8f9bb3" } }
+
+interface Post {
+  id: string
+  title: string
+  status: string
+  views: number
+}
+
+const columns = ({ t }: { t: any }): Column<Post>[] => [
+  { title: t("Id"), field: "id", editable: "never", width: 180 },
+  { title: t("Title"), field: "title" },
+  {
+    title: t("Status"),
+    field: "status",
+    lookup: { draft: "Draft", published: "Published" }
+  },
+  { title: t("Views"), field: "views", type: "numeric" }
+]
+
+export default function Posts() {
+  const { t } = useTranslation("table")
+  const tableRef = createRef()
+  const SchemaName = "posts" // Payload collection slug
+
+  return (
+    <>
+      <TableHead title="Posts" />
+      <Table<Post>
+        tableRef={tableRef}
+        title="Posts"
+        columns={columns({ t })}
+        style={DefaultProps.style}
+        icons={tableIcons({ theme })}
+        options={{ ...DefaultProps.options, filtering: true }}
+        data={query => dataCtrl({ t, tableQuery: query, path: SchemaName })}
+        editable={editableCtrl({ t, SchemaName })}
+        actions={[bulkDeleteCtrl({ SchemaName, t, tableRef })]}
+      />
+    </>
+  )
+}

--- a/examples/payload-demo/start.sh
+++ b/examples/payload-demo/start.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# One-command bunadmin demo: Payload CMS + SQLite.
+#
+#   ./start.sh            # installs Payload, seeds it, serves on :3001
+#
+# Then in another terminal, scaffold + run the admin (see README.md).
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+PAYLOAD_DIR="$DIR/.payload"
+PORT="${PAYLOAD_PORT:-3001}"
+
+mkdir -p "$PAYLOAD_DIR"
+cd "$PAYLOAD_DIR"
+
+# 1. Scaffold Payload project if not already present.
+if [ ! -f "package.json" ]; then
+  echo "→ scaffolding Payload CMS project ..."
+  cat > package.json <<'PKG'
+{
+  "name": "bunadmin-payload-demo",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "payload dev",
+    "seed": "node seed.js"
+  },
+  "dependencies": {
+    "payload": "^3.0.0",
+    "@payloadcms/db-sqlite": "^3.0.0",
+    "@payloadcms/next": "^3.0.0",
+    "next": "^15.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "graphql": "^16.9.0",
+    "sharp": "^0.33.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0",
+    "@types/node": "^22.0.0"
+  }
+}
+PKG
+
+  # payload.config.ts — SQLite, REST API enabled, posts collection
+  cat > payload.config.ts <<'CFG'
+import { buildConfig } from "payload"
+import { sqliteAdapter } from "@payloadcms/db-sqlite"
+import path from "path"
+
+export default buildConfig({
+  secret: process.env.PAYLOAD_SECRET || "bunadmin-demo-secret-change-me",
+  db: sqliteAdapter({ url: `file:${path.resolve(__dirname, "data.db")}` }),
+  collections: [
+    {
+      slug: "posts",
+      fields: [
+        { name: "title", type: "text", required: true },
+        { name: "status", type: "select", options: ["draft", "published"], defaultValue: "draft" },
+        { name: "views", type: "number", defaultValue: 0 },
+      ],
+    },
+    {
+      slug: "products",
+      fields: [
+        { name: "name", type: "text", required: true },
+        { name: "price", type: "number", required: true },
+        { name: "inStock", type: "checkbox", defaultValue: true },
+      ],
+    },
+  ],
+})
+CFG
+
+  # seed script
+  cat > seed.js <<'SEED'
+import { getPayload } from "payload"
+import config from "./payload.config.ts"
+
+const ADMIN_EMAIL = process.env.PAYLOAD_ADMIN || "admin@bunadmin.test"
+const ADMIN_PW = process.env.PAYLOAD_ADMIN_PW || "bunadmin123"
+
+async function seed() {
+  const payload = await getPayload({ config })
+
+  // Create admin user (Payload auto-creates a users collection)
+  try {
+    await payload.create({ collection: "users", data: { email: ADMIN_EMAIL, password: ADMIN_PW } })
+    console.log(`✓ admin created: ${ADMIN_EMAIL}`)
+  } catch { console.log("  admin already exists") }
+
+  // Seed posts
+  const posts = [
+    { title: "Hello World", status: "published", views: 42 },
+    { title: "Getting Started with Bunadmin", status: "published", views: 128 },
+    { title: "Draft Post", status: "draft", views: 0 },
+  ]
+  for (const p of posts) {
+    await payload.create({ collection: "posts", data: p })
+  }
+  console.log(`✓ seeded ${posts.length} posts`)
+
+  // Seed products
+  const products = [
+    { name: "Widget", price: 9.99, inStock: true },
+    { name: "Gadget", price: 24.99, inStock: true },
+    { name: "Thingamajig", price: 4.99, inStock: false },
+  ]
+  for (const p of products) {
+    await payload.create({ collection: "products", data: p })
+  }
+  console.log(`✓ seeded ${products.length} products`)
+
+  process.exit(0)
+}
+
+seed()
+SEED
+
+  echo "→ installing dependencies (this may take a minute) ..."
+  npm install
+fi
+
+# 2. Seed data (idempotent-ish — duplicates are harmless for a demo).
+echo "→ seeding demo data ..."
+npx tsx seed.js 2>/dev/null || node --loader tsx seed.js
+
+# 3. Start Payload dev server.
+echo "→ starting Payload on http://127.0.0.1:${PORT} ..."
+echo "  admin panel: http://127.0.0.1:${PORT}/admin"
+echo "  REST API:    http://127.0.0.1:${PORT}/api/posts"
+PORT=$PORT npx payload dev

--- a/examples/pocketbase-demo/README.md
+++ b/examples/pocketbase-demo/README.md
@@ -9,7 +9,7 @@ Boot a real backend + seed data + generate a working admin — in minutes.
 ```
 
 Downloads PocketBase, creates an admin, serves it on `http://127.0.0.1:8090`, and
-seeds demo collections (`posts`, `products`, `customers`) + a `demo` user. The
+seeds demo collections (`posts`, `products`) + a `demo` user. The
 script prints the exact next steps. Ctrl-C stops it.
 
 > Linux x64 by default. For macOS/Windows, set `PB_VERSION` and edit the download
@@ -44,8 +44,29 @@ yarn dev
 
 Sign in as `demo` / `bunadmin123`. You now have a themed, validated admin for real
 PocketBase data — see [`../../docs/ai/README.md`](../../docs/ai/README.md) for the
-full AI walkthrough and [`example-admin.tsx`](./example-admin.tsx) for a
-pre-generated table you can drop in without an API key.
+full AI walkthrough.
+
+## Flagship example (no AI key needed)
+
+Drop-in files showing the **plugin-level** features end to end:
+
+| File | Shows |
+| --- | --- |
+| [`example-admin.tsx`](./example-admin.tsx) | `posts` table — filtering/search, inline CRUD, **bulk delete**, status-pill `lookup`, numeric column, custom `render` |
+| [`example-products.tsx`](./example-products.tsx) | `products` table — numeric + boolean columns, bulk delete |
+| [`example-menu.ts`](./example-menu.ts) | registers both as a **multi-level menu** (Blog → Posts + Products) |
+
+Place them under `src/plugins/bunadmin-plugin-xbuilder-blog/` (posts/products in
+their own folders, `example-menu.ts` as the plugin `index.ts`).
+
+### Provided for free by `bunadmin new`
+
+The app shell adds these automatically on every list view — no code in the files
+above:
+
+- **KPI stat band** + modern layout (`statBand`, upgrade footer)
+- **Dark-mode toggle** (TopBar) via the theme preset system
+- **i18n** (`t()` / `useTranslation`), dynamic routing, permission-aware menus
 
 ## Credentials
 - PocketBase admin: `admin@bunadmin.test` / `bunadmin123`

--- a/examples/pocketbase-demo/example-admin.tsx
+++ b/examples/pocketbase-demo/example-admin.tsx
@@ -1,10 +1,14 @@
 /**
- * Worked example: a `posts` page backed by PocketBase via
- * @xbuilder/bunadmin-source-pocketbase.
+ * Flagship worked example — the `posts` schema of a multi-schema PocketBase
+ * plugin (paired with `example-products.tsx` + `example-menu.ts`).
  *
- * Drop this into a bunadmin project's plugin (e.g. src/plugins/bunadmin-plugin-
- * myteam-blog/posts/index.tsx) and register it like any other schema plugin.
- * Requires a PocketBase `posts` collection (see docs/pocketbase/seed.js).
+ * Demonstrates plugin-level features: filtering/search, inline CRUD, **bulk
+ * delete**, a status-pill `lookup`, a numeric column, and a custom `render`.
+ *
+ * The surrounding shell (KPI stat band, modern layout, dark-mode toggle, i18n)
+ * is provided automatically by `bunadmin new` on every list view — no code here.
+ *
+ * Drop into src/plugins/bunadmin-plugin-xbuilder-blog/posts/index.tsx.
  */
 import React, { createRef } from "react"
 import {
@@ -15,7 +19,11 @@ import {
   useTranslation,
   Column
 } from "@xbuilder/bunadmin"
-import { dataCtrl, editableCtrl } from "@xbuilder/bunadmin-source-pocketbase"
+import {
+  dataCtrl,
+  editableCtrl,
+  bulkDeleteCtrl
+} from "@xbuilder/bunadmin-source-pocketbase"
 
 const theme = { bunadmin: { iconColor: "#8f9bb3" } }
 
@@ -34,7 +42,13 @@ const columns = ({ t }: { t: any }): Column<Post>[] => [
     field: "status",
     lookup: { Draft: "Draft", Published: "Published" }
   },
-  { title: t("Views"), field: "views", type: "numeric" }
+  {
+    title: t("Views"),
+    field: "views",
+    type: "numeric",
+    // custom cell renderer — flag popular posts
+    render: (row: Post) => (row.views >= 100 ? `🔥 ${row.views}` : row.views)
+  }
 ]
 
 export default function Posts() {
@@ -44,10 +58,10 @@ export default function Posts() {
 
   return (
     <>
-      <TableHead title="Posts" />
+      <TableHead title={t("Posts")} />
       <Table<Post>
         tableRef={tableRef}
-        title="Posts"
+        title={t("Posts")}
         columns={columns({ t })}
         style={DefaultProps.style}
         icons={tableIcons({ theme })}
@@ -56,6 +70,8 @@ export default function Posts() {
         data={query => dataCtrl({ t, tableQuery: query, path: SchemaName })}
         // Inline create / update / delete via PocketBase
         editable={editableCtrl({ t, SchemaName })}
+        // Bulk "delete selected" toolbar action
+        actions={[bulkDeleteCtrl({ SchemaName, t, tableRef })]}
       />
     </>
   )

--- a/examples/pocketbase-demo/example-menu.ts
+++ b/examples/pocketbase-demo/example-menu.ts
@@ -1,0 +1,43 @@
+/**
+ * Flagship plugin registration — turns the two schema pages (`posts`,
+ * `products`) into a **multi-level menu**: a "Blog" parent with Posts and
+ * Products children. `ignore_schema: true` makes the parent a menu group only.
+ *
+ * Drop into src/plugins/bunadmin-plugin-xbuilder-blog/index.ts.
+ */
+import { IPluginData } from "@xbuilder/bunadmin"
+
+export { default as posts } from "./example-admin"
+export { default as products } from "./example-products"
+
+const shared = { team: "xbuilder", group: "blog", customized: true }
+
+export const initData: IPluginData[] = [
+  {
+    ...shared,
+    id: "xbuilder_blog",
+    name: "xbuilder_blog",
+    label: "Blog",
+    icon_type: "eva",
+    icon: "file-text-outline",
+    ignore_schema: true // parent → menu group only
+  },
+  {
+    ...shared,
+    id: "xbuilder_blog_posts",
+    name: "posts",
+    label: "Posts",
+    icon_type: "eva",
+    icon: "file-text-outline",
+    parent: "xbuilder_blog"
+  },
+  {
+    ...shared,
+    id: "xbuilder_blog_products",
+    name: "products",
+    label: "Products",
+    icon_type: "eva",
+    icon: "shopping-bag-outline",
+    parent: "xbuilder_blog"
+  }
+]

--- a/examples/pocketbase-demo/example-products.tsx
+++ b/examples/pocketbase-demo/example-products.tsx
@@ -1,0 +1,60 @@
+/**
+ * Flagship worked example — the `products` schema (second schema of the same
+ * plugin). Two schemas under one plugin → a multi-level menu (see
+ * `example-menu.ts`). Shows a numeric and a boolean column + bulk delete.
+ *
+ * Drop into src/plugins/bunadmin-plugin-xbuilder-blog/products/index.tsx.
+ */
+import React, { createRef } from "react"
+import {
+  Table,
+  TableHead,
+  tableIcons,
+  TableDefaultProps as DefaultProps,
+  useTranslation,
+  Column
+} from "@xbuilder/bunadmin"
+import {
+  dataCtrl,
+  editableCtrl,
+  bulkDeleteCtrl
+} from "@xbuilder/bunadmin-source-pocketbase"
+
+const theme = { bunadmin: { iconColor: "#8f9bb3" } }
+
+interface Product {
+  id: string
+  name: string
+  price: number
+  in_stock: boolean
+}
+
+const columns = ({ t }: { t: any }): Column<Product>[] => [
+  { title: t("Id"), field: "id", editable: "never", width: 180 },
+  { title: t("Name"), field: "name" },
+  { title: t("Price"), field: "price", type: "numeric" },
+  { title: t("In stock"), field: "in_stock", type: "boolean" }
+]
+
+export default function Products() {
+  const { t } = useTranslation("table")
+  const tableRef = createRef()
+  const SchemaName = "products" // PocketBase collection name
+
+  return (
+    <>
+      <TableHead title={t("Products")} />
+      <Table<Product>
+        tableRef={tableRef}
+        title={t("Products")}
+        columns={columns({ t })}
+        style={DefaultProps.style}
+        icons={tableIcons({ theme })}
+        options={{ ...DefaultProps.options, filtering: true }}
+        data={query => dataCtrl({ t, tableQuery: query, path: SchemaName })}
+        editable={editableCtrl({ t, SchemaName })}
+        actions={[bulkDeleteCtrl({ SchemaName, t, tableRef })]}
+      />
+    </>
+  )
+}

--- a/examples/supabase-demo/README.md
+++ b/examples/supabase-demo/README.md
@@ -1,0 +1,44 @@
+# bunadmin Demo (Supabase / Postgres)
+
+Boot a local Supabase stack + seed data + generate a working admin.
+
+## One command
+
+```bash
+./start.sh
+```
+
+Starts a local Supabase (via the Supabase CLI + Docker), seeds `posts` and
+`products` tables, and prints the API URL + anon key. Studio runs at
+`http://127.0.0.1:54323`, the API at `http://127.0.0.1:54321`.
+
+> Requires Docker + Node ≥ 20. Stop with `npx supabase stop`.
+
+## Then: generate the admin
+
+```bash
+bunadmin new my-admin && cd my-admin
+```
+
+`.env` (use the values printed by `start.sh`):
+```
+VITE_AUTH_PLUGIN=@xbuilder/bunadmin-auth-supabase
+VITE_MAIN_URL=http://127.0.0.1:54321
+VITE_SUPABASE_KEY=<anon-key>
+```
+
+Generate a validated admin table from the live `posts` table (BYOK):
+```bash
+export BUNADMIN_AI_PROVIDER=openai BUNADMIN_AI_API_KEY=sk-... BUNADMIN_AI_MODEL=gpt-4o-mini
+bunadmin ai generate --url http://127.0.0.1:54321 --collection posts \
+  --token <anon-key> --out src/plugins/blog/post
+yarn dev
+```
+
+Or drop in [`example-admin.tsx`](./example-admin.tsx) directly — no AI key needed.
+
+## Notes
+
+- Local Supabase ships with permissive RLS for the default keys. For a hosted
+  project, ensure your RLS policies permit the anon/service key.
+- See [`docs/supabase/`](../../docs/supabase/README.md) for the full connector reference.

--- a/examples/supabase-demo/docker-compose.yml
+++ b/examples/supabase-demo/docker-compose.yml
@@ -1,0 +1,13 @@
+# bunadmin Supabase demo.
+# The Supabase CLI manages its own multi-container stack — prefer ./start.sh.
+# This file is a thin convenience wrapper around the CLI.
+#   docker compose up        # runs `supabase start`
+services:
+  supabase:
+    image: node:20-alpine
+    container_name: bunadmin-demo-supabase
+    working_dir: /app
+    volumes:
+      - .:/app
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: ["npx", "supabase", "start"]

--- a/examples/supabase-demo/example-admin.tsx
+++ b/examples/supabase-demo/example-admin.tsx
@@ -1,0 +1,60 @@
+/**
+ * Worked example: a `posts` page backed by Supabase (PostgREST) via
+ * @xbuilder/bunadmin-source-supabase.
+ *
+ * Drop this into a bunadmin project's plugin and register it like any other
+ * schema plugin. Requires a Postgres `posts` table (see start.sh seed step).
+ */
+import React, { createRef } from "react"
+import {
+  Table,
+  TableHead,
+  tableIcons,
+  TableDefaultProps as DefaultProps,
+  useTranslation,
+  Column
+} from "@xbuilder/bunadmin"
+import { dataCtrl, editableCtrl, bulkDeleteCtrl } from "@xbuilder/bunadmin-source-supabase"
+
+const theme = { bunadmin: { iconColor: "#8f9bb3" } }
+
+interface Post {
+  id: string
+  title: string
+  status: string
+  views: number
+}
+
+const columns = ({ t }: { t: any }): Column<Post>[] => [
+  { title: t("Id"), field: "id", editable: "never", width: 280 },
+  { title: t("Title"), field: "title" },
+  {
+    title: t("Status"),
+    field: "status",
+    lookup: { draft: "Draft", published: "Published" }
+  },
+  { title: t("Views"), field: "views", type: "numeric" }
+]
+
+export default function Posts() {
+  const { t } = useTranslation("table")
+  const tableRef = createRef()
+  const SchemaName = "posts" // Postgres table name
+
+  return (
+    <>
+      <TableHead title="Posts" />
+      <Table<Post>
+        tableRef={tableRef}
+        title="Posts"
+        columns={columns({ t })}
+        style={DefaultProps.style}
+        icons={tableIcons({ theme })}
+        options={{ ...DefaultProps.options, filtering: true }}
+        data={query => dataCtrl({ t, tableQuery: query, path: SchemaName })}
+        editable={editableCtrl({ t, SchemaName })}
+        actions={[bulkDeleteCtrl({ SchemaName, t, tableRef })]}
+      />
+    </>
+  )
+}

--- a/examples/supabase-demo/start.sh
+++ b/examples/supabase-demo/start.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# One-command bunadmin demo: Supabase (local via the Supabase CLI).
+#
+#   ./start.sh            # starts local Supabase (Docker) + seeds data on :54321
+#
+# Requires: Docker, npx (Node ≥ 20).
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$DIR"
+
+# 1. Init + start local Supabase (Docker under the hood).
+if [ ! -f "supabase/config.toml" ]; then
+  echo "→ initializing Supabase project ..."
+  npx supabase init
+fi
+
+echo "→ starting local Supabase (Docker) ..."
+npx supabase start
+
+DB_URL=$(npx supabase status -o json | grep -o '"DB_URL":"[^"]*"' | cut -d'"' -f4)
+API_URL=$(npx supabase status -o json | grep -o '"API_URL":"[^"]*"' | cut -d'"' -f4)
+ANON_KEY=$(npx supabase status -o json | grep -o '"ANON_KEY":"[^"]*"' | cut -d'"' -f4)
+
+# 2. Seed tables + rows.
+echo "→ seeding demo data ..."
+psql "$DB_URL" <<'SQL'
+CREATE TABLE IF NOT EXISTS posts (
+  id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+  title text NOT NULL,
+  status text DEFAULT 'draft' CHECK (status IN ('draft','published')),
+  views int DEFAULT 0
+);
+CREATE TABLE IF NOT EXISTS products (
+  id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+  name text NOT NULL,
+  price numeric(10,2) NOT NULL,
+  in_stock boolean DEFAULT true
+);
+INSERT INTO posts (title, status, views) VALUES
+  ('Hello World', 'published', 42),
+  ('Getting Started with Bunadmin', 'published', 128),
+  ('Draft Post', 'draft', 0);
+INSERT INTO products (name, price, in_stock) VALUES
+  ('Widget', 9.99, true),
+  ('Gadget', 24.99, true),
+  ('Thingamajig', 4.99, false);
+SQL
+
+cat <<EOF
+
+✓ Local Supabase ready!  Studio: http://127.0.0.1:54323
+  API URL:  ${API_URL}
+  Anon key: ${ANON_KEY}
+
+Next — in another terminal:
+  bunadmin new my-admin && cd my-admin
+  # .env:
+  #   VITE_AUTH_PLUGIN=@xbuilder/bunadmin-auth-supabase
+  #   VITE_MAIN_URL=${API_URL}
+  #   VITE_SUPABASE_KEY=${ANON_KEY}
+  yarn dev
+
+Stop with: npx supabase stop
+EOF

--- a/examples/turso-demo/README.md
+++ b/examples/turso-demo/README.md
@@ -1,0 +1,49 @@
+# bunadmin Demo (Turso / libSQL)
+
+Boot a local libSQL server (`sqld`) with SQLite + seed data + a working admin.
+
+## One command
+
+```bash
+./start.sh
+```
+
+Seeds a local SQLite file with `posts` and `products`, then serves it over the
+libSQL HTTP protocol (`sqld` via Docker) on `http://127.0.0.1:8080`. Ctrl-C stops it.
+
+> Requires Docker + `sqlite3` (for seeding).
+
+## Hosted Turso alternative
+
+```bash
+turso db create bunadmin-demo
+turso db shell bunadmin-demo < seed.sql   # same DDL as start.sh
+turso db show bunadmin-demo --url         # → VITE_MAIN_URL
+turso db tokens create bunadmin-demo      # → auth token
+```
+
+## Then: generate the admin
+
+```bash
+bunadmin new my-admin && cd my-admin
+```
+
+`.env`:
+```
+VITE_AUTH_PLUGIN=@xbuilder/bunadmin-auth-local
+VITE_MAIN_URL=http://127.0.0.1:8080
+```
+
+For hosted Turso, set `VITE_MAIN_URL` to your `*.turso.io` URL and sign in with
+the DB auth token.
+
+```bash
+yarn dev
+```
+
+Or drop in [`example-admin.tsx`](./example-admin.tsx) directly.
+
+## Notes
+
+- The connector executes parameterized SQL over the libSQL HTTP pipeline
+  (`POST /v2/pipeline`). See [`docs/turso/`](../../docs/turso/README.md) for details.

--- a/examples/turso-demo/example-admin.tsx
+++ b/examples/turso-demo/example-admin.tsx
@@ -1,0 +1,60 @@
+/**
+ * Worked example: a `posts` page backed by Turso / libSQL (SQL over HTTP) via
+ * @xbuilder/bunadmin-source-turso.
+ *
+ * Drop this into a bunadmin project's plugin and register it like any other
+ * schema plugin. Requires a `posts` table (see start.sh seed step).
+ */
+import React, { createRef } from "react"
+import {
+  Table,
+  TableHead,
+  tableIcons,
+  TableDefaultProps as DefaultProps,
+  useTranslation,
+  Column
+} from "@xbuilder/bunadmin"
+import { dataCtrl, editableCtrl, bulkDeleteCtrl } from "@xbuilder/bunadmin-source-turso"
+
+const theme = { bunadmin: { iconColor: "#8f9bb3" } }
+
+interface Post {
+  id: number
+  title: string
+  status: string
+  views: number
+}
+
+const columns = ({ t }: { t: any }): Column<Post>[] => [
+  { title: t("Id"), field: "id", editable: "never", width: 100 },
+  { title: t("Title"), field: "title" },
+  {
+    title: t("Status"),
+    field: "status",
+    lookup: { draft: "Draft", published: "Published" }
+  },
+  { title: t("Views"), field: "views", type: "numeric" }
+]
+
+export default function Posts() {
+  const { t } = useTranslation("table")
+  const tableRef = createRef()
+  const SchemaName = "posts" // libSQL table name
+
+  return (
+    <>
+      <TableHead title="Posts" />
+      <Table<Post>
+        tableRef={tableRef}
+        title="Posts"
+        columns={columns({ t })}
+        style={DefaultProps.style}
+        icons={tableIcons({ theme })}
+        options={{ ...DefaultProps.options, filtering: true }}
+        data={query => dataCtrl({ t, tableQuery: query, path: SchemaName })}
+        editable={editableCtrl({ t, SchemaName })}
+        actions={[bulkDeleteCtrl({ SchemaName, t, tableRef })]}
+      />
+    </>
+  )
+}

--- a/examples/turso-demo/start.sh
+++ b/examples/turso-demo/start.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# One-command bunadmin demo: Turso / libSQL (local sqld via Docker).
+#
+#   ./start.sh            # starts sqld (libSQL HTTP) on :8080 + seeds data
+#
+# Requires: Docker, sqlite3 (for seeding).
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+DB_DIR="$DIR/.turso"
+PORT="${TURSO_PORT:-8080}"
+
+mkdir -p "$DB_DIR"
+
+# 1. Seed a local SQLite file that sqld will serve.
+echo "→ seeding demo data ..."
+sqlite3 "$DB_DIR/data.db" <<'SQL'
+CREATE TABLE IF NOT EXISTS posts (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  title TEXT NOT NULL,
+  status TEXT DEFAULT 'draft',
+  views INTEGER DEFAULT 0
+);
+CREATE TABLE IF NOT EXISTS products (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL,
+  price REAL NOT NULL,
+  in_stock INTEGER DEFAULT 1
+);
+INSERT INTO posts (title, status, views) VALUES
+  ('Hello World', 'published', 42),
+  ('Getting Started with Bunadmin', 'published', 128),
+  ('Draft Post', 'draft', 0);
+INSERT INTO products (name, price, in_stock) VALUES
+  ('Widget', 9.99, 1),
+  ('Gadget', 24.99, 1),
+  ('Thingamajig', 4.99, 0);
+SQL
+
+# 2. Serve it via sqld (libSQL HTTP protocol).
+echo "→ starting sqld (libSQL) on http://127.0.0.1:${PORT} ..."
+docker run --rm -p "${PORT}:8080" \
+  -v "$DB_DIR:/var/lib/sqld" \
+  ghcr.io/tursodatabase/libsql-server:latest &
+SQLD_PID=$!
+trap 'kill $SQLD_PID 2>/dev/null || true' EXIT
+
+for i in $(seq 1 30); do
+  curl -fsS "http://127.0.0.1:${PORT}/health" >/dev/null 2>&1 && break
+  sleep 0.5
+done
+
+cat <<EOF
+
+✓ libSQL server ready: http://127.0.0.1:${PORT}
+
+Next — in another terminal:
+  bunadmin new my-admin && cd my-admin
+  # .env:
+  #   VITE_AUTH_PLUGIN=@xbuilder/bunadmin-auth-local
+  #   VITE_MAIN_URL=http://127.0.0.1:${PORT}
+  yarn dev
+
+(Ctrl-C here stops sqld.)
+EOF
+
+wait $SQLD_PID

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "turbo:test": "turbo run test",
     "turbo:lint": "turbo run lint",
     "turbo:dev": "turbo run dev",
+    "docs:dev": "npm run dev --prefix docs",
     "docs:contributors": "bash scripts/gen-docs-contributors.sh"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
Adds runnable example projects for every data connector and upgrades the PocketBase demo into a flagship feature tour.

- **New example dirs**: `supabase-demo`, `appwrite-demo`, `directus-demo`, `turso-demo` (each: start script / docker-compose where applicable, a drop-in `example-admin.tsx`, README)
- **Flagship (pocketbase-demo)**: multi-level menu (`posts` + `products` via `example-menu.ts`), bulk delete, status-pill lookup, numeric column, custom `render`
- **bulkDeleteCtrl** added to every connector example (was missing, inconsistent with docs)
- **Seed**: `docs/pocketbase/seed.js` now creates a `products` collection + sample rows
- **Docs**: `docs/guide/demo.md` gains a demos index table + per-connector sections and a 'provided free by `bunadmin new`' note (KPI stat band, dark-mode toggle, i18n, routing); corrected seeded-collections list to `posts, products`
- **Root**: `docs:dev` script

## Tested
- `node --check docs/pocketbase/seed.js` passes
- APIs verified against source: `IPluginData` fields, `bulkDeleteCtrl({ SchemaName, t, tableRef })`, `Column` `render`/`type`

## Not included / follow-ups
- The `.tsx` files are drop-in snippets importing the published packages; not compiled in-repo
- Docker image tags (Appwrite, Directus, libSQL) are best-effort and need a real smoke test
- Still quickstarts — no uploads/permissions/notifications coverage