### PR TITLE
feat(worker): D1 gateway + 30-min reset cron for the demo

### DIFF
--- a/workers/d1-demo-api/.gitignore
+++ b/workers/d1-demo-api/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.wrangler
+.dev.vars
+package-lock.json

--- a/workers/d1-demo-api/README.md
+++ b/workers/d1-demo-api/README.md
@@ -1,0 +1,47 @@
+# dashin-d1-demo-api — Cloudflare D1 gateway for the Dashin demo
+
+A tiny Worker that exposes a Cloudflare **D1** database over HTTP so the
+browser-side [`@dashin-dev/source-d1`](../../packages/dashin-source-d1) connector
+can run its parameterised SQL. It also resets the demo data on a schedule.
+
+This is what makes a **100%-free, all-Cloudflare** Dashin demo possible: D1
+(free tier) + Workers (free tier) + Pages for the frontend (free tier).
+
+## API
+
+| Route | Body | Returns |
+|-------|------|---------|
+| `POST /query` | `{ sql, args }` | `{ rows, rowsAffected }` or `{ error }` |
+| `POST /reset` | — (Bearer `RESET_TOKEN`) | `{ ok: true }` — re-seed now |
+| `GET /health` | — | `{ ok: true }` |
+
+**Safety (public demo):** `/query` only allows `SELECT/INSERT/UPDATE/DELETE` on the
+demo tables (`posts`, `products`); DDL, multi-statements and comments are rejected.
+The `scheduled` cron (`*/30 * * * *`, in `wrangler.jsonc`) re-seeds every 30 min, so
+any visitor edits revert. There are **no server credentials** — the demo logs in
+via the client-side `auth-local` plugin.
+
+## Deploy (your Cloudflare account)
+
+```bash
+cd workers/d1-demo-api
+npm install
+
+npx wrangler d1 create dashin-demo          # paste database_id into wrangler.jsonc
+npx wrangler d1 execute dashin-demo --remote --file=schema.sql
+npx wrangler secret put RESET_TOKEN          # optional, gates /reset
+npx wrangler deploy
+curl -X POST https://<worker-url>/reset -H "Authorization: Bearer <token>"   # initial seed
+```
+
+Then point the Dashin demo frontend at the Worker URL via `VITE_MAIN_URL`.
+
+## Local development
+
+```bash
+npm install
+npx wrangler d1 execute dashin-demo --local --file=schema.sql   # create local tables
+npx wrangler dev                                                # http://localhost:8787
+curl -X POST localhost:8787/reset                               # seed (no token locally)
+curl -X POST localhost:8787/query -d '{"sql":"SELECT * FROM \"posts\"","args":[]}'
+```

--- a/workers/d1-demo-api/package.json
+++ b/workers/d1-demo-api/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "dashin-d1-demo-api",
+  "version": "0.1.0",
+  "private": true,
+  "description": "HTTP gateway over Cloudflare D1 for the Dashin source-d1 demo (query API + 30-min reset cron).",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "init:local": "wrangler d1 execute dashin-demo --local --file=schema.sql",
+    "init:remote": "wrangler d1 execute dashin-demo --remote --file=schema.sql"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20250101.0",
+    "wrangler": "^3.99.0"
+  }
+}

--- a/workers/d1-demo-api/schema.sql
+++ b/workers/d1-demo-api/schema.sql
@@ -1,0 +1,20 @@
+-- Dashin × Cloudflare D1 demo schema.
+-- Run once after creating the D1 database:
+--   npx wrangler d1 execute dashin-demo --remote --file=schema.sql
+-- (use --local to target the local miniflare D1 for development).
+-- Seed data is owned by the Worker (src/index.ts SEED) and applied via the
+-- 30-min reset cron or `POST /reset`; this file only defines the tables.
+
+CREATE TABLE IF NOT EXISTS posts (
+  id     INTEGER PRIMARY KEY AUTOINCREMENT,
+  title  TEXT    NOT NULL,
+  status TEXT    NOT NULL DEFAULT 'draft',
+  views  INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS products (
+  id       INTEGER PRIMARY KEY AUTOINCREMENT,
+  name     TEXT    NOT NULL,
+  price    REAL    NOT NULL DEFAULT 0,
+  in_stock INTEGER NOT NULL DEFAULT 1
+);

--- a/workers/d1-demo-api/src/index.ts
+++ b/workers/d1-demo-api/src/index.ts
@@ -1,0 +1,119 @@
+/**
+ * Dashin D1 demo gateway Worker.
+ *
+ * Exposes a tiny HTTP API over a Cloudflare D1 database so the browser-side
+ * `@dashin-dev/source-d1` connector can run its (injection-safe, parameterised)
+ * SQL:
+ *   POST /query  { sql, args }  -> { rows, rowsAffected } | { error }
+ *   POST /reset                 -> re-seed (also runs on a cron) [token-gated]
+ *
+ * Public-demo safety:
+ *  - A SQL guard allows only SELECT/INSERT/UPDATE/DELETE on the demo tables,
+ *    rejects DDL, multi-statements and comments.
+ *  - A `scheduled` cron re-seeds the data every 30 min (see wrangler.jsonc), so
+ *    anything a visitor changes reverts. There are no server-side credentials
+ *    (the demo logs in via the client-side auth-local plugin).
+ */
+
+export interface Env {
+  DB: D1Database
+  /** Optional bearer token gating POST /reset (set via `wrangler secret put`). */
+  RESET_TOKEN?: string
+}
+
+const ALLOWED_TABLES = ["posts", "products"]
+
+/** The seed = single source of truth for demo data. Run on reset + cron. */
+const SEED: string[] = [
+  `DELETE FROM posts`,
+  `DELETE FROM products`,
+  `INSERT INTO posts (title, status, views) VALUES
+     ('Welcome to the Dashin × Cloudflare D1 demo', 'published', 1280),
+     ('Edit me — everything resets every 30 minutes', 'published', 342),
+     ('Draft: this admin runs 100% free on Cloudflare', 'draft', 12)`,
+  `INSERT INTO products (name, price, in_stock) VALUES
+     ('Starter', 0, 1),
+     ('Pro', 19, 1),
+     ('Enterprise', 99, 0)`
+]
+
+const CORS: Record<string, string> = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization"
+}
+
+const json = (body: unknown, status = 200): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json", ...CORS }
+  })
+
+/** Returns an error string if the statement is not allowed, else null. */
+export function guard(sql: string): string | null {
+  const s = sql.trim()
+  if (!s) return "empty statement"
+  if (s.includes("--") || s.includes("/*")) return "comments not allowed"
+  // No inner semicolons (one statement only); a single trailing `;` is fine.
+  if (s.replace(/;\s*$/, "").includes(";")) return "multiple statements not allowed"
+  const verb = (s.match(/^([A-Za-z]+)/)?.[1] || "").toUpperCase()
+  if (!["SELECT", "INSERT", "UPDATE", "DELETE"].includes(verb))
+    return `statement not allowed: ${verb || "?"}`
+  // The connector always quotes the table identifier right after the verb/FROM.
+  const m = s.match(
+    /^(?:SELECT[\s\S]*?\bFROM|INSERT\s+INTO|UPDATE|DELETE\s+FROM)\s+"([A-Za-z_][A-Za-z0-9_]*)"/i
+  )
+  if (!m) return "could not identify target table"
+  if (!ALLOWED_TABLES.includes(m[1])) return `table not allowed: ${m[1]}`
+  return null
+}
+
+async function reseed(env: Env): Promise<void> {
+  await env.DB.batch(SEED.map(sql => env.DB.prepare(sql)))
+}
+
+export default {
+  async fetch(req: Request, env: Env): Promise<Response> {
+    if (req.method === "OPTIONS") return new Response(null, { headers: CORS })
+    const url = new URL(req.url)
+
+    if (url.pathname === "/query" && req.method === "POST") {
+      let body: { sql?: string; args?: unknown[] }
+      try {
+        body = await req.json()
+      } catch {
+        return json({ error: "invalid JSON body" })
+      }
+      const sql = String(body.sql || "")
+      const args = Array.isArray(body.args) ? body.args : []
+      const bad = guard(sql)
+      if (bad) return json({ error: bad })
+      try {
+        const { results, meta } = await env.DB.prepare(sql)
+          .bind(...args)
+          .all()
+        return json({ rows: results ?? [], rowsAffected: meta?.changes ?? 0 })
+      } catch (e: any) {
+        return json({ error: String(e?.message || e) })
+      }
+    }
+
+    if (url.pathname === "/reset" && req.method === "POST") {
+      const auth = req.headers.get("Authorization") || ""
+      if (env.RESET_TOKEN && auth !== `Bearer ${env.RESET_TOKEN}`)
+        return json({ error: "unauthorized" }, 401)
+      await reseed(env)
+      return json({ ok: true, reset: true })
+    }
+
+    if (url.pathname === "/" || url.pathname === "/health")
+      return json({ ok: true, service: "dashin-d1-demo-api" })
+
+    return json({ error: "not found" }, 404)
+  },
+
+  // The "reset every 30 minutes" — schedule is in wrangler.jsonc (triggers.crons).
+  async scheduled(_event: ScheduledEvent, env: Env): Promise<void> {
+    await reseed(env)
+  }
+}

--- a/workers/d1-demo-api/wrangler.jsonc
+++ b/workers/d1-demo-api/wrangler.jsonc
@@ -1,0 +1,26 @@
+// Dashin D1 demo gateway Worker.
+//
+// Setup:
+//   cd workers/d1-demo-api && npm install
+//   npx wrangler d1 create dashin-demo      # paste the database_id below
+//   npx wrangler d1 execute dashin-demo --remote --file=schema.sql
+//   npx wrangler secret put RESET_TOKEN     # optional: gate POST /reset
+//   npx wrangler deploy
+//   curl -X POST https://<worker-url>/reset -H "Authorization: Bearer <token>"
+{
+  "name": "dashin-d1-demo-api",
+  "main": "src/index.ts",
+  "compatibility_date": "2025-01-01",
+  "observability": { "enabled": true },
+
+  // "reset every 30 minutes" — the scheduled() handler re-seeds the demo data.
+  "triggers": { "crons": ["*/30 * * * *"] },
+
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "dashin-demo",
+      "database_id": "REPLACE_WITH_YOUR_D1_DATABASE_ID"
+    }
+  ]
+}


### PR DESCRIPTION
PR #2 of 3 for **Cloudflare D1** support: the Worker that exposes D1 over HTTP so the browser-side `@dashin-dev/source-d1` connector (PR #104) can reach it. Together they enable a **100%-free, all-Cloudflare** Dashin demo.

### `workers/d1-demo-api`
- **`POST /query { sql, args }`** → `{ rows, rowsAffected }` — runs the connector's parameterised SQL via `env.DB.prepare().bind().all()`.
- **SQL guard** (public-demo safety): only `SELECT/INSERT/UPDATE/DELETE` on the demo tables (`posts`, `products`); rejects DDL, multi-statements, comments.
- **`scheduled()` cron `*/30 * * * *`** → re-seeds = **"data resets every 30 minutes"**. Same reseed via token-gated `POST /reset` for instant init.
- **No server credentials** — demo auth is client-side `auth-local`, so there's nothing for a visitor to change (your other requirement).
- `schema.sql` (tables) + `README.md` (deploy steps).

### Verified locally (`wrangler dev` + local D1)
```
RESET      -> {ok:true}
SELECT posts -> 3 rows (correct seed data)
INSERT     -> rowsAffected 1  (then SELECT -> 4 rows)
GUARD DROP -> "statement not allowed: DROP"
GUARD users-> "table not allowed: users"
GUARD multi-> "multiple statements not allowed"
RESET      -> posts back to 3 (reverts the edit)
```
`wrangler deploy --dry-run` bundles clean (D1 binding + cron recognized).

### Next
PR #3: demo wiring (a `source-d1` posts/products plugin) + full end-to-end local verification (Playwright on a live D1-backed table) + deploy docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)