### PR TITLE
build(deploy): SPA _redirects for the demo (CF Pages flow)

### DIFF
--- a/packages/dashin/public/_redirects
+++ b/packages/dashin/public/_redirects
@@ -1,0 +1,5 @@
+# SPA fallback for Cloudflare Pages: serve index.html for client-side routes.
+# (Vite copies public/ to the build output, so this lands at dist/_redirects.)
+# The Workers flow handles this via wrangler.demo.jsonc's not_found_handling;
+# this file makes the Pages "Build output directory" flow work too.
+/*    /index.html    200


### PR DESCRIPTION
Adds `packages/dashin/public/_redirects` (`/* /index.html 200`) so the demo SPA's deep links/refreshes don't 404 when deployed via Cloudflare's **Pages** (Build-output-directory) git flow — the same way the docs deploy. The Workers flow already handles this via `wrangler.demo.jsonc`; this covers both. Verified it lands at `dist/_redirects` after `vite build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)