### PR TITLE
fix(deploy): drop _redirects (breaks Workers static-assets deploy)

### DIFF
--- a/packages/dashin/public/_redirects
+++ b/packages/dashin/public/_redirects
@@ -1,5 +1,0 @@
-# SPA fallback for Cloudflare Pages: serve index.html for client-side routes.
-# (Vite copies public/ to the build output, so this lands at dist/_redirects.)
-# The Workers flow handles this via wrangler.demo.jsonc's not_found_handling;
-# this file makes the Pages "Build output directory" flow work too.
-/*    /index.html    200


### PR DESCRIPTION
Cloudflare Workers static-assets rejects `/* /index.html 200` ("Infinite loop detected", code 100324). The demo deploys via the Workers flow (`wrangler.demo.jsonc`), where SPA fallback is handled by `not_found_handling: "single-page-application"` — so `_redirects` is redundant and fatal here. Removing it. Verified by redeploying the live demo without it: it serves the SPA and `/d1/posts` resolves to the live D1 table.