### PR TITLE
cleanup(brand): purge bunadmin/xbuilder from demo creds, hosts & LICENSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ See [`docs/pocketbase/`](docs/pocketbase/).
 [dashin.dev](https://dashin.dev/)
 
 - Username: `admin`
-- Password: `bunadmin`
+- Password: `dashin`
 
 [More details](https://dashin.dev/guide/demo)
 
@@ -82,7 +82,7 @@ $ yarn dev
 The dev server (Vite) runs at [http://localhost:3000](http://localhost:3000).
 
 - Username: `admin`
-- Password: `bunadmin`
+- Password: `dashin`
 
 ### Scripts
 

--- a/docs/guide/demo.md
+++ b/docs/guide/demo.md
@@ -36,7 +36,7 @@ dashin ai generate --url http://127.0.0.1:8090 --collection posts --token <admin
 yarn dev
 ```
 
-Sign in as `demo` / `bunadmin123`. See the [AI guide](/ai/) for the full flow,
+Sign in as `demo` / `dashin123`. See the [AI guide](/ai/) for the full flow,
 including `ai theme` and `ai refine`.
 
 ### Flagship example (no AI key)
@@ -52,8 +52,8 @@ i18n, dynamic routing — is added automatically by `dashin new` on every list
 view, so it needs no code in these files.
 
 ## Credentials (PocketBase)
-- PocketBase admin: `admin@bunadmin.test` / `bunadmin123`
-- Demo user (app login): `demo` / `bunadmin123`
+- PocketBase admin: `admin@dashin.test` / `dashin123`
+- Demo user (app login): `demo` / `dashin123`
 
 ---
 
@@ -85,7 +85,7 @@ yarn dev
 Or drop in the pre-built [`example-admin.tsx`](https://github.com/dashindev/dashin/tree/master/examples/payload-demo/example-admin.tsx) — no AI key needed.
 
 ### Credentials (Payload)
-- Payload admin: `admin@bunadmin.test` / `bunadmin123`
+- Payload admin: `admin@dashin.test` / `dashin123`
 
 ---
 
@@ -153,7 +153,7 @@ VITE_MAIN_URL=http://127.0.0.1:8055
 ```
 
 ### Credentials (Directus)
-- Directus admin: `admin@bunadmin.test` / `bunadmin123`
+- Directus admin: `admin@dashin.test` / `dashin123`
 
 ---
 

--- a/docs/pocketbase/README.md
+++ b/docs/pocketbase/README.md
@@ -15,8 +15,8 @@ Dashin ships two plugins for it:
 
 ```bash
 # download the binary for your OS from https://pocketbase.io/docs/
-./pocketbase admin create admin@bunadmin.test bunadmin123   # PocketBase 0.22
-# (0.23+: ./pocketbase superuser create admin@bunadmin.test bunadmin123)
+./pocketbase admin create admin@dashin.test dashin123   # PocketBase 0.22
+# (0.23+: ./pocketbase superuser create admin@dashin.test dashin123)
 ./pocketbase serve --http=127.0.0.1:8090
 ```
 
@@ -30,7 +30,7 @@ With PocketBase running:
 node docs/pocketbase/seed.js
 ```
 
-Creates a `posts` collection, a demo user (`demo` / `bunadmin123`), and a few
+Creates a `posts` collection, a demo user (`demo` / `dashin123`), and a few
 records. Override with `PB_URL`, `PB_ADMIN`, `PB_ADMIN_PW` env vars.
 
 ## 3. Point your Dashin project at it

--- a/docs/pocketbase/seed.js
+++ b/docs/pocketbase/seed.js
@@ -6,12 +6,12 @@
  *   PB_URL=... PB_ADMIN=... PB_ADMIN_PW=... node docs/pocketbase/seed.js
  *
  * Creates: a `posts` collection (name/status/views), a demo user
- * (demo / bunadmin123), and a few sample records. Idempotent-ish: ignores
+ * (demo / dashin123), and a few sample records. Idempotent-ish: ignores
  * "already exists" errors.
  */
 const PB = process.env.PB_URL || "http://127.0.0.1:8090"
-const ADMIN = process.env.PB_ADMIN || "admin@bunadmin.test"
-const ADMIN_PW = process.env.PB_ADMIN_PW || "bunadmin123"
+const ADMIN = process.env.PB_ADMIN || "admin@dashin.test"
+const ADMIN_PW = process.env.PB_ADMIN_PW || "dashin123"
 
 async function api(path, opts = {}, token) {
   const res = await fetch(`${PB}${path}`, {
@@ -103,14 +103,14 @@ async function main() {
       method: "POST",
       body: {
         username: "demo",
-        email: "demo@bunadmin.test",
-        password: "bunadmin123",
-        passwordConfirm: "bunadmin123"
+        email: "demo@dashin.test",
+        password: "dashin123",
+        passwordConfirm: "dashin123"
       }
     },
     token
   )
-  console.log("demo user:", user.ok ? "created (demo / bunadmin123)" : `skip (${user.status})`)
+  console.log("demo user:", user.ok ? "created (demo / dashin123)" : `skip (${user.status})`)
 
   // sample records
   for (let i = 1; i <= 3; i++) {

--- a/examples/directus-demo/README.md
+++ b/examples/directus-demo/README.md
@@ -17,7 +17,7 @@ Wait ~15s for first-boot migrations, then sign in to the app at `/admin`.
 
 Create the demo collection once in the Directus data studio:
 
-1. Sign in at `http://127.0.0.1:8055` (`admin@bunadmin.test` / `bunadmin123`).
+1. Sign in at `http://127.0.0.1:8055` (`admin@dashin.test` / `dashin123`).
 2. Create a `posts` collection with fields: `title` (string), `status`
    (string), `views` (integer).
 3. Under **Settings → Roles & Permissions**, grant read/write on `posts`.
@@ -42,7 +42,7 @@ Or drop in [`example-admin.tsx`](./example-admin.tsx) directly.
 
 ## Credentials
 
-- Directus admin: `admin@bunadmin.test` / `bunadmin123`
+- Directus admin: `admin@dashin.test` / `dashin123`
 
 ## Notes
 

--- a/examples/directus-demo/docker-compose.yml
+++ b/examples/directus-demo/docker-compose.yml
@@ -12,8 +12,8 @@ services:
       - SECRET=dashin-demo-secret-change-me
       - DB_CLIENT=sqlite3
       - DB_FILENAME=/directus/database/data.db
-      - ADMIN_EMAIL=admin@bunadmin.test
-      - ADMIN_PASSWORD=bunadmin123
+      - ADMIN_EMAIL=admin@dashin.test
+      - ADMIN_PASSWORD=dashin123
     volumes:
       - directus_db:/directus/database
     healthcheck:

--- a/examples/payload-demo/README.md
+++ b/examples/payload-demo/README.md
@@ -42,11 +42,11 @@ yarn dev
 
 Or drop in [`example-admin.tsx`](./example-admin.tsx) directly — no AI key needed.
 
-Sign in as `admin@bunadmin.test` / `bunadmin123`.
+Sign in as `admin@dashin.test` / `dashin123`.
 
 ## Credentials
 
-- Payload admin: `admin@bunadmin.test` / `bunadmin123`
+- Payload admin: `admin@dashin.test` / `dashin123`
 
 ## API endpoints
 

--- a/examples/payload-demo/start.sh
+++ b/examples/payload-demo/start.sh
@@ -77,8 +77,8 @@ CFG
 import { getPayload } from "payload"
 import config from "./payload.config.ts"
 
-const ADMIN_EMAIL = process.env.PAYLOAD_ADMIN || "admin@bunadmin.test"
-const ADMIN_PW = process.env.PAYLOAD_ADMIN_PW || "bunadmin123"
+const ADMIN_EMAIL = process.env.PAYLOAD_ADMIN || "admin@dashin.test"
+const ADMIN_PW = process.env.PAYLOAD_ADMIN_PW || "dashin123"
 
 async function seed() {
   const payload = await getPayload({ config })

--- a/examples/pocketbase-demo/README.md
+++ b/examples/pocketbase-demo/README.md
@@ -42,7 +42,7 @@ dashin ai generate --url http://127.0.0.1:8090 --collection posts \
 yarn dev
 ```
 
-Sign in as `demo` / `bunadmin123`. You now have a themed, validated admin for real
+Sign in as `demo` / `dashin123`. You now have a themed, validated admin for real
 PocketBase data — see [`../../docs/ai/README.md`](../../docs/ai/README.md) for the
 full AI walkthrough.
 
@@ -69,5 +69,5 @@ above:
 - **i18n** (`t()` / `useTranslation`), dynamic routing, permission-aware menus
 
 ## Credentials
-- PocketBase admin: `admin@bunadmin.test` / `bunadmin123`
-- Demo user (app login): `demo` / `bunadmin123`
+- PocketBase admin: `admin@dashin.test` / `dashin123`
+- Demo user (app login): `demo` / `dashin123`

--- a/examples/pocketbase-demo/start.sh
+++ b/examples/pocketbase-demo/start.sh
@@ -10,8 +10,8 @@ PB_VERSION="${PB_VERSION:-0.22.21}"
 PB_PORT="${PB_PORT:-8090}"
 DIR="$(cd "$(dirname "$0")" && pwd)"
 PB_DIR="$DIR/.pb"
-ADMIN_EMAIL="${PB_ADMIN:-admin@bunadmin.test}"
-ADMIN_PW="${PB_ADMIN_PW:-bunadmin123}"
+ADMIN_EMAIL="${PB_ADMIN:-admin@dashin.test}"
+ADMIN_PW="${PB_ADMIN_PW:-dashin123}"
 
 mkdir -p "$PB_DIR"
 cd "$PB_DIR"
@@ -46,7 +46,7 @@ PB_URL="http://127.0.0.1:${PB_PORT}" PB_ADMIN="$ADMIN_EMAIL" PB_ADMIN_PW="$ADMIN
 cat <<EOF
 
 ✓ Demo backend ready: http://127.0.0.1:${PB_PORT}  (admin UI: /_/)
-  admin: ${ADMIN_EMAIL} / ${ADMIN_PW}   demo user: demo / bunadmin123
+  admin: ${ADMIN_EMAIL} / ${ADMIN_PW}   demo user: demo / dashin123
 
 Next — in another terminal:
   dashin new my-admin && cd my-admin

--- a/packages/dashin-cli/templates/typescript-nextjs/.env.example
+++ b/packages/dashin-cli/templates/typescript-nextjs/.env.example
@@ -4,9 +4,9 @@ SKIP_PREFLIGHT_CHECK=true
 
 NEXT_PUBLIC_SITE_NAME="Dashin Demo"
 NEXT_PUBLIC_AUTH_PLUGIN=@dashin-dev/auth-local
-NEXT_PUBLIC_MAIN_URL=http://blog-service.eg.bunadmin.com/api/v1
-NEXT_PUBLIC_AUTH_URL=http://blog-service.eg.bunadmin.com
-NEXT_PUBLIC_UPLOAD_URL=http://blog-service.eg.bunadmin.com
+NEXT_PUBLIC_MAIN_URL=http://blog-service.eg.dashin.dev/api/v1
+NEXT_PUBLIC_AUTH_URL=http://blog-service.eg.dashin.dev
+NEXT_PUBLIC_UPLOAD_URL=http://blog-service.eg.dashin.dev
 # NEXT_PUBLIC_FILE_PREVIEW_URL=
 NEXT_PUBLIC_SITE_URLS="http://192.168.2.2:51802/api/v1, http://192.168.2.2:51803/api/v1"
 NEXT_PUBLIC_DB_NAME=Dashin

--- a/packages/dashin-cli/templates/typescript-vite/.env.example
+++ b/packages/dashin-cli/templates/typescript-vite/.env.example
@@ -2,9 +2,9 @@
 
 VITE_SITE_NAME="Dashin Demo"
 VITE_AUTH_PLUGIN=@dashin-dev/auth-local
-VITE_MAIN_URL=http://blog-service.eg.bunadmin.com/api/v1
-VITE_AUTH_URL=http://blog-service.eg.bunadmin.com
-VITE_UPLOAD_URL=http://blog-service.eg.bunadmin.com
+VITE_MAIN_URL=http://blog-service.eg.dashin.dev/api/v1
+VITE_AUTH_URL=http://blog-service.eg.dashin.dev
+VITE_UPLOAD_URL=http://blog-service.eg.dashin.dev
 # VITE_FILE_PREVIEW_URL=
 VITE_SITE_URLS="http://192.168.2.2:51802/api/v1, http://192.168.2.2:51803/api/v1"
 VITE_DB_NAME=Dashin

--- a/packages/dashin-source-strapi/LICENSE
+++ b/packages/dashin-source-strapi/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2020-present XBuilder.net
+   Copyright 2020-present Dashin
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/packages/dashin/.env.example
+++ b/packages/dashin/.env.example
@@ -2,9 +2,9 @@
 
 VITE_SITE_NAME="Dashin Demo"
 VITE_AUTH_PLUGIN=@dashin-dev/auth-local
-VITE_MAIN_URL=http://blog-service.eg.bunadmin.com/api/v1
-VITE_AUTH_URL=http://blog-service.eg.bunadmin.com
-VITE_UPLOAD_URL=http://blog-service.eg.bunadmin.com
+VITE_MAIN_URL=http://blog-service.eg.dashin.dev/api/v1
+VITE_AUTH_URL=http://blog-service.eg.dashin.dev
+VITE_UPLOAD_URL=http://blog-service.eg.dashin.dev
 # VITE_FILE_PREVIEW_URL=
 VITE_SITE_URLS="http://192.168.2.2:51802/api/v1, http://192.168.2.2:51803/api/v1"
 VITE_DB_NAME=Dashin

--- a/packages/dashin/LICENSE
+++ b/packages/dashin/LICENSE
@@ -186,7 +186,7 @@ APPENDIX: How to apply the Apache License to your work.
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-Copyright 2020-present XBuilder.net
+Copyright 2020-present Dashin
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/dashin/example/.env.production.example
+++ b/packages/dashin/example/.env.production.example
@@ -2,9 +2,9 @@
 
 REACT_APP_SITE_NAME="Dashin Demo"
 REACT_APP_AUTH_PLUGIN=@dashin-dev/auth-strapi
-REACT_APP_MAIN_URL=http://blog-service.eg.bunadmin.com/api/v1
-REACT_APP_AUTH_URL=http://blog-service.eg.bunadmin.com
-REACT_APP_UPLOAD_URL=http://blog-service.eg.bunadmin.com
+REACT_APP_MAIN_URL=http://blog-service.eg.dashin.dev/api/v1
+REACT_APP_AUTH_URL=http://blog-service.eg.dashin.dev
+REACT_APP_UPLOAD_URL=http://blog-service.eg.dashin.dev
 # REACT_APP_FILE_PREVIEW_URL=
 REACT_APP_SITE_URLS="http://192.168.2.2:51802/api/v1, http://192.168.2.2:51803/api/v1"
 REACT_APP_I18N_CODE=en

--- a/plugins/auth-strapi/LICENSE
+++ b/plugins/auth-strapi/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2020-present XBuilder.net
+   Copyright 2020-present Dashin
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/plugins/docs/LICENSE
+++ b/plugins/docs/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2020-present XBuilder.net
+   Copyright 2020-present Dashin
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/plugins/docs/getting-started/remote-data.mdx
+++ b/plugins/docs/getting-started/remote-data.mdx
@@ -12,14 +12,14 @@ In this tutorial, we will:
 
 ## Online demo
 
-[http://blog.eg.bunadmin.com/](http://blog.eg.bunadmin.com/blog/post)
+[http://blog.eg.dashin.dev/](http://blog.eg.dashin.dev/blog/post)
 
 **_It takes less time but has restricted permissions, and the test data will be reset from time to time_**
 
 Login with any user below (different menus)
 
 - Username: `admin`, `reviewer`, `user`
-- Password: `bunadmin`
+- Password: `dashin`
 
 ## Local test
 
@@ -93,13 +93,13 @@ Open [http://localhost:1911/](http://localhost:1911/)
 Login with any user below (different menus):
 
 - Username: `admin`, `reviewer`, `user`
-- Password: `bunadmin`
+- Password: `dashin`
 
 Strapi super administrator:
 
 - Dashboard: [`http://localhost:1337/admin/`](http://localhost:1337/admin/)
-- Username: `bunadmin_example_strapi`
-- Password: `bunadmin`
+- Username: `dashin_example_strapi`
+- Password: `dashin`
 
 **_Due to the security mechanism of Strapi, Strapi dashboard users and front-end users adopt different APIs. Therefore, in this example, the Strapi super administrator cannot login through dashin._**
 

--- a/plugins/upload-strapi/LICENSE
+++ b/plugins/upload-strapi/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2020-present XBuilder.net
+   Copyright 2020-present Dashin
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Removes the **last** brand strings from the tree (20 files). After this, the only file containing `bunadmin`/`xbuilder` is `CHANGELOG.md` — by design (it documents the BunAdmin→Dashin migration).

- **Demo credentials** renamed *consistently* across the seed scripts / docker-compose that **create** them and the docs that **document** them, so the demos still work end-to-end:
  - `bunadmin123` → `dashin123`; `admin@bunadmin.test` → `admin@dashin.test`; password `bunadmin` → `dashin`; `bunadmin_example_strapi` → `dashin_example_strapi`
- **Host URLs** `*.bunadmin.com` → `*.dashin.dev` (env examples + the remote-data tutorial)
- **LICENSE** copyright `XBuilder.net` → `Dashin` (×5)

### Note
The `*.dashin.dev` demo hosts and the Strapi remote-data backend **don't exist yet** — they go live when the demo host is stood up (the open dashin.dev-host task). They were already pointing at the old brand's hosts, so there's no functional regression; this just makes the brand consistent.

After merge, `git grep -i "bunadmin\|xbuilder"` returns only `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)