### PR TITLE
chore(deploy): set D1 database_id for the live demo worker

### DIFF
--- a/workers/d1-demo-api/wrangler.jsonc
+++ b/workers/d1-demo-api/wrangler.jsonc
@@ -20,7 +20,7 @@
     {
       "binding": "DB",
       "database_name": "dashin-demo",
-      "database_id": "REPLACE_WITH_YOUR_D1_DATABASE_ID"
+      "database_id": "ccc77367-ae94-4211-b3b7-6406e60bb9f7"
     }
   ]
 }


### PR DESCRIPTION
Records the D1 `database_id` for the deployed demo Worker, so it is redeployable (incl. Workers Builds git integration). The id is a resource identifier, not a secret. Worker + D1 are live and verified (seed / query / SQL-guard).