### PR TITLE
feat(connector): add @dashin-dev/source-d1 (Cloudflare D1 data source)

### DIFF
--- a/packages/dashin-source-d1/controllers/bulkDeleteCtrl.tsx
+++ b/packages/dashin-source-d1/controllers/bulkDeleteCtrl.tsx
@@ -1,0 +1,19 @@
+import React from "react"
+import { Action, BulkDeleteProps } from "@dashin-dev/dashin"
+// @ts-ignore
+import { EvaIcon } from "@dashin-dev/dashin"
+import { bulkDeleteSer } from "../services/bulk"
+
+export default function bulkDeleteCtrl<RowData extends object>(props: BulkDeleteProps): Action<RowData> {
+  const { t, SchemaName, tableRef, primaryKey } = props
+  return {
+    tooltip: t("Delete all selected rows"),
+    icon: () => <EvaIcon name="trash-2-outline" size="large" fill="gray" />,
+    onClick: async (_e, data) => {
+      data = data as RowData[]
+      if (!data.length) return
+      await bulkDeleteSer({ data, t, SchemaName, tableRef, primaryKey })
+      tableRef.current && tableRef.current.onQueryChange()
+    }
+  }
+}

--- a/packages/dashin-source-d1/controllers/dataCtrl.ts
+++ b/packages/dashin-source-d1/controllers/dataCtrl.ts
@@ -1,0 +1,28 @@
+import listSer from "../services/listSer"
+import { DataCtrl, ListService } from "../types"
+import { notice, QueryResult } from "@dashin-dev/dashin"
+
+export default async function dataCtrl<RowData extends object>({
+  t,
+  listService,
+  ...sharedProps
+}: DataCtrl<RowData>): Promise<QueryResult<RowData>> {
+  const { path, tableQuery } = sharedProps
+  let data: any, errors, totalCount = 0
+
+  if (listService) {
+    const r = await listService(); data = r.data; errors = r.errors; totalCount = r.totalCount
+  } else if (path) {
+    const r = await listSer({ path, ...sharedProps } as ListService<RowData>)
+    data = r.data; errors = r.errors; totalCount = r.totalCount
+  } else {
+    await notice({ title: t ? t("One of the listService or path is required") : "path required", severity: "error" })
+    return { page: tableQuery.page, data: [], totalCount: 0 }
+  }
+
+  if (errors) {
+    await notice({ title: t ? t("Request Failed") : "Request Failed", severity: "error", content: JSON.stringify(errors) })
+    return { page: tableQuery.page, data: [], totalCount: 0 }
+  }
+  return { page: tableQuery.page, data, totalCount }
+}

--- a/packages/dashin-source-d1/controllers/editableCtrl.ts
+++ b/packages/dashin-source-d1/controllers/editableCtrl.ts
@@ -1,0 +1,12 @@
+import { EditableCtrl, EditableDataType } from "@dashin-dev/dashin"
+import { addSer, updateSer, deleteSer } from "../services/crud"
+import { bulkUpdateSer } from "../services/bulk"
+
+export default function editableCtrl({ t, SchemaName, disableAdd }: EditableCtrl): EditableDataType<any> {
+  return {
+    onRowAdd: disableAdd ? undefined : async newData => await addSer({ t, SchemaName, newData }),
+    onRowUpdate: async (newData, oldData) => await updateSer({ t, SchemaName, newData, oldData }),
+    onBulkUpdate: async changes => await bulkUpdateSer({ t, SchemaName, changes }),
+    onRowDelete: async oldData => await deleteSer({ t, SchemaName, oldData })
+  }
+}

--- a/packages/dashin-source-d1/controllers/index.ts
+++ b/packages/dashin-source-d1/controllers/index.ts
@@ -1,0 +1,3 @@
+export { default as dataCtrl } from "./dataCtrl"
+export { default as editableCtrl } from "./editableCtrl"
+export { default as bulkDeleteCtrl } from "./bulkDeleteCtrl"

--- a/packages/dashin-source-d1/index.ts
+++ b/packages/dashin-source-d1/index.ts
@@ -1,0 +1,11 @@
+import { Query } from "@dashin-dev/dashin"
+
+export interface DataCtrl extends EditableCtrl {
+  query: Query<any>
+}
+export interface EditableCtrl {
+  SchemaName: string
+}
+
+export * from "./services"
+export * from "./controllers"

--- a/packages/dashin-source-d1/package.json
+++ b/packages/dashin-source-d1/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@dashin-dev/source-d1",
+  "version": "2.0.0-alpha.0",
+  "publishConfig": { "access": "public" },
+  "license": "Apache-2.0",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "files": ["lib"],
+  "devDependencies": {
+    "@dashin-dev/dashin": "^2.0.0-alpha.0",
+    "prettier": "1.19.1",
+    "typescript": "4.8.3",
+    "vitest": "^1.6.0"
+  },
+  "scripts": {
+    "tsc:watch": "tsc -w",
+    "tsc:clean": "tsc --build --clean",
+    "tsc:build": "tsc",
+    "test": "vitest run"
+  }
+}

--- a/packages/dashin-source-d1/services/__tests__/bulk.test.ts
+++ b/packages/dashin-source-d1/services/__tests__/bulk.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+const execute = vi.fn()
+vi.mock("../client", () => ({ execute: (...a: any[]) => execute(...a) }))
+vi.mock("@dashin-dev/dashin", () => ({ notice: vi.fn() }))
+
+import { bulkDeleteSer, bulkUpdateSer } from "../bulk"
+
+const t = (s: string) => s
+
+describe("d1 bulk services", () => {
+  beforeEach(() => execute.mockReset().mockResolvedValue({ rows: [], affectedRows: 1 }))
+
+  it("bulkDelete issues one DELETE per row", async () => {
+    await bulkDeleteSer({ t, SchemaName: "posts", data: [{ id: 1 }, { id: 2 }] } as any)
+    expect(execute).toHaveBeenCalledTimes(2)
+    expect(execute.mock.calls[0][0].sql).toContain('DELETE FROM "posts"')
+    expect(execute.mock.calls[1][0].args).toEqual([2])
+  })
+
+  it("bulkUpdate issues one UPDATE per change", async () => {
+    await bulkUpdateSer({
+      t, SchemaName: "posts",
+      changes: { a: { oldData: { id: 1 }, newData: { name: "x" } } }
+    } as any)
+    expect(execute.mock.calls[0][0].sql).toContain('UPDATE "posts"')
+    expect(execute.mock.calls[0][0].args).toEqual(["x", 1])
+  })
+})

--- a/packages/dashin-source-d1/services/__tests__/crud.test.ts
+++ b/packages/dashin-source-d1/services/__tests__/crud.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+const execute = vi.fn()
+vi.mock("../client", () => ({ execute: (...a: any[]) => execute(...a) }))
+vi.mock("@dashin-dev/dashin", () => ({ EditableCtrl: {}, notice: vi.fn() }))
+
+import { addSer, updateSer, deleteSer } from "../crud"
+
+const t = (s: string) => s
+
+describe("d1 CRUD services", () => {
+  beforeEach(() => execute.mockReset().mockResolvedValue({ rows: [], affectedRows: 1 }))
+
+  it("add builds INSERT", async () => {
+    await addSer({ t, SchemaName: "posts", newData: { name: "a", views: 3 } } as any)
+    const stmt = execute.mock.calls[0][0]
+    expect(stmt.sql).toBe('INSERT INTO "posts" ("name", "views") VALUES (?, ?)')
+    expect(stmt.args).toEqual(["a", 3])
+  })
+
+  it("update builds UPDATE ... WHERE id=?", async () => {
+    await updateSer({ t, SchemaName: "posts", newData: { name: "b" }, oldData: { id: 9 } } as any)
+    const stmt = execute.mock.calls[0][0]
+    expect(stmt.sql).toBe('UPDATE "posts" SET "name" = ? WHERE "id" = ?')
+    expect(stmt.args).toEqual(["b", 9])
+  })
+
+  it("delete builds DELETE ... WHERE id=?", async () => {
+    await deleteSer({ t, SchemaName: "posts", oldData: { id: 9 } } as any)
+    const stmt = execute.mock.calls[0][0]
+    expect(stmt.sql).toBe('DELETE FROM "posts" WHERE "id" = ?')
+    expect(stmt.args).toEqual([9])
+  })
+})

--- a/packages/dashin-source-d1/services/__tests__/listSer.test.ts
+++ b/packages/dashin-source-d1/services/__tests__/listSer.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+// Mock the D1 client so listSer is tested without a network.
+const execute = vi.fn()
+vi.mock("../client", () => ({ execute: (...a: any[]) => execute(...a) }))
+// listSer also imports nothing else from @dashin-dev/dashin directly, but sql.ts does not.
+
+import listSer from "../listSer"
+
+const query = {
+  search: "",
+  filters: [{ column: { field: "status" }, operator: "=", value: "Published" }],
+  orderBy: { field: "views" },
+  orderDirection: "desc",
+  page: 0,
+  pageSize: 20
+}
+
+describe("d1 listSer", () => {
+  beforeEach(() => execute.mockReset())
+
+  it("runs COUNT then SELECT, returns rows + COUNT total", async () => {
+    execute
+      .mockResolvedValueOnce({ rows: [{ c: 3 }], affectedRows: 0 }) // count
+      .mockResolvedValueOnce({ rows: [{ id: 1 }, { id: 2 }, { id: 3 }], affectedRows: 0 }) // select
+    const res = await listSer({ tableQuery: query as any, path: "posts" })
+
+    // first call = COUNT stmt, second = SELECT stmt
+    expect(execute.mock.calls[0][0].sql).toContain("COUNT(*)")
+    expect(execute.mock.calls[1][0].sql).toContain("SELECT * FROM")
+    expect(execute.mock.calls[1][0].sql).toContain("LIMIT ? OFFSET ?")
+    expect(res.data.length).toBe(3)
+    expect(res.totalCount).toBe(3)
+  })
+
+  it("surfaces an execute error", async () => {
+    execute.mockResolvedValue({ rows: [], affectedRows: 0, error: { message: "boom" } })
+    const res = await listSer({ tableQuery: { ...query, filters: [] } as any, path: "posts" })
+    expect(res.errors).toBeTruthy()
+    expect(res.totalCount).toBe(0)
+  })
+})

--- a/packages/dashin-source-d1/services/__tests__/sql.test.ts
+++ b/packages/dashin-source-d1/services/__tests__/sql.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest"
+import {
+  ident,
+  buildWhere,
+  buildSelect,
+  buildCount,
+  buildInsert,
+  buildUpdate,
+  buildDelete
+} from "../sql"
+
+const f = (field: string, operator: string, value: any) =>
+  ({ column: { field }, operator, value } as any)
+
+describe("ident (injection guard)", () => {
+  it("quotes valid identifiers", () => {
+    expect(ident("status")).toBe('"status"')
+  })
+  it("rejects unsafe identifiers", () => {
+    expect(() => ident("a; DROP TABLE users")).toThrow()
+    expect(() => ident('a" OR 1=1')).toThrow()
+  })
+})
+
+describe("buildWhere", () => {
+  it("binds values as params, never interpolates", () => {
+    const { clause, args } = buildWhere([f("status", "=", "Published")])
+    expect(clause).toBe(' WHERE "status" = ?')
+    expect(args).toEqual(["Published"])
+  })
+  it("maps contains -> LIKE %v% and not-contains -> NOT LIKE", () => {
+    expect(buildWhere([f("name", "_cs=", "ab")]).args).toEqual(["%ab%"])
+    expect(buildWhere([f("name", "_ncs=", "ab")]).clause).toContain("NOT LIKE")
+  })
+  it("appends search on the search field", () => {
+    const { clause, args } = buildWhere([], "hi", "name")
+    expect(clause).toBe(' WHERE "name" LIKE ?')
+    expect(args).toEqual(["%hi%"])
+  })
+  it("skips empty values", () => {
+    expect(buildWhere([f("a", "=", "")]).clause).toBe("")
+  })
+})
+
+describe("buildSelect / buildCount", () => {
+  const q = {
+    search: "",
+    filters: [f("status", "=", "Published")],
+    orderBy: { field: "views" },
+    orderDirection: "desc",
+    page: 2,
+    pageSize: 10
+  }
+  it("select adds ORDER BY + LIMIT/OFFSET as params", () => {
+    const s = buildSelect("posts", q)
+    expect(s.sql).toBe(
+      'SELECT * FROM "posts" WHERE "status" = ? ORDER BY "views" DESC LIMIT ? OFFSET ?'
+    )
+    expect(s.args).toEqual(["Published", 10, 20])
+  })
+  it("count uses same filters, no limit", () => {
+    const c = buildCount("posts", q)
+    expect(c.sql).toBe('SELECT COUNT(*) AS c FROM "posts" WHERE "status" = ?')
+    expect(c.args).toEqual(["Published"])
+  })
+})
+
+describe("insert / update / delete", () => {
+  it("insert binds all columns", () => {
+    const s = buildInsert("posts", { name: "x", views: 3 })
+    expect(s.sql).toBe('INSERT INTO "posts" ("name", "views") VALUES (?, ?)')
+    expect(s.args).toEqual(["x", 3])
+  })
+  it("update excludes pk from SET, binds pk last", () => {
+    const s = buildUpdate("posts", { id: 9, name: "y" }, "id", 9)
+    expect(s.sql).toBe('UPDATE "posts" SET "name" = ? WHERE "id" = ?')
+    expect(s.args).toEqual(["y", 9])
+  })
+  it("delete by pk", () => {
+    const s = buildDelete("posts", "id", 9)
+    expect(s.sql).toBe('DELETE FROM "posts" WHERE "id" = ?')
+    expect(s.args).toEqual([9])
+  })
+})

--- a/packages/dashin-source-d1/services/bulk.ts
+++ b/packages/dashin-source-d1/services/bulk.ts
@@ -1,0 +1,40 @@
+import { notice, BulkDeleteProps, BulkUpdateProps } from "@dashin-dev/dashin"
+import { buildDelete, buildUpdate } from "./sql"
+import { execute } from "./client"
+
+async function batchNotice(t: any, n: number, ok: number, fail: number) {
+  await notice({
+    title: t(`Batch Request Completed`),
+    severity: ok === n ? "success" : fail === n ? "error" : "info",
+    content: `${n} items${ok ? `, ${ok} success` : ""}${fail ? `, ${fail} failure.` : ""}`
+  })
+}
+
+export async function bulkDeleteSer<T extends object>({
+  t, SchemaName, primaryKey = "id", data
+}: BulkDeleteProps & { data: T[] }) {
+  let ok = 0, fail = 0
+  const resList: any[] = []
+  for (const item of data) {
+    // @ts-ignore
+    const res = await execute(buildDelete(SchemaName, primaryKey, item[primaryKey]))
+    resList.push(res)
+    res.error ? fail++ : ok++
+  }
+  await batchNotice(t, data.length, ok, fail)
+  return resList
+}
+
+export async function bulkUpdateSer<T>({ t, SchemaName, changes }: BulkUpdateProps<T>) {
+  const list = Object.values(changes)
+  let ok = 0, fail = 0
+  const resList: any[] = []
+  for (const c of list) {
+    const { oldData, newData } = c as any
+    const res = await execute(buildUpdate(SchemaName, newData, "id", oldData.id))
+    resList.push(res)
+    res.error ? fail++ : ok++
+  }
+  await batchNotice(t, list.length, ok, fail)
+  return resList
+}

--- a/packages/dashin-source-d1/services/client.ts
+++ b/packages/dashin-source-d1/services/client.ts
@@ -1,0 +1,39 @@
+/**
+ * Cloudflare D1 HTTP client. Executes a statement via `POST /query` against the
+ * D1 gateway Worker (see workers/d1-demo-api) and returns its decoded rows.
+ *
+ * Wire format (kept deliberately simple — the Worker runs the SQL on D1):
+ *   request:  { sql: string, args: any[] }
+ *   response: { rows: object[], rowsAffected: number }  // success
+ *             { error: any }                            // query/guard error
+ */
+import { ENV, request, storedToken } from "@dashin-dev/dashin"
+import { Stmt } from "./sql"
+
+/** Coerce a JS value into something D1's bind() accepts (string/number/null). */
+function arg(v: any): any {
+  if (v === undefined) return null
+  if (typeof v === "boolean") return v ? 1 : 0
+  return v
+}
+
+/** Execute one SQL statement against the D1 gateway Worker. */
+export async function execute(
+  stmt: Stmt,
+  prefix?: string
+): Promise<{ rows: any[]; affectedRows: number; error?: any }> {
+  const token = await storedToken()
+  const res = await request(`/query`, {
+    prefix: prefix || ENV.MAIN_URL || ENV.AUTH_URL,
+    method: "POST",
+    headers: token
+      ? { Authorization: `Bearer ${String(token).replace(/^Bearer /, "")}` }
+      : {},
+    data: { sql: stmt.sql, args: stmt.args.map(arg) }
+  })
+
+  if (!res || res.error) {
+    return { rows: [], affectedRows: 0, error: (res && res.error) || res }
+  }
+  return { rows: res.rows || [], affectedRows: res.rowsAffected || 0 }
+}

--- a/packages/dashin-source-d1/services/crud.ts
+++ b/packages/dashin-source-d1/services/crud.ts
@@ -1,0 +1,37 @@
+import { EditableCtrl, notice } from "@dashin-dev/dashin"
+import { buildInsert, buildUpdate, buildDelete } from "./sql"
+import { execute } from "./client"
+
+interface Add<R> extends EditableCtrl { newData: R }
+interface Upd<R> extends EditableCtrl { newData: R; oldData: R; primaryKey?: string }
+interface Del<R> extends EditableCtrl { oldData: R; primaryKey?: string }
+
+export async function addSer({ t, SchemaName, newData }: Add<any>) {
+  const res = await execute(buildInsert(SchemaName, newData))
+  await notice(
+    res.error
+      ? { title: t("Create Failed"), severity: "warning", content: res.error }
+      : { title: t("Created"), severity: "success" }
+  )
+  return res
+}
+
+export async function updateSer({ t, SchemaName, newData, oldData, primaryKey = "id" }: Upd<any>) {
+  const res = await execute(buildUpdate(SchemaName, newData, primaryKey, oldData[primaryKey]))
+  await notice(
+    res.error
+      ? { title: t("Save Failed"), severity: "warning", content: JSON.stringify({ errors: res.error, newData }) }
+      : { title: t("Changes Saved"), severity: "success" }
+  )
+  return res
+}
+
+export async function deleteSer({ t, SchemaName, oldData, primaryKey = "id" }: Del<any>) {
+  const res = await execute(buildDelete(SchemaName, primaryKey, oldData[primaryKey]))
+  await notice(
+    res.error
+      ? { title: t("Delete Failed"), severity: "warning", content: JSON.stringify(oldData) }
+      : { title: t("Deleted"), severity: "success" }
+  )
+  return res
+}

--- a/packages/dashin-source-d1/services/index.ts
+++ b/packages/dashin-source-d1/services/index.ts
@@ -1,0 +1,5 @@
+export { addSer, updateSer, deleteSer } from "./crud"
+export { default as listSer } from "./listSer"
+export { bulkDeleteSer, bulkUpdateSer } from "./bulk"
+export * from "./sql"
+export { execute } from "./client"

--- a/packages/dashin-source-d1/services/listSer.ts
+++ b/packages/dashin-source-d1/services/listSer.ts
@@ -1,0 +1,25 @@
+/**
+ * Remote data controller (Cloudflare D1) — SELECT + COUNT via POST /query.
+ */
+import { ListService } from "../types"
+import { buildSelect, buildCount } from "./sql"
+import { execute } from "./client"
+
+export default async function listSer<RowData extends object>({
+  tableQuery,
+  path,
+  prefix,
+  searchField = "name"
+}: ListService<RowData>) {
+  const countRes = await execute(buildCount(path, tableQuery, searchField), prefix)
+  const listRes = await execute(buildSelect(path, tableQuery, searchField), prefix)
+
+  const errors = listRes.error || countRes.error
+  const total = countRes.rows[0] ? Number(countRes.rows[0].c) : listRes.rows.length
+
+  return {
+    data: listRes.rows || [],
+    totalCount: errors ? 0 : total,
+    errors
+  }
+}

--- a/packages/dashin-source-d1/services/sql.ts
+++ b/packages/dashin-source-d1/services/sql.ts
@@ -1,0 +1,118 @@
+/**
+ * Pure SQL builders for Cloudflare D1. VALUES are always bound parameters (`?`)
+ * — never string-interpolated — so this is injection-safe. Identifiers
+ * (table/column names) can't be parameters, so they're validated against a
+ * strict pattern and quoted. Testable core of the connector.
+ */
+import { Filter } from "@dashin-dev/dashin"
+
+/** A SQL statement with bound args, in D1 stmt shape. */
+export interface Stmt {
+  sql: string
+  args: any[]
+}
+
+const IDENT = /^[A-Za-z_][A-Za-z0-9_]*$/
+
+/** Validate + quote a SQL identifier (table/column). Throws on anything unsafe. */
+export function ident(name: string): string {
+  if (!IDENT.test(name)) throw new Error(`unsafe SQL identifier: ${JSON.stringify(name)}`)
+  return `"${name}"`
+}
+
+/** Map a dashin operator to a SQL operator + value transform (for LIKE). */
+function sqlOp(operator: string, value: any): { op: string; val: any } {
+  switch (operator) {
+    case "!=":
+      return { op: "!=", val: value }
+    case ">":
+      return { op: ">", val: value }
+    case ">=":
+      return { op: ">=", val: value }
+    case "<":
+      return { op: "<", val: value }
+    case "<=":
+      return { op: "<=", val: value }
+    case "_ncs=":
+    case "_nc=":
+      return { op: "NOT LIKE", val: `%${value}%` }
+    case "=":
+      return { op: "=", val: value }
+    case "_cs=":
+    case "_c=":
+    default:
+      return { op: "LIKE", val: `%${value}%` }
+  }
+}
+
+/** Build the WHERE clause (+ args) from table filters + optional search. */
+export function buildWhere(
+  filters: Filter<any>[],
+  searchWords?: string,
+  searchField = "name"
+): { clause: string; args: any[] } {
+  const parts: string[] = []
+  const args: any[] = []
+  filters.forEach(({ column: { field }, operator, value }) => {
+    if (!field || value === undefined || value === "") return
+    const { op, val } = sqlOp(operator as string, value)
+    parts.push(`${ident(String(field))} ${op} ?`)
+    args.push(val)
+  })
+  if (searchWords) {
+    parts.push(`${ident(searchField)} LIKE ?`)
+    args.push(`%${searchWords}%`)
+  }
+  return { clause: parts.length ? ` WHERE ${parts.join(" AND ")}` : "", args }
+}
+
+/** SELECT with filters, sort, pagination. */
+export function buildSelect(
+  table: string,
+  tableQuery: any,
+  searchField = "name"
+): Stmt {
+  const { search, filters = [], orderBy, orderDirection, page = 0, pageSize = 20 } = tableQuery
+  const { clause, args } = buildWhere(filters, search, searchField)
+  let sql = `SELECT * FROM ${ident(table)}${clause}`
+  if (orderBy && orderBy.field) {
+    sql += ` ORDER BY ${ident(String(orderBy.field))} ${orderDirection === "desc" ? "DESC" : "ASC"}`
+  }
+  sql += ` LIMIT ? OFFSET ?`
+  return { sql, args: [...args, pageSize, page * pageSize] }
+}
+
+/** COUNT(*) with the same filters (for totalCount). */
+export function buildCount(table: string, tableQuery: any, searchField = "name"): Stmt {
+  const { search, filters = [] } = tableQuery
+  const { clause, args } = buildWhere(filters, search, searchField)
+  return { sql: `SELECT COUNT(*) AS c FROM ${ident(table)}${clause}`, args }
+}
+
+/** INSERT from a row object. */
+export function buildInsert(table: string, data: Record<string, any>): Stmt {
+  const keys = Object.keys(data)
+  const cols = keys.map(ident).join(", ")
+  const ph = keys.map(() => "?").join(", ")
+  return { sql: `INSERT INTO ${ident(table)} (${cols}) VALUES (${ph})`, args: keys.map(k => data[k]) }
+}
+
+/** UPDATE by primary key. */
+export function buildUpdate(
+  table: string,
+  data: Record<string, any>,
+  pk: string,
+  pkValue: any
+): Stmt {
+  const keys = Object.keys(data).filter(k => k !== pk)
+  const set = keys.map(k => `${ident(k)} = ?`).join(", ")
+  return {
+    sql: `UPDATE ${ident(table)} SET ${set} WHERE ${ident(pk)} = ?`,
+    args: [...keys.map(k => data[k]), pkValue]
+  }
+}
+
+/** DELETE by primary key. */
+export function buildDelete(table: string, pk: string, pkValue: any): Stmt {
+  return { sql: `DELETE FROM ${ident(table)} WHERE ${ident(pk)} = ?`, args: [pkValue] }
+}

--- a/packages/dashin-source-d1/tsconfig.json
+++ b/packages/dashin-source-d1/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig",
+  "compilerOptions": {
+    "rootDir": "./",
+    "outDir": "./lib",
+    "declaration": true,
+    "declarationDir": "./lib",
+    "baseUrl": "./"
+  },
+  "exclude": ["node_modules", "lib", "**/__tests__/**", "**/*.test.ts", "**/*.test.tsx"],
+  "include": ["*.ts", "*.tsx"]
+}

--- a/packages/dashin-source-d1/types.ts
+++ b/packages/dashin-source-d1/types.ts
@@ -1,0 +1,19 @@
+import { TFunction } from "i18next"
+import { Query, ListServiceRes } from "@dashin-dev/dashin"
+
+export type DataCtrl<RowData extends object> = {
+  t?: TFunction
+  listService?: () => Promise<ListServiceRes>
+  tableQuery: ListService<RowData>["tableQuery"]
+  path?: ListService<RowData>["path"]
+  prefix?: ListService<RowData>["prefix"]
+  searchField?: ListService<RowData>["searchField"]
+}
+
+export type ListService<RowData extends object> = {
+  tableQuery: Query<RowData>
+  /** SQLite table name */
+  path: string
+  prefix?: string
+  searchField?: "name" | string
+}

--- a/packages/dashin/vite.config.ts
+++ b/packages/dashin/vite.config.ts
@@ -117,6 +117,10 @@ export default defineConfig(({ mode }) => {
           replacement: r("../dashin-source-turso/index.ts")
         },
         {
+          find: /^@dashin-dev\/source-d1$/,
+          replacement: r("../dashin-source-d1/index.ts")
+        },
+        {
           find: /^@dashin-dev\/rich-text-editor$/,
           replacement: r("../dashin-rich-text-editor/index.tsx")
         },


### PR DESCRIPTION
First of 3 PRs adding **Cloudflare D1** support (the all-free-on-Cloudflare backend). This one is the **connector package**.

D1 is serverless SQLite, so the connector reuses the Turso connector's proven, injection-safe SQL builders (`services/sql.ts`) **verbatim** and only swaps the transport:
- **`services/client.ts`** — `POST /query { sql, args }` to a D1 gateway Worker (added in PR #2), decodes `{ rows, rowsAffected }`. Simpler than libSQL (no typed-arg encoding); coerces booleans → 0/1, undefined → null for D1's `bind()`.
- Identical public API to every other connector: `dataCtrl` / `editableCtrl` / `bulkDeleteCtrl` + services. Wired via a Vite alias (`@dashin-dev/source-d1` → `../dashin-source-d1/index.ts`).

### Verified
- **18 unit tests pass** (sql / crud / listSer / bulk — the SQL builders + mocked transport).
- `tsc` builds the package clean.

### Next PRs
- (2) `workers/d1-demo-api` — the D1 HTTP gateway Worker + 30-min reset cron + SQL guard.
- (3) demo wiring + end-to-end local verification (Playwright on a live D1-backed table) + deploy docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)