### PR TITLE
feat(list): real data-driven stat band + distribution charts

### DIFF
--- a/packages/dashin/src/components/Table/__tests__/computeStats.test.ts
+++ b/packages/dashin/src/components/Table/__tests__/computeStats.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi } from "vitest"
+import { computeStats } from "../computeStats"
+
+const postsCols = [
+  { field: "id", title: "Id" },
+  { field: "title", title: "Title" },
+  { field: "status", title: "Status", lookup: { draft: "Draft", published: "Published" } },
+  { field: "views", title: "Views" }
+] as any[]
+
+/** Mock the table's data() fetcher: total = 3, published = 2, draft = 1. */
+function mockFetch() {
+  return vi.fn(async (q: any) => {
+    const f = (q.filters || [])[0]
+    if (!f) return { totalCount: 3 }
+    return { totalCount: f.value === "published" ? 2 : 1 }
+  })
+}
+
+describe("computeStats", () => {
+  it("returns just a Total card when there is no enum column", async () => {
+    const fetch = vi.fn(async () => ({ totalCount: 7 }))
+    const stats = await computeStats(
+      [{ field: "id", title: "Id" }, { field: "title", title: "Title" }] as any,
+      fetch,
+      "Items"
+    )
+    expect(stats).toHaveLength(1)
+    expect(stats![0]).toMatchObject({ label: "Total Items", value: 7 })
+    expect(fetch).toHaveBeenCalledTimes(1) // only the unfiltered total
+  })
+
+  it("builds Total + per-status cards with real counts and a distribution", async () => {
+    const fetch = mockFetch()
+    const stats = await computeStats(postsCols, fetch, "Posts (Cloudflare D1)")
+    expect(stats).not.toBeNull()
+
+    const total = stats![0]
+    expect(total).toMatchObject({ label: "Total Posts", value: 3, delta: "by Status" })
+    // distribution: one segment per non-empty status, in lookup order
+    expect(total.dist!.map(d => d.value)).toEqual([1, 2]) // draft=1, published=2
+    expect(total.dist!.map(d => d.label)).toEqual(["Draft", "Published"])
+
+    const labels = stats!.slice(1).map(s => s.label)
+    expect(labels).toEqual(["Draft", "Published"])
+    const published = stats!.find(s => s.label === "Published")!
+    expect(published.value).toBe(2)
+    expect(published.delta).toBe("66.7% of total")
+  })
+
+  it("returns null if the fetcher throws", async () => {
+    const fetch = vi.fn(async () => {
+      throw new Error("network")
+    })
+    expect(await computeStats(postsCols, fetch, "Posts")).toBeNull()
+  })
+})

--- a/packages/dashin/src/components/Table/computeStats.ts
+++ b/packages/dashin/src/components/Table/computeStats.ts
@@ -1,0 +1,95 @@
+import { Column } from "./models/material-table-shim"
+import { Stat } from "../regions/StatBand"
+
+/** Minimal fetcher: the table's `data(query)` → we only read totalCount. */
+export type CountFetch = (query: any) => Promise<{ totalCount: number }>
+
+const PALETTE = ["#3366ff", "#00d68f", "#ffaa00", "#ff3d71", "#8b5cf6", "#22b8cf"]
+
+const countQuery = (filters: any[] = []) => ({
+  page: 0,
+  pageSize: 1,
+  search: "",
+  orderDirection: "asc" as const,
+  filters
+})
+
+const pct = (n: number, total: number) =>
+  total > 0 ? `${((n / total) * 100).toFixed(1)}% of total` : "—"
+
+/** "Posts (Cloudflare D1)" -> "Posts" */
+const shortLabel = (title?: string) =>
+  (title || "").replace(/\s*\(.*?\)\s*/g, "").trim()
+
+/**
+ * Compute real list-page stats from the table's own data source — no connector
+ * change: one unfiltered count for the total, plus one filtered count per value
+ * of the first enum/lookup column (the "status"-style field).
+ *
+ * - With an enum column: a Total card (with a distribution bar) + a card per
+ *   value (count + % of total).
+ * - Without one: just the Total card.
+ * Returns null on error (band stays hidden).
+ */
+export async function computeStats<RowData extends object>(
+  cols: Column<RowData>[],
+  fetch: CountFetch,
+  title?: string
+): Promise<Stat[] | null> {
+  try {
+    const total = (await fetch(countQuery())).totalCount
+
+    const enumCol = cols.find(
+      c =>
+        c.field &&
+        c.lookup &&
+        Object.keys(c.lookup).length >= 2 &&
+        Object.keys(c.lookup).length <= 8
+    )
+
+    const totalLabel = `Total ${shortLabel(title) || "records"}`.trim()
+    if (!enumCol || !enumCol.lookup) {
+      return [{ label: totalLabel, value: total, trend: "neutral" }]
+    }
+
+    const entries = Object.entries(enumCol.lookup).slice(0, 6)
+    const counts = await Promise.all(
+      entries.map(async ([value, label]) => ({
+        value,
+        label: String(label),
+        count: (
+          await fetch(
+            countQuery([{ column: { field: enumCol.field }, operator: "=", value }])
+          )
+        ).totalCount
+      }))
+    )
+
+    const dist = counts
+      .map((c, i) => ({ label: c.label, value: c.count, color: PALETTE[i % PALETTE.length] }))
+      .filter(s => s.value > 0)
+
+    const totalCard: Stat = {
+      label: totalLabel,
+      value: total,
+      delta: `by ${enumCol.title || "category"}`,
+      trend: "neutral",
+      dist
+    }
+
+    const valueCards: Stat[] = counts.slice(0, 3).map((c, i) => ({
+      label: c.label,
+      value: c.count,
+      delta: pct(c.count, total),
+      trend: "neutral",
+      dist: [
+        { label: c.label, value: c.count, color: PALETTE[i % PALETTE.length] },
+        { label: "other", value: Math.max(0, total - c.count), color: "var(--bn-border)" }
+      ]
+    }))
+
+    return [totalCard, ...valueCards].slice(0, 4)
+  } catch {
+    return null
+  }
+}

--- a/packages/dashin/src/components/Table/index.tsx
+++ b/packages/dashin/src/components/Table/index.tsx
@@ -1,5 +1,13 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react"
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState
+} from "react"
 import { TableProps } from "@/components"
+import { StatsContext } from "./statsContext"
+import { computeStats } from "./computeStats"
 import {
   Column,
   Query,
@@ -37,6 +45,7 @@ export default function Table<RowData extends object>(
   const { group: qGroup, name: qName } = router.query
   const { columns, data, title, editable, options, actions, detailPanel, onRowClick } = props
   const isRemote = typeof data === "function"
+  const { setStats } = useContext(StatsContext)
   const pageSize: number =
     options?.pageSize || DefaultProps.options?.pageSize || 10
   const showFiltering = !!options?.filtering
@@ -109,6 +118,24 @@ export default function Table<RowData extends object>(
     },
     [data, buildQuery]
   )
+
+  // Push real list-page stats (total + per-enum distribution) up to the
+  // StatBand. Recomputed when the table identity (title) changes, not on
+  // every filter/page change.
+  useEffect(() => {
+    if (!isRemote || !setStats) return
+    let cancelled = false
+    computeStats(cols, data as any, typeof title === "string" ? title : undefined).then(
+      s => {
+        if (!cancelled) setStats(s)
+      }
+    )
+    return () => {
+      cancelled = true
+      setStats(null)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [title, isRemote])
 
   // initial / data change
   useEffect(() => {

--- a/packages/dashin/src/components/Table/statsContext.ts
+++ b/packages/dashin/src/components/Table/statsContext.ts
@@ -1,0 +1,12 @@
+import React from "react"
+import { Stat } from "../regions/StatBand"
+
+/**
+ * Lets a deeply-nested <Table> push computed list-page stats up to the
+ * <StatBand> rendered by DefaultLayout. `setStats(null)` clears them.
+ */
+export interface StatsContextValue {
+  setStats?: (stats: Stat[] | null) => void
+}
+
+export const StatsContext = React.createContext<StatsContextValue>({})

--- a/packages/dashin/src/components/regions/StatBand.tsx
+++ b/packages/dashin/src/components/regions/StatBand.tsx
@@ -17,6 +17,14 @@ export interface Stat {
   icon?: React.ReactNode
   /** optional sparkline data points (mockup-3 mini chart) */
   spark?: number[]
+  /** optional distribution segments → a stacked mini bar chart */
+  dist?: DistSegment[]
+}
+
+export interface DistSegment {
+  label: string
+  value: number
+  color: string
 }
 
 export interface StatBandProps {
@@ -55,6 +63,36 @@ function Sparkline({ points, color }: { points: number[]; color: string }) {
   )
 }
 
+/** Stacked horizontal bar of distribution segments + a small legend. */
+function DistBar({ segments }: { segments: DistSegment[] }) {
+  const total = segments.reduce((s, x) => s + (x.value || 0), 0)
+  if (total <= 0) return null
+  const visible = segments.filter(s => s.value > 0)
+  return (
+    <div className="mt-3">
+      <div className="flex h-2 w-full overflow-hidden rounded-full bg-bn-border">
+        {visible.map((s, i) => (
+          <div
+            key={i}
+            style={{ width: `${(s.value / total) * 100}%`, background: s.color }}
+            title={`${s.label}: ${s.value}`}
+          />
+        ))}
+      </div>
+      {visible.length > 1 && (
+        <div className="mt-2 flex flex-wrap gap-x-3 gap-y-1">
+          {visible.map((s, i) => (
+            <span key={i} className="inline-flex items-center gap-1 text-[11px] text-icon-muted">
+              <span className="inline-block h-2 w-2 rounded-full" style={{ background: s.color }} />
+              {s.label}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
 export default function StatBand({ stats }: StatBandProps) {
   if (!stats || stats.length === 0) return null
   return (
@@ -80,8 +118,12 @@ export default function StatBand({ stats }: StatBandProps) {
               {s.delta}
             </div>
           )}
-          {s.spark && (
-            <Sparkline points={s.spark} color={sparkStroke[s.trend || "neutral"]} />
+          {s.dist && s.dist.length > 0 ? (
+            <DistBar segments={s.dist} />
+          ) : (
+            s.spark && (
+              <Sparkline points={s.spark} color={sparkStroke[s.trend || "neutral"]} />
+            )
           )}
         </div>
       ))}

--- a/packages/dashin/src/pages/[group]-[name].tsx
+++ b/packages/dashin/src/pages/[group]-[name].tsx
@@ -63,20 +63,13 @@ const DynamicGroupNamePage = ({
     sidebarFooter: "upgrade" as const,
     buttons: "labeled" as const
   }
-  const stats = isListView
-    ? [
-        { label: "Total Posts", value: "128", delta: "All time posts", trend: "neutral" as const, spark: [4, 6, 5, 8, 7, 9, 11] },
-        { label: "Published", value: "45", delta: "35.2% of total", trend: "up" as const, spark: [2, 3, 5, 4, 6, 7, 8] },
-        { label: "Pending", value: "28", delta: "21.9% of total", trend: "neutral" as const, spark: [3, 2, 4, 3, 5, 4, 6] },
-        { label: "Rejected", value: "21", delta: "16.4% of total", trend: "down" as const, spark: [5, 4, 3, 4, 2, 3, 2] }
-      ]
-    : undefined
-
+  // The stat band is now data-driven: the <Table> computes real totals +
+  // per-status distribution and pushes them up via StatsContext (see
+  // components/Table). No hardcoded placeholders here.
   return (
     <DefaultLayout
       leftMenu={{ data: leftMenuData }}
       layout={layout}
-      stats={stats}
       sidebarUpgrade={{
         title: "Dashin Pro",
         description: "Unlock advanced features and premium components.",

--- a/packages/dashin/src/private/DefaultLayout/index.tsx
+++ b/packages/dashin/src/private/DefaultLayout/index.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from "react"
 import LeftMenu from "../../components/LeftMenu"
 import TopBar from "../../components/TopBar"
-import StatBand from "../../components/regions/StatBand"
+import StatBand, { Stat } from "../../components/regions/StatBand"
+import { StatsContext } from "../../components/Table/statsContext"
 import SidebarFooter from "../../components/regions/SidebarFooter"
 import { DefaultLayoutProps } from "@/components"
 import { getLayout } from "@/utils/themes/layouts"
@@ -15,12 +16,33 @@ import { importPlugin, hasPlugin } from "@/utils/pluginRegistry"
  * @param props
  * @constructor
  */
+/** Placeholder cards shown while the table computes its stats. */
+function StatBandSkeleton() {
+  return (
+    <div className="grid gap-4 mb-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-4">
+      {Array.from({ length: 4 }).map((_, i) => (
+        <div
+          key={i}
+          className="bg-content-box border border-bn-border rounded-bn p-4 shadow-bn animate-pulse"
+        >
+          <div className="h-3 w-20 rounded bg-bn-border" />
+          <div className="mt-3 h-6 w-12 rounded bg-bn-border" />
+          <div className="mt-4 h-2 w-full rounded-full bg-bn-border" />
+        </div>
+      ))}
+    </div>
+  )
+}
+
 export default function DefaultLayout(props: DefaultLayoutProps) {
   const { children, leftMenu, stats, sidebarStats, sidebarUpgrade } = props
   const cfg = getLayout(props.layout?.id)
   const layout = { ...cfg, ...props.layout }
   const [open, setOpen] = React.useState(true)
   const [phoneVertical, setPhoneVertical] = useState(false)
+  // Live stats pushed up from the <Table> (fallback to the `stats` prop).
+  const [liveStats, setLiveStats] = useState<Stat[] | null>(null)
+  const bandStats = liveStats ?? stats
 
   useEffect(() => {
     const mq = window.matchMedia("(max-width:640px)")
@@ -90,10 +112,17 @@ export default function DefaultLayout(props: DefaultLayoutProps) {
               : "calc(100vw - 73px)"
           }}
         >
-          {layout.statBand && stats && <StatBand stats={stats} />}
-          <div className="bg-content-box overflow-hidden rounded-bn h-full shadow">
-            {children}
-          </div>
+          <StatsContext.Provider value={{ setStats: setLiveStats }}>
+            {layout.statBand &&
+              (bandStats && bandStats.length ? (
+                <StatBand stats={bandStats} />
+              ) : (
+                liveStats === null && <StatBandSkeleton />
+              ))}
+            <div className="bg-content-box overflow-hidden rounded-bn h-full shadow">
+              {children}
+            </div>
+          </StatsContext.Provider>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Replaces the hardcoded placeholder KPIs (`128 / 45 / 28 / 21` + fake sparklines, shown on every list view) with **live stats computed from the table's own data** — generic across all list views, **no connector change**.

### How
- **`components/Table/computeStats.ts`** — one unfiltered count for the total + one filtered count per value of the first **enum/lookup** column (the "status"-style field). Builds a **Total** card (with a distribution bar) + a card per value (count + % of total). Tables without an enum column get just a Total card.
- **`statsContext.ts` + `DefaultLayout`** — the deeply-nested `<Table>` pushes its computed stats up to the `<StatBand>` via React context; skeleton cards show while loading.
- **`regions/StatBand`** — new **`DistBar`** chart (stacked proportion bar + legend), rendered when a stat has `dist`.
- `<Table>` recomputes on table-identity change (not per filter/page); page drops the placeholders.

### Verified
- `computeStats` unit tests (3) + app **vitest 102 pass**, **typecheck clean**.
- Live build against the deployed D1 Worker: **Total 3 · Published 2 (66.7%) · Draft 1 (33.3%)** with proportional bars, exactly matching the table (1-3 of 3). Screenshot shared in chat.

Generic: e.g. Products would show Total + In stock / Out of stock from its `in_stock` lookup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)