### PR TITLE
fix(meta): purge xbuilder/bunadmin leftovers from package.json

### DIFF
--- a/packages/dashin-cli/package.json
+++ b/packages/dashin-cli/package.json
@@ -14,7 +14,7 @@
     "tsc:clean": "tsc --build --clean",
     "tsc:build": "tsc",
     "test": "xo && ava",
-    "local-install-global": "npm run tsc && npm uninstall bunadmin-cli --global && npm install --global ./"
+    "local-install-global": "npm run tsc && npm uninstall @dashin-dev/cli --global && npm install --global ./"
   },
   "files": [
     "cli.js",

--- a/packages/dashin-rich-text-editor/package.json
+++ b/packages/dashin-rich-text-editor/package.json
@@ -2,7 +2,7 @@
   "name": "@dashin-dev/rich-text-editor",
   "version": "2.0.0-alpha.0",
   "publishConfig": { "access": "public" },
-  "description": "Rich Text Editor for bunadmin",
+  "description": "Rich Text Editor for dashin",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "files": [
@@ -15,9 +15,9 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [
-    "bunadmin"
+    "dashin"
   ],
-  "author": "xbuilder",
+  "author": "Dashin Team",
   "license": "Apache-2.0",
   "dependencies": {
     "@tiptap/core": "^2.4.0",

--- a/packages/dashin/package.json
+++ b/packages/dashin/package.json
@@ -11,7 +11,7 @@
   "bugs": {
     "url": "https://github.com/dashindev/dashin/issues"
   },
-  "author": "XBuilder Team",
+  "author": "Dashin Team",
   "main": "lib/main.js",
   "types": "lib/main.d.ts",
   "files": [
@@ -97,7 +97,7 @@
     "dashboard",
     "admin panel"
   ],
-  "homepage": "https://www.xbuilder.net/",
+  "homepage": "https://dashin.dev/",
   "browserslist": {
     "production": [
       ">0.2%",


### PR DESCRIPTION
Cleans up npm-facing `package.json` metadata that the BunAdmin→Dashin rename PRs missed. These would otherwise show on the npm pages of the 2.0 `@dashin-dev/*` packages.

- **@dashin-dev/dashin** — `author` "XBuilder Team" → "Dashin Team"; `homepage` `xbuilder.net` → `dashin.dev`
- **@dashin-dev/rich-text-editor** — `author` "xbuilder" → "Dashin Team"; `description` "…for bunadmin" → "…for dashin"; keyword `bunadmin` → `dashin`
- **@dashin-dev/cli** — `local-install-global` script now uninstalls `@dashin-dev/cli` (was `bunadmin-cli`)

After this, a sweep of all 16 `package.json` files is free of `bunadmin`/`xbuilder`. Verified locally that all 16 packages still build and `npm pack --dry-run` produces tarballs containing `lib/` + their `main` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)