### PR TITLE
fix(worker): accept parameterized LIMIT (connector data queries)

### DIFF
--- a/workers/d1-demo-api/src/index.ts
+++ b/workers/d1-demo-api/src/index.ts
@@ -89,15 +89,12 @@ export function guard(sql: string): string | null {
   const table = targetTable(s)
   if (!table) return "could not identify target table"
   if (!ALLOWED_TABLES.includes(table)) return `table not allowed: ${table}`
+  // Result size is already bounded by the per-table row cap (MAX_ROWS_PER_TABLE),
+  // so a LIMIT isn't required. The connector parameterises LIMIT as `LIMIT ?`;
+  // only reject an explicit, oversized literal LIMIT.
   if (verb === "SELECT") {
-    // Aggregates (the connector's COUNT(*) for totalCount) return one row, so
-    // they don't need a LIMIT. Row-returning SELECTs must be bounded.
-    const isAggregate = /^SELECT\s+COUNT\s*\(/i.test(s)
-    if (!isAggregate) {
-      const lim = s.match(/\bLIMIT\s+(\d+)/i)
-      if (!lim) return "SELECT must include a LIMIT"
-      if (Number(lim[1]) > SELECT_MAX_LIMIT) return `LIMIT too large (max ${SELECT_MAX_LIMIT})`
-    }
+    const lim = s.match(/\bLIMIT\s+(\d+)/i)
+    if (lim && Number(lim[1]) > SELECT_MAX_LIMIT) return `LIMIT too large (max ${SELECT_MAX_LIMIT})`
   }
   return null
 }


### PR DESCRIPTION
Follow-up to #110. The hardening required a **literal** `LIMIT <n>`, but the connector sends `SELECT * FROM "posts" LIMIT ? OFFSET ?` (parameterised) — so the guard saw 'no LIMIT' and rejected **every data query**. (#110 only un-blocked the COUNT; the data SELECT still failed.)

Since result size is already bounded by the **500-row table cap**, a LIMIT isn't required — only reject an explicit oversized *literal* LIMIT (>200).

**Verified live** on the free-account deploy: the D1 Posts table loads its rows (all `/query` → 200), and every guard still holds — DROP / disallowed-table / oversized-LIMIT / multi-statement rejected, `/reset` 401 without token, 16/45 rapid requests rate-limited (429).

🤖 Generated with [Claude Code](https://claude.com/claude-code)