### PR TITLE
feat(demo): D1-backed demo plugin + example + docs

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -35,7 +35,8 @@ export default defineConfig({
     "supabase/README.md": "supabase/index.md",
     "directus/README.md": "directus/index.md",
     "payload/README.md": "payload/index.md",
-    "turso/README.md": "turso/index.md"
+    "turso/README.md": "turso/index.md",
+    "d1/README.md": "d1/index.md"
   },
 
   themeConfig: {
@@ -79,7 +80,8 @@ export default defineConfig({
           { text: "Supabase / Postgres", link: "/supabase/" },
           { text: "Directus", link: "/directus/" },
           { text: "Payload", link: "/payload/" },
-          { text: "Turso / libSQL", link: "/turso/" }
+          { text: "Turso / libSQL", link: "/turso/" },
+          { text: "Cloudflare D1 (free)", link: "/d1/" }
         ]
       },
       {

--- a/docs/d1/README.md
+++ b/docs/d1/README.md
@@ -1,0 +1,64 @@
+# Cloudflare D1
+
+Run Dashin **100% free on Cloudflare** with a real SQL database.
+[`@dashin-dev/source-d1`](https://github.com/dashindev/dashin/tree/master/packages/dashin-source-d1)
+is a data-source connector for **Cloudflare D1** (serverless SQLite).
+
+Because D1 is reachable only through a Worker binding, the connector talks to a
+tiny gateway Worker that runs its (parameterised, injection-safe) SQL on D1:
+
+```
+browser (source-d1)  ──POST /query {sql,args}──▶  Worker  ──▶  Cloudflare D1
+```
+
+This is what makes an all-Cloudflare-free demo possible — Pages (frontend) +
+Workers + D1 are all on free tiers. Servers like PocketBase / Strapi / Payload
+can't run on Cloudflare; D1 can.
+
+## Setup
+
+1. **Deploy the gateway Worker + database** —
+   [`workers/d1-demo-api`](https://github.com/dashindev/dashin/tree/master/workers/d1-demo-api):
+
+   ```bash
+   cd workers/d1-demo-api && npm install
+   npx wrangler d1 create dashin-demo                     # → paste database_id into wrangler.jsonc
+   npx wrangler d1 execute dashin-demo --remote --file=schema.sql
+   npx wrangler deploy
+   curl -X POST https://<worker>.workers.dev/reset        # seed
+   ```
+
+2. **Point your admin at it** (`.env`):
+
+   ```
+   VITE_AUTH_PLUGIN=@dashin-dev/auth-local
+   VITE_MAIN_URL=https://<worker>.workers.dev
+   ```
+
+3. **Add a table** — import the connector in a plugin:
+
+   ```tsx
+   import { dataCtrl, editableCtrl, bulkDeleteCtrl } from "@dashin-dev/source-d1"
+
+   <Table
+     columns={columns({ t })}
+     data={query => dataCtrl({ t, tableQuery: query, path: "posts" })}
+     editable={editableCtrl({ t, SchemaName: "posts" })}
+     actions={[bulkDeleteCtrl({ SchemaName: "posts", t, tableRef })]}
+   />
+   ```
+
+   See the full [d1-demo example](https://github.com/dashindev/dashin/tree/master/examples/d1-demo).
+
+## Public-demo safety
+
+The gateway Worker only allows `SELECT/INSERT/UPDATE/DELETE` on the demo tables
+(rejects DDL, multi-statements, comments) and **re-seeds every 30 minutes** via a
+free Worker cron, so visitor edits revert. Auth is client-side `auth-local`, so
+there are no server credentials to change.
+
+## How it differs from the Turso connector
+
+Both are SQLite-over-HTTP and share the same SQL builders. Turso speaks the
+libSQL `/v2/pipeline` protocol directly; D1 goes through your Worker's simple
+`POST /query` — which also lets the Worker enforce the safety rules above.

--- a/examples/d1-demo/README.md
+++ b/examples/d1-demo/README.md
@@ -1,0 +1,55 @@
+# dashin Demo (Cloudflare D1) — 100% free, all-Cloudflare
+
+Run a real database-backed Dashin admin **entirely on Cloudflare's free tier**:
+
+```
+browser (Dashin + @dashin-dev/source-d1)   ->  Cloudflare Pages   (free)
+        │  POST /query
+        ▼
+   d1-demo-api Worker  ->  Cloudflare D1     (Workers + D1 free tier)
+```
+
+Unlike PocketBase / Strapi / Payload (stateful servers that can't run on
+Cloudflare), **D1 is serverless SQLite** — so there's nothing to host and no
+recurring cost.
+
+## 1. Deploy the gateway Worker + D1
+
+See [`workers/d1-demo-api`](../../workers/d1-demo-api):
+
+```bash
+cd workers/d1-demo-api && npm install
+npx wrangler d1 create dashin-demo                      # paste database_id into wrangler.jsonc
+npx wrangler d1 execute dashin-demo --remote --file=schema.sql
+npx wrangler deploy                                     # -> https://<worker>.workers.dev
+curl -X POST https://<worker>.workers.dev/reset         # seed
+```
+
+The Worker also re-seeds every 30 min (cron), so a public demo never drifts.
+
+## 2. Point a Dashin admin at it
+
+```bash
+dashin new my-admin && cd my-admin
+```
+
+`.env`:
+```
+VITE_AUTH_PLUGIN=@dashin-dev/auth-local   # client-side login (admin / dashin)
+VITE_MAIN_URL=https://<worker>.workers.dev
+```
+
+Drop [`example-admin.tsx`](./example-admin.tsx) into a plugin (a `posts` table),
+`yarn dev`, and you have a working D1-backed admin — create / edit / delete,
+filter, sort, paginate.
+
+## Why credentials can't be changed
+
+Auth is the **client-side `auth-local`** plugin: each visitor logs in locally
+(`admin` / `dashin`), so there's no shared server account to change. Data lives
+in D1 and resets on the cron.
+
+## Local development
+
+Run the Worker locally (`wrangler dev` + `--local` D1) and set
+`VITE_MAIN_URL=http://127.0.0.1:8787`. See the Worker README.

--- a/examples/d1-demo/example-admin.tsx
+++ b/examples/d1-demo/example-admin.tsx
@@ -1,0 +1,67 @@
+/**
+ * Worked example: a `posts` page backed by Cloudflare D1 (serverless SQLite)
+ * via @dashin-dev/source-d1.
+ *
+ * D1 isn't directly reachable from the browser, so the connector talks to a
+ * tiny gateway Worker (workers/d1-demo-api) that runs the SQL on D1:
+ *   browser (source-d1) -> POST {worker}/query -> D1
+ *
+ * Drop this into a dashin project's plugin and register it like any other
+ * schema plugin. Requires a `posts` table (see workers/d1-demo-api/schema.sql)
+ * and `VITE_MAIN_URL` pointed at the Worker.
+ */
+import React, { createRef } from "react"
+import {
+  Table,
+  TableHead,
+  tableIcons,
+  TableDefaultProps as DefaultProps,
+  useTranslation,
+  Column
+} from "@dashin-dev/dashin"
+import { dataCtrl, editableCtrl, bulkDeleteCtrl } from "@dashin-dev/source-d1"
+
+const theme = { dashin: { iconColor: "#8f9bb3" } }
+
+interface Post {
+  id: number
+  title: string
+  status: string
+  views: number
+}
+
+const columns = ({ t }: { t: any }): Column<Post>[] => [
+  { title: t("Id"), field: "id", editable: "never", width: 100 },
+  { title: t("Title"), field: "title" },
+  {
+    title: t("Status"),
+    field: "status",
+    lookup: { draft: "Draft", published: "Published" }
+  },
+  { title: t("Views"), field: "views", type: "numeric" }
+]
+
+export default function Posts() {
+  const { t } = useTranslation("table")
+  const tableRef = createRef()
+  const SchemaName = "posts" // D1 table name
+
+  return (
+    <>
+      <TableHead title="Posts" />
+      <Table<Post>
+        tableRef={tableRef}
+        title="Posts"
+        columns={columns({ t })}
+        style={DefaultProps.style}
+        icons={tableIcons({ theme })}
+        options={{ ...DefaultProps.options, filtering: true }}
+        data={query =>
+          dataCtrl({ t, tableQuery: query, path: SchemaName, searchField: "title" })
+        }
+        editable={editableCtrl({ t, SchemaName })}
+        actions={[bulkDeleteCtrl({ SchemaName, t, tableRef })]}
+      />
+    </>
+  )
+}

--- a/packages/dashin/src/private/plugins/dashin-plugin-dashin-d1/index.ts
+++ b/packages/dashin/src/private/plugins/dashin-plugin-dashin-d1/index.ts
@@ -1,0 +1,42 @@
+import { IPluginData } from "@dashin-dev/dashin"
+
+// A demo plugin backed by Cloudflare D1 via @dashin-dev/source-d1.
+// Point VITE_MAIN_URL at the d1-demo-api Worker to see live data.
+export { default as posts } from "./posts"
+export { default as products } from "./products"
+
+const shared = {
+  team: "dashin",
+  group: "d1",
+  customized: true
+}
+
+export const initData: IPluginData[] = [
+  {
+    ...shared,
+    id: "dashin_d1",
+    name: "dashin_d1",
+    label: "Cloudflare D1",
+    icon_type: "eva",
+    icon: "cloud-upload-outline",
+    ignore_schema: true
+  },
+  {
+    ...shared,
+    id: "dashin_d1_posts",
+    name: "posts",
+    label: "Posts",
+    icon_type: "eva",
+    icon: "file-text-outline",
+    parent: "dashin_d1"
+  },
+  {
+    ...shared,
+    id: "dashin_d1_products",
+    name: "products",
+    label: "Products",
+    icon_type: "eva",
+    icon: "shopping-bag-outline",
+    parent: "dashin_d1"
+  }
+]

--- a/packages/dashin/src/private/plugins/dashin-plugin-dashin-d1/posts/columns.tsx
+++ b/packages/dashin/src/private/plugins/dashin-plugin-dashin-d1/posts/columns.tsx
@@ -1,0 +1,16 @@
+import { TFunction } from "i18next"
+import { Column } from "@/components/Table/models/material-table-shim"
+import Type from "./types"
+
+export const columns = ({ t }: { t: TFunction }): Column<Type>[] => [
+  { title: t("Id"), field: "id", editable: "never", width: 90 },
+  { title: t("Title"), field: "title" },
+  {
+    title: t("Status"),
+    field: "status",
+    lookup: { draft: t("Draft"), published: t("Published") }
+  },
+  { title: t("Views"), field: "views", type: "numeric" }
+]
+
+export default columns

--- a/packages/dashin/src/private/plugins/dashin-plugin-dashin-d1/posts/index.tsx
+++ b/packages/dashin/src/private/plugins/dashin-plugin-dashin-d1/posts/index.tsx
@@ -1,0 +1,38 @@
+import React, { createRef } from "react"
+import {
+  Table,
+  TableHead,
+  tableIcons,
+  TableDefaultProps as DefaultProps,
+  useTranslation
+} from "@dashin-dev/dashin"
+import { bulkDeleteCtrl, dataCtrl, editableCtrl } from "@dashin-dev/source-d1"
+
+import { SchemaLabel, SchemaColumns, SchemaName } from "./plugin"
+import Type from "./types"
+
+const theme = { dashin: { iconColor: "#8f9bb3" } }
+
+export default function Posts() {
+  const { t } = useTranslation("table")
+  const tableRef = createRef()
+
+  return (
+    <>
+      <TableHead title={t(SchemaLabel)} />
+      <Table<Type>
+        tableRef={tableRef}
+        title={t(SchemaLabel)}
+        columns={SchemaColumns({ t })}
+        style={DefaultProps.style}
+        icons={tableIcons({ theme })}
+        options={{ ...DefaultProps.options, filtering: true }}
+        data={async (tableQuery: any) =>
+          await dataCtrl({ t, tableQuery, path: SchemaName, searchField: "title" })
+        }
+        editable={editableCtrl({ t, SchemaName })}
+        actions={[bulkDeleteCtrl({ SchemaName, t, tableRef })]}
+      />
+    </>
+  )
+}

--- a/packages/dashin/src/private/plugins/dashin-plugin-dashin-d1/posts/plugin.ts
+++ b/packages/dashin/src/private/plugins/dashin-plugin-dashin-d1/posts/plugin.ts
@@ -1,0 +1,7 @@
+import Columns from "./columns"
+
+export const SchemaName = "posts"
+
+export const SchemaLabel = "Posts (Cloudflare D1)"
+
+export const SchemaColumns = Columns

--- a/packages/dashin/src/private/plugins/dashin-plugin-dashin-d1/posts/types.ts
+++ b/packages/dashin/src/private/plugins/dashin-plugin-dashin-d1/posts/types.ts
@@ -1,0 +1,6 @@
+export default interface Type {
+  id: number
+  title: string
+  status: string
+  views: number
+}

--- a/packages/dashin/src/private/plugins/dashin-plugin-dashin-d1/products/columns.tsx
+++ b/packages/dashin/src/private/plugins/dashin-plugin-dashin-d1/products/columns.tsx
@@ -1,0 +1,16 @@
+import { TFunction } from "i18next"
+import { Column } from "@/components/Table/models/material-table-shim"
+import Type from "./types"
+
+export const columns = ({ t }: { t: TFunction }): Column<Type>[] => [
+  { title: t("Id"), field: "id", editable: "never", width: 90 },
+  { title: t("Name"), field: "name" },
+  { title: t("Price"), field: "price", type: "numeric" },
+  {
+    title: t("In stock"),
+    field: "in_stock",
+    lookup: { 1: t("In stock"), 0: t("Out of stock") }
+  }
+]
+
+export default columns

--- a/packages/dashin/src/private/plugins/dashin-plugin-dashin-d1/products/index.tsx
+++ b/packages/dashin/src/private/plugins/dashin-plugin-dashin-d1/products/index.tsx
@@ -1,0 +1,38 @@
+import React, { createRef } from "react"
+import {
+  Table,
+  TableHead,
+  tableIcons,
+  TableDefaultProps as DefaultProps,
+  useTranslation
+} from "@dashin-dev/dashin"
+import { bulkDeleteCtrl, dataCtrl, editableCtrl } from "@dashin-dev/source-d1"
+
+import { SchemaLabel, SchemaColumns, SchemaName } from "./plugin"
+import Type from "./types"
+
+const theme = { dashin: { iconColor: "#8f9bb3" } }
+
+export default function Products() {
+  const { t } = useTranslation("table")
+  const tableRef = createRef()
+
+  return (
+    <>
+      <TableHead title={t(SchemaLabel)} />
+      <Table<Type>
+        tableRef={tableRef}
+        title={t(SchemaLabel)}
+        columns={SchemaColumns({ t })}
+        style={DefaultProps.style}
+        icons={tableIcons({ theme })}
+        options={{ ...DefaultProps.options, filtering: true }}
+        data={async (tableQuery: any) =>
+          await dataCtrl({ t, tableQuery, path: SchemaName, searchField: "name" })
+        }
+        editable={editableCtrl({ t, SchemaName })}
+        actions={[bulkDeleteCtrl({ SchemaName, t, tableRef })]}
+      />
+    </>
+  )
+}

--- a/packages/dashin/src/private/plugins/dashin-plugin-dashin-d1/products/plugin.ts
+++ b/packages/dashin/src/private/plugins/dashin-plugin-dashin-d1/products/plugin.ts
@@ -1,0 +1,7 @@
+import Columns from "./columns"
+
+export const SchemaName = "products"
+
+export const SchemaLabel = "Products (Cloudflare D1)"
+
+export const SchemaColumns = Columns

--- a/packages/dashin/src/private/plugins/dashin-plugin-dashin-d1/products/types.ts
+++ b/packages/dashin/src/private/plugins/dashin-plugin-dashin-d1/products/types.ts
@@ -1,0 +1,6 @@
+export default interface Type {
+  id: number
+  name: string
+  price: number
+  in_stock: number
+}


### PR DESCRIPTION
PR #3 of 3 for **Cloudflare D1** — wires the connector (#104) to the Worker (#105) as a working demo, with the all-free-on-Cloudflare docs.

### What's here
- **`src/private/plugins/dashin-plugin-dashin-d1`** — a "Cloudflare D1" sidebar group with **Posts** + **Products** tables backed by `@dashin-dev/source-d1`. Point `VITE_MAIN_URL` at the gateway Worker to see live data.
- **`examples/d1-demo`** — copy-paste example + README (deploy Worker → set env → add a table).
- **`docs/d1`** — connector guide; added to the Connectors sidebar.

### Verified end-to-end (locally, no CF account)
Built the app with `VITE_MAIN_URL` → a `wrangler dev` local-D1 Worker, then drove it in a real browser:

> The Dashin admin renders the **live D1 `posts` table** — 3 seed rows, status pills (Published/Draft), view counts, edit/delete actions, filters/search — confirmed by **4 successful `POST /query`** calls to the Worker.

App **vitest 99/99** + **app typecheck** pass; `vite build` clean.

### One wiring note
Component routing resolves via `handlePluginPath` → `dashin-plugin-[team]-[group]/[name]`, so the plugin folder is `dashin-plugin-dashin-d1` (team `dashin`, group `d1`) and the route is `/d1/posts`.

### Deploy (your CF account)
Steps in `docs/d1` + `workers/d1-demo-api/README.md`: create D1 → deploy Worker → set the demo project's `VITE_MAIN_URL` → `demo.dashin.dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)