### PR TITLE
chore(deploy): keep account-specific database_id in a gitignored local config

### DIFF
--- a/workers/d1-demo-api/.gitignore
+++ b/workers/d1-demo-api/.gitignore
@@ -2,3 +2,6 @@ node_modules
 .wrangler
 .dev.vars
 package-lock.json
+# Local deploy config holding your real, account-specific database_id.
+# Keep account values OUT of the committed wrangler.jsonc.
+wrangler.local.jsonc

--- a/workers/d1-demo-api/README.md
+++ b/workers/d1-demo-api/README.md
@@ -29,18 +29,23 @@ This is what makes a **100%-free, all-Cloudflare** Dashin demo possible: D1
 
 ## Deploy (your Cloudflare account)
 
+Keep your account-specific `database_id` **out of git** — put it in a gitignored
+`wrangler.local.jsonc` and pass `-c` on every remote command:
+
 ```bash
 cd workers/d1-demo-api
 npm install
 
-npx wrangler d1 create dashin-demo          # paste database_id into wrangler.jsonc
-npx wrangler d1 execute dashin-demo --remote --file=schema.sql
-npx wrangler secret put RESET_TOKEN          # required — gates POST /reset
-npx wrangler deploy
+npx wrangler d1 create dashin-demo                 # note the database_id
+cp wrangler.jsonc wrangler.local.jsonc             # gitignored; put your real id here
+npx wrangler d1 execute dashin-demo --remote --file=schema.sql -c wrangler.local.jsonc
+npx wrangler secret put RESET_TOKEN -c wrangler.local.jsonc   # required — gates POST /reset
+npx wrangler deploy -c wrangler.local.jsonc
 curl -X POST https://<worker-url>/reset -H "Authorization: Bearer <token>"   # initial seed
 ```
 
-Then point the Dashin demo frontend at the Worker URL via `VITE_MAIN_URL`.
+Then point the Dashin demo frontend at the Worker URL via `VITE_MAIN_URL`
+(set it in the frontend's gitignored `.env.local`, not in any committed file).
 
 ## Local development
 

--- a/workers/d1-demo-api/wrangler.jsonc
+++ b/workers/d1-demo-api/wrangler.jsonc
@@ -1,13 +1,17 @@
 // Dashin D1 demo gateway Worker.
 //
-// Setup:
+// Setup (keep your account-specific database_id OUT of this committed file):
 //   cd workers/d1-demo-api && npm install
-//   npx wrangler d1 create dashin-demo      # put YOUR database_id below
-//                                           # (it's account-specific — don't commit a real one)
-//   npx wrangler d1 execute dashin-demo --remote --file=schema.sql
-//   npx wrangler secret put RESET_TOKEN     # optional: gate POST /reset
-//   npx wrangler deploy
+//   npx wrangler d1 create dashin-demo            # note the database_id
+//   cp wrangler.jsonc wrangler.local.jsonc        # gitignored override
+//   # ...put your real database_id in wrangler.local.jsonc, then use -c on every
+//   #    remote command:
+//   npx wrangler d1 execute dashin-demo --remote --file=schema.sql -c wrangler.local.jsonc
+//   npx wrangler secret put RESET_TOKEN -c wrangler.local.jsonc   # gate POST /reset
+//   npx wrangler deploy -c wrangler.local.jsonc
 //   curl -X POST https://<worker-url>/reset -H "Authorization: Bearer <token>"
+//
+// (Local dev — `wrangler dev --local` — works with the placeholder id as-is.)
 {
   "name": "dashin-d1-demo-api",
   "main": "src/index.ts",


### PR DESCRIPTION
Account-specific values (D1 `database_id`, worker URL) must never be committed. This makes that the default:
- committed `wrangler.jsonc` keeps a **placeholder** id;
- real ids live in a gitignored **`wrangler.local.jsonc`**, passed via `-c` on remote commands;
- mirrors the frontend's gitignored `.env.local` for `VITE_MAIN_URL`.

Local dev (`wrangler dev --local`) still works with the placeholder. README + the wrangler.jsonc header updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)