### PR TITLE
feat(demo): e-commerce dashboard landing with live D1 charts

### DIFF
--- a/packages/dashin/e2e/ecommerce.spec.ts
+++ b/packages/dashin/e2e/ecommerce.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect, Page } from "@playwright/test"
+
+// Live e-commerce demo e2e. Drives a real dev server (VITE_MAIN_URL pointed at a
+// local wrangler dev D1 gateway). Because the dev server may run off the single
+// CORS-allowed port (:3000), we inject permissive CORS headers on the worker
+// responses via route interception (the established off-port pattern). Logs in
+// with the client-side auth-local plugin (admin / dashin), then asserts the
+// dashboard KPIs + charts render with real data and entity tables load.
+// Opt-in: this suite needs a running dev server + a reachable D1 gateway Worker,
+// so it's skipped by default (incl. CI, which has no backend). Run it with
+// E2E_LIVE=1 after starting `wrangler dev` and a dev server pointed at it.
+const LIVE = !!process.env.E2E_LIVE
+const BASE = process.env.E2E_BASE || "http://localhost:3100"
+const WORKER = /127\.0\.0\.1:8790\//
+
+test.skip(!LIVE, "live demo e2e — set E2E_LIVE=1 with a dev server + local D1 worker")
+
+async function allowCors(page: Page) {
+  await page.route(WORKER, async route => {
+    const cors = {
+      "access-control-allow-origin": "*",
+      "access-control-allow-methods": "GET,POST,OPTIONS",
+      "access-control-allow-headers": "content-type,authorization"
+    }
+    if (route.request().method() === "OPTIONS") {
+      return route.fulfill({ status: 204, headers: cors })
+    }
+    const resp = await route.fetch()
+    const body = await resp.body()
+    await route.fulfill({ status: resp.status(), headers: { ...resp.headers(), ...cors }, body })
+  })
+}
+
+async function login(page: Page) {
+  await allowCors(page)
+  await page.goto(`${BASE}/auth/sign-in`)
+  await page.waitForLoadState("networkidle")
+  const user = page.locator('input[name="username"]')
+  if (await user.count()) {
+    await user.fill("admin")
+    await page.locator('input[name="password"]').fill("dashin")
+    await page.locator('button[type="submit"]').click()
+    await page.waitForLoadState("networkidle")
+  }
+}
+
+test("dashboard renders KPIs + charts with real data", async ({ page }) => {
+  await login(page)
+  await page.goto(`${BASE}/`)
+  await page.waitForLoadState("networkidle")
+
+  await expect(page.getByRole("heading", { name: /Store/ })).toBeVisible({ timeout: 30_000 })
+  await expect(page.getByText("Revenue (30d)")).toBeVisible({ timeout: 30_000 })
+  await expect(page.getByText("Orders (30d)")).toBeVisible()
+
+  // A real currency value in the KPI band (e.g. $1,234.00)
+  await expect(page.getByText(/\$[\d,]+\.\d{2}/).first()).toBeVisible({ timeout: 30_000 })
+
+  await expect(page.locator('svg[aria-label="Trend chart"]')).toBeVisible()
+  await expect(page.locator('svg[aria-label="Donut chart"]')).toBeVisible()
+  await expect(page.getByText("Orders by status")).toBeVisible()
+  await expect(page.getByText("Products by category")).toBeVisible()
+  await expect(page.getByText("Recent orders")).toBeVisible()
+})
+
+test("grouped sidebar + orders table loads real rows", async ({ page }) => {
+  await login(page)
+  await page.goto(`${BASE}/`)
+  await page.waitForLoadState("networkidle")
+
+  await expect(page.getByText("Catalog", { exact: true })).toBeVisible({ timeout: 30_000 })
+  await expect(page.getByText("Sales", { exact: true })).toBeVisible()
+
+  await page.goto(`${BASE}/d1/orders`)
+  await page.waitForLoadState("networkidle")
+  await page.waitForTimeout(1500)
+  await expect(page.getByText(/\$[\d,]+\.\d{2}/).first()).toBeVisible({ timeout: 30_000 })
+  await expect(page.getByText(/Paid|Shipped|Pending|Cancelled/).first()).toBeVisible()
+})
+
+test("products table resolves category lookups", async ({ page }) => {
+  await login(page)
+  await page.goto(`${BASE}/d1/products`)
+  await page.waitForLoadState("networkidle")
+  await page.waitForTimeout(1500)
+  await expect(page.getByText(/Electronics|Apparel|Books|Grocery/).first()).toBeVisible({ timeout: 30_000 })
+})

--- a/packages/dashin/src/components/charts/BarChart.tsx
+++ b/packages/dashin/src/components/charts/BarChart.tsx
@@ -1,0 +1,48 @@
+import React from "react"
+
+export interface BarDatum {
+  label: string
+  value: number
+  /** optional per-bar color; falls back to the primary gradient */
+  color?: string
+}
+
+export interface BarChartProps {
+  data: BarDatum[]
+  /** Format the value shown at the end of each bar. */
+  format?: (n: number) => string
+}
+
+/**
+ * Horizontal bar chart (no chart lib) — one row per datum, bar width
+ * proportional to the max value. Token-styled; falls back to the primary
+ * gradient when a datum has no explicit color.
+ */
+export default function BarChart({ data, format = n => String(n) }: BarChartProps) {
+  if (!data || data.length === 0) {
+    return <div className="py-6 text-sm text-icon-muted">No data.</div>
+  }
+  const max = Math.max(...data.map(d => d.value), 1)
+  return (
+    <div className="space-y-3">
+      {data.map((d, i) => (
+        <div key={i}>
+          <div className="mb-1 flex justify-between text-xs">
+            <span className="text-foreground">{d.label}</span>
+            <span className="text-icon-muted">{format(d.value)}</span>
+          </div>
+          <div className="h-2 w-full overflow-hidden rounded-full bg-bn-border">
+            <div
+              className={d.color ? "" : "bg-primary-gradient"}
+              style={{
+                width: `${Math.max((d.value / max) * 100, 2)}%`,
+                height: "100%",
+                background: d.color || undefined
+              }}
+            />
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/packages/dashin/src/components/charts/Donut.tsx
+++ b/packages/dashin/src/components/charts/Donut.tsx
@@ -1,0 +1,110 @@
+import React from "react"
+
+export interface DonutSegment {
+  label: string
+  value: number
+  color: string
+}
+
+export interface DonutProps {
+  data: DonutSegment[]
+  size?: number
+  thickness?: number
+  /** Big number shown in the center (defaults to the segment total). */
+  centerValue?: string | number
+  centerLabel?: string
+}
+
+/**
+ * Donut/ring chart (no chart lib) — each segment is a stroked circle arc drawn
+ * with stroke-dasharray, rotated so segments sit end-to-end starting at 12
+ * o'clock. Includes a centered total and a legend.
+ */
+export default function Donut({
+  data,
+  size = 168,
+  thickness = 20,
+  centerValue,
+  centerLabel
+}: DonutProps) {
+  const total = data.reduce((s, d) => s + (d.value || 0), 0)
+  const r = (size - thickness) / 2
+  const c = size / 2
+  const circ = 2 * Math.PI * r
+
+  let offset = 0
+  const arcs = total > 0
+    ? data
+        .filter(d => d.value > 0)
+        .map((d, i) => {
+          const frac = d.value / total
+          const seg = (
+            <circle
+              key={i}
+              cx={c}
+              cy={c}
+              r={r}
+              fill="none"
+              stroke={d.color}
+              strokeWidth={thickness}
+              strokeDasharray={`${(frac * circ).toFixed(2)} ${(circ - frac * circ).toFixed(2)}`}
+              strokeDashoffset={(-offset * circ).toFixed(2)}
+            >
+              <title>{`${d.label}: ${d.value}`}</title>
+            </circle>
+          )
+          offset += frac
+          return seg
+        })
+    : null
+
+  return (
+    <div className="flex items-center gap-5">
+      <svg width={size} height={size} role="img" aria-label="Donut chart">
+        {/* track */}
+        <circle
+          cx={c}
+          cy={c}
+          r={r}
+          fill="none"
+          stroke="var(--bn-border, #e5e7eb)"
+          strokeWidth={thickness}
+        />
+        {/* rotate -90deg so the first arc starts at the top */}
+        <g transform={`rotate(-90 ${c} ${c})`}>{arcs}</g>
+        <text
+          x={c}
+          y={c - 2}
+          textAnchor="middle"
+          className="fill-foreground"
+          style={{ fontSize: 22, fontWeight: 600 }}
+        >
+          {centerValue ?? total}
+        </text>
+        {centerLabel && (
+          <text
+            x={c}
+            y={c + 16}
+            textAnchor="middle"
+            className="fill-icon-muted"
+            style={{ fontSize: 11 }}
+          >
+            {centerLabel}
+          </text>
+        )}
+      </svg>
+      <ul className="space-y-1.5">
+        {data.map((d, i) => (
+          <li key={i} className="flex items-center gap-2 whitespace-nowrap text-sm">
+            <span className="inline-block h-2.5 w-2.5 shrink-0 rounded-full" style={{ background: d.color }} />
+            <span className="text-foreground">{d.label}</span>
+            <span className="ml-auto pl-3 text-icon-muted">
+              {d.value}
+              {total > 0 ? ` · ${Math.round((d.value / total) * 100)}%` : ""}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/packages/dashin/src/components/charts/TrendChart.tsx
+++ b/packages/dashin/src/components/charts/TrendChart.tsx
@@ -1,0 +1,107 @@
+import React, { useId } from "react"
+
+export interface TrendChartProps {
+  /** Y values, oldest → newest. */
+  points: number[]
+  /** Optional X labels aligned to `points` (only first/last are drawn). */
+  labels?: string[]
+  height?: number
+  /** Stroke/area color (defaults to the primary token). */
+  color?: string
+  /** Format a Y value for the hover title / peak label. */
+  format?: (n: number) => string
+}
+
+/**
+ * Hand-rolled area + line trend chart (no chart lib), styled with design
+ * tokens. Scales to its container width via a viewBox; the area uses a soft
+ * vertical gradient and the latest point is marked.
+ */
+export default function TrendChart({
+  points,
+  labels,
+  height = 220,
+  color = "var(--bn-primary, #6366f1)",
+  format = n => String(n)
+}: TrendChartProps) {
+  const gid = useId().replace(/:/g, "")
+  const W = 720
+  const H = height
+  const padX = 8
+  const padY = 16
+
+  if (!points || points.length < 2) {
+    return (
+      <div
+        className="flex items-center justify-center text-sm text-icon-muted"
+        style={{ height }}
+      >
+        Not enough data yet.
+      </div>
+    )
+  }
+
+  const max = Math.max(...points)
+  const min = Math.min(...points, 0)
+  const span = max - min || 1
+  const innerW = W - padX * 2
+  const innerH = H - padY * 2
+
+  const x = (i: number) => padX + (i / (points.length - 1)) * innerW
+  const y = (v: number) => padY + innerH - ((v - min) / span) * innerH
+
+  const line = points.map((p, i) => `${i === 0 ? "M" : "L"}${x(i).toFixed(1)},${y(p).toFixed(1)}`).join(" ")
+  const area = `${line} L${x(points.length - 1).toFixed(1)},${(H - padY).toFixed(1)} L${x(0).toFixed(1)},${(H - padY).toFixed(1)} Z`
+
+  const lastI = points.length - 1
+  const peakI = points.indexOf(max)
+
+  return (
+    <div>
+      <svg
+        viewBox={`0 0 ${W} ${H}`}
+        width="100%"
+        height={H}
+        preserveAspectRatio="none"
+        role="img"
+        aria-label="Trend chart"
+      >
+        <defs>
+          <linearGradient id={`area-${gid}`} x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor={color} stopOpacity="0.28" />
+            <stop offset="100%" stopColor={color} stopOpacity="0" />
+          </linearGradient>
+        </defs>
+        {/* baseline */}
+        <line
+          x1={padX}
+          y1={H - padY}
+          x2={W - padX}
+          y2={H - padY}
+          stroke="var(--bn-border, #e5e7eb)"
+          strokeWidth={1}
+        />
+        <path d={area} fill={`url(#area-${gid})`} />
+        <path
+          d={line}
+          fill="none"
+          stroke={color}
+          strokeWidth={2.5}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        {/* peak + latest markers */}
+        <circle cx={x(peakI)} cy={y(max)} r={3.5} fill={color} opacity={0.5} />
+        <circle cx={x(lastI)} cy={y(points[lastI])} r={4} fill={color}>
+          <title>{format(points[lastI])}</title>
+        </circle>
+      </svg>
+      {labels && labels.length === points.length && (
+        <div className="mt-1 flex justify-between text-[11px] text-icon-muted">
+          <span>{labels[0]}</span>
+          <span>{labels[lastI]}</span>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/dashin/src/components/dashboard/Dashboard.tsx
+++ b/packages/dashin/src/components/dashboard/Dashboard.tsx
@@ -1,0 +1,234 @@
+import React, { useEffect, useState } from "react"
+import { ENV } from "@dashin-dev/dashin"
+import { execute } from "@dashin-dev/source-d1"
+
+import Card from "../ui/Card"
+import StatBand, { Stat } from "../regions/StatBand"
+import TrendChart from "../charts/TrendChart"
+import BarChart from "../charts/BarChart"
+import Donut, { DonutSegment } from "../charts/Donut"
+import {
+  CUSTOMER_LOOKUP,
+  ORDER_STATUS_LOOKUP,
+  money
+} from "../../private/plugins/dashin-plugin-dashin-d1/lookups"
+import {
+  STATUS_COLORS,
+  buildDayAxis,
+  computeDelta,
+  dailySalesQuery,
+  mergeDailySeries,
+  newCustomersQuery,
+  activeProductsQuery,
+  recentOrdersQuery,
+  statusBreakdownQuery,
+  topCategoriesQuery,
+  totalsQuery,
+  Stmt
+} from "./queries"
+
+const DAYS = 30
+const STATUS_ORDER = ["paid", "shipped", "pending", "cancelled"]
+
+const num = (rows: any[], field = "c"): number => Number(rows?.[0]?.[field] ?? 0)
+const delta = (pct: number) => `${pct > 0 ? "▲" : pct < 0 ? "▼" : "•"} ${Math.abs(pct)}% vs prev 7d`
+
+// Minimal lucide-style stroke icons for the KPI chips.
+const ic = (d: React.ReactNode) => (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    {d}
+  </svg>
+)
+const ICONS = {
+  revenue: ic(<><line x1="12" y1="1" x2="12" y2="23" /><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6" /></>),
+  orders: ic(<><circle cx="9" cy="21" r="1" /><circle cx="20" cy="21" r="1" /><path d="M1 1h4l2.68 13.39a2 2 0 0 0 2 1.61h9.72a2 2 0 0 0 2-1.61L23 6H6" /></>),
+  customers: ic(<><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" /><circle cx="9" cy="7" r="4" /><path d="M23 21v-2a4 4 0 0 0-3-3.87" /></>),
+  products: ic(<><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z" /><polyline points="3.27 6.96 12 12.01 20.73 6.96" /></>)
+}
+
+interface Data {
+  kpis: Stat[]
+  revSeries: number[]
+  axisLabels: string[]
+  status: DonutSegment[]
+  totalOrders: number
+  topCats: { label: string; value: number }[]
+  recent: any[]
+}
+
+export default function Dashboard() {
+  const [data, setData] = useState<Data | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let alive = true
+    const run = (s: Stmt) => execute(s, ENV.MAIN_URL)
+    ;(async () => {
+      try {
+        const [daily, status, cats, recent, custTotal, prodTotal, prodActive, newCust] =
+          await Promise.all([
+            run(dailySalesQuery(DAYS)),
+            run(statusBreakdownQuery()),
+            run(topCategoriesQuery(6)),
+            run(recentOrdersQuery(6)),
+            run(totalsQuery("customers")),
+            run(totalsQuery("products")),
+            run(activeProductsQuery()),
+            run(newCustomersQuery(DAYS))
+          ])
+
+        const firstErr = [daily, status, cats, recent, custTotal, prodTotal, prodActive, newCust]
+          .map(r => r.error)
+          .find(Boolean)
+        if (firstErr) throw new Error(typeof firstErr === "string" ? firstErr : JSON.stringify(firstErr))
+
+        const axis = buildDayAxis(new Date(), DAYS)
+        const revSeries = mergeDailySeries(daily.rows, axis, "revenue")
+        const ordSeries = mergeDailySeries(daily.rows, axis, "orders")
+        const revTotal = revSeries.reduce((s, v) => s + v, 0)
+        const ordTotal = ordSeries.reduce((s, v) => s + v, 0)
+        const revD = computeDelta(revSeries, 7)
+        const ordD = computeDelta(ordSeries, 7)
+
+        const statusMap = new Map<string, number>(
+          (status.rows || []).map((r: any) => [String(r.status), Number(r.c) || 0])
+        )
+        const segs: DonutSegment[] = STATUS_ORDER.filter(s => statusMap.has(s)).map(s => ({
+          label: ORDER_STATUS_LOOKUP[s] || s,
+          value: statusMap.get(s) || 0,
+          color: STATUS_COLORS[s] || "#94a3b8"
+        }))
+
+        const kpis: Stat[] = [
+          {
+            label: "Revenue (30d)",
+            value: money(revTotal),
+            delta: delta(revD.pct),
+            trend: revD.trend,
+            icon: ICONS.revenue,
+            spark: revSeries
+          },
+          {
+            label: "Orders (30d)",
+            value: ordTotal,
+            delta: delta(ordD.pct),
+            trend: ordD.trend,
+            icon: ICONS.orders,
+            spark: ordSeries
+          },
+          {
+            label: "Customers",
+            value: num(custTotal.rows),
+            delta: `+${num(newCust.rows)} new (30d)`,
+            trend: num(newCust.rows) > 0 ? "up" : "neutral",
+            icon: ICONS.customers
+          },
+          {
+            label: "Products",
+            value: num(prodTotal.rows),
+            delta: `${num(prodActive.rows)} active`,
+            trend: "neutral",
+            icon: ICONS.products
+          }
+        ]
+
+        if (alive)
+          setData({
+            kpis,
+            revSeries,
+            axisLabels: axis.map(d => d.slice(5).replace("-", "/")),
+            status: segs,
+            totalOrders: (status.rows || []).reduce((s: number, r: any) => s + (Number(r.c) || 0), 0),
+            topCats: (cats.rows || []).map((r: any) => ({ label: r.label, value: Number(r.value) || 0 })),
+            recent: recent.rows || []
+          })
+      } catch (e: any) {
+        if (alive) setError(e?.message || String(e))
+      }
+    })()
+    return () => {
+      alive = false
+    }
+  }, [])
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold text-foreground">{ENV.SITE_NAME} Store</h1>
+        <p className="text-sm text-icon-muted">
+          A live e-commerce admin on Cloudflare D1 — fully editable. Demo data resets every 30 minutes.
+        </p>
+      </div>
+
+      {error ? (
+        <Card className="p-6 text-sm text-danger">
+          Couldn’t load dashboard data: {error}
+        </Card>
+      ) : !data ? (
+        <Skeleton />
+      ) : (
+        <>
+          <StatBand stats={data.kpis} />
+
+          <div className="grid gap-4 lg:grid-cols-3">
+            <Card className="p-5 lg:col-span-2">
+              <div className="mb-3 flex items-baseline justify-between">
+                <h2 className="font-medium text-foreground">Revenue · last 30 days</h2>
+                <span className="text-sm text-icon-muted">{money(data.revSeries.reduce((s, v) => s + v, 0))}</span>
+              </div>
+              <TrendChart points={data.revSeries} labels={data.axisLabels} format={money} />
+            </Card>
+            <Card className="p-5">
+              <h2 className="mb-3 font-medium text-foreground">Orders by status</h2>
+              <Donut data={data.status} centerValue={data.totalOrders} centerLabel="orders" />
+            </Card>
+          </div>
+
+          <div className="grid gap-4 lg:grid-cols-2">
+            <Card className="p-5">
+              <h2 className="mb-4 font-medium text-foreground">Products by category</h2>
+              <BarChart data={data.topCats} />
+            </Card>
+            <Card className="p-5">
+              <h2 className="mb-3 font-medium text-foreground">Recent orders</h2>
+              <ul className="divide-y divide-bn-border">
+                {data.recent.map((o: any) => (
+                  <li key={o.id} className="flex items-center justify-between py-2 text-sm">
+                    <span className="text-foreground">
+                      #{o.id} · {CUSTOMER_LOOKUP[o.customer_id] || `Customer ${o.customer_id}`}
+                    </span>
+                    <span className="flex items-center gap-3">
+                      <span
+                        className="rounded-full px-2 py-0.5 text-xs font-medium"
+                        style={{ background: (STATUS_COLORS[o.status] || "#94a3b8") + "22", color: STATUS_COLORS[o.status] || "#64748b" }}
+                      >
+                        {ORDER_STATUS_LOOKUP[o.status] || o.status}
+                      </span>
+                      <span className="text-icon-muted">{money(o.total)}</span>
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </Card>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
+
+function Skeleton() {
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="h-28 animate-pulse rounded-bn border border-bn-border bg-content-box" />
+        ))}
+      </div>
+      <div className="grid gap-4 lg:grid-cols-3">
+        <div className="h-64 animate-pulse rounded-bn border border-bn-border bg-content-box lg:col-span-2" />
+        <div className="h-64 animate-pulse rounded-bn border border-bn-border bg-content-box" />
+      </div>
+    </div>
+  )
+}

--- a/packages/dashin/src/components/dashboard/__tests__/queries.test.ts
+++ b/packages/dashin/src/components/dashboard/__tests__/queries.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from "vitest"
+import {
+  totalsQuery,
+  activeProductsQuery,
+  newCustomersQuery,
+  dailySalesQuery,
+  statusBreakdownQuery,
+  topCategoriesQuery,
+  recentOrdersQuery,
+  buildDayAxis,
+  mergeDailySeries,
+  computeDelta
+} from "../queries"
+
+// The D1 gateway guard rejects DDL / comments / multi-statements and only
+// allows the four store tables — so the builders must stay plain SELECTs.
+const ALLOWED = ["categories", "products", "customers", "orders"]
+function assertGuardSafe(sql: string) {
+  expect(sql.trim().toUpperCase().startsWith("SELECT")).toBe(true)
+  expect(sql).not.toMatch(/;/) // single statement
+  expect(sql).not.toMatch(/--|\/\*/) // no comments
+  // every quoted "table" reference is allow-listed
+  const tables = [...sql.matchAll(/"([a-z_]+)"/g)].map(m => m[1])
+  for (const t of tables) expect(ALLOWED).toContain(t)
+}
+
+describe("dashboard query builders", () => {
+  it("totalsQuery counts a table, parameter-free", () => {
+    const q = totalsQuery("orders")
+    expect(q.sql).toBe('SELECT COUNT(*) AS c FROM "orders"')
+    expect(q.args).toEqual([])
+    assertGuardSafe(q.sql)
+  })
+
+  it("activeProductsQuery filters by status", () => {
+    const q = activeProductsQuery()
+    expect(q.sql).toContain("status = 'active'")
+    assertGuardSafe(q.sql)
+  })
+
+  it("newCustomersQuery binds a relative day offset", () => {
+    const q = newCustomersQuery(30)
+    expect(q.sql).toContain("date('now', ?)")
+    expect(q.args).toEqual(["-30 days"])
+    assertGuardSafe(q.sql)
+  })
+
+  it("dailySalesQuery groups by day and only sums paid/shipped revenue", () => {
+    const q = dailySalesQuery(30)
+    expect(q.sql).toContain("GROUP BY day")
+    expect(q.sql).toContain("strftime('%Y-%m-%d', created_at)")
+    expect(q.sql).toContain("status IN ('paid','shipped')")
+    expect(q.args).toEqual(["-29 days"]) // inclusive window of `days`
+    assertGuardSafe(q.sql)
+  })
+
+  it("statusBreakdownQuery groups orders by status", () => {
+    const q = statusBreakdownQuery()
+    expect(q.sql).toContain("GROUP BY status")
+    assertGuardSafe(q.sql)
+  })
+
+  it("topCategoriesQuery joins products⋈categories with a bound limit", () => {
+    const q = topCategoriesQuery(6)
+    expect(q.sql).toContain('"products" p JOIN "categories" c')
+    expect(q.sql).toContain("LIMIT ?")
+    expect(q.args).toEqual([6])
+    assertGuardSafe(q.sql)
+  })
+
+  it("recentOrdersQuery orders by id desc with a bound limit", () => {
+    const q = recentOrdersQuery(5)
+    expect(q.sql).toContain("ORDER BY id DESC")
+    expect(q.args).toEqual([5])
+    assertGuardSafe(q.sql)
+  })
+})
+
+describe("buildDayAxis", () => {
+  it("returns `days` ascending UTC dates ending at `end`", () => {
+    const axis = buildDayAxis(new Date("2026-06-04T10:00:00Z"), 5)
+    expect(axis).toEqual([
+      "2026-05-31",
+      "2026-06-01",
+      "2026-06-02",
+      "2026-06-03",
+      "2026-06-04"
+    ])
+  })
+
+  it("spans month boundaries correctly", () => {
+    const axis = buildDayAxis(new Date("2026-03-01T00:00:00Z"), 2)
+    expect(axis).toEqual(["2026-02-28", "2026-03-01"])
+  })
+})
+
+describe("mergeDailySeries", () => {
+  it("projects rows onto the axis, 0-filling gaps", () => {
+    const axis = ["2026-06-01", "2026-06-02", "2026-06-03"]
+    const rows = [
+      { day: "2026-06-01", revenue: 100, orders: 2 },
+      { day: "2026-06-03", revenue: 50, orders: 1 }
+    ]
+    expect(mergeDailySeries(rows, axis, "revenue")).toEqual([100, 0, 50])
+    expect(mergeDailySeries(rows, axis, "orders")).toEqual([2, 0, 1])
+  })
+})
+
+describe("computeDelta", () => {
+  it("computes percentage change of last window vs prior window", () => {
+    // prior 2 = [10,10]=20, last 2 = [15,15]=30 → +50%
+    expect(computeDelta([10, 10, 15, 15], 2)).toEqual({ pct: 50, trend: "up" })
+  })
+
+  it("flags a decrease as down", () => {
+    expect(computeDelta([20, 20, 5, 5], 2)).toEqual({ pct: -75, trend: "down" })
+  })
+
+  it("treats growth from zero prior as +100% up", () => {
+    expect(computeDelta([0, 0, 5, 5], 2)).toEqual({ pct: 100, trend: "up" })
+  })
+
+  it("returns neutral when there is no movement", () => {
+    expect(computeDelta([5, 5, 5, 5], 2)).toEqual({ pct: 0, trend: "neutral" })
+  })
+
+  it("is safe with insufficient history", () => {
+    expect(computeDelta([5], 7).trend).toBe("up")
+    expect(computeDelta([], 7)).toEqual({ pct: 0, trend: "neutral" })
+  })
+})

--- a/packages/dashin/src/components/dashboard/queries.ts
+++ b/packages/dashin/src/components/dashboard/queries.ts
@@ -1,0 +1,118 @@
+/**
+ * Pure SQL builders + transforms for the e-commerce dashboard.
+ *
+ * Every builder returns a `{ sql, args }` statement understood by the
+ * `@dashin-dev/source-d1` connector (and the D1 gateway Worker's guard: only
+ * SELECT on the allow-listed tables, no DDL / comments / multi-statements).
+ * Kept side-effect-free so they're unit-testable without a database.
+ */
+
+export interface Stmt {
+  sql: string
+  args: any[]
+}
+
+/** Statuses that count toward realised revenue. */
+export const REVENUE_STATUSES = ["paid", "shipped"] as const
+
+/** Colors for the order-status donut/legend (match the column status pills). */
+export const STATUS_COLORS: Record<string, string> = {
+  paid: "#22c55e",
+  shipped: "#3b82f6",
+  pending: "#f59e0b",
+  cancelled: "#94a3b8"
+}
+
+// ── Row counts ───────────────────────────────────────────────
+export const totalsQuery = (table: string): Stmt => ({
+  sql: `SELECT COUNT(*) AS c FROM "${table}"`,
+  args: []
+})
+
+export const activeProductsQuery = (): Stmt => ({
+  sql: `SELECT COUNT(*) AS c FROM "products" WHERE status = 'active'`,
+  args: []
+})
+
+export const newCustomersQuery = (days: number): Stmt => ({
+  sql: `SELECT COUNT(*) AS c FROM "customers" WHERE created_at >= date('now', ?)`,
+  args: [`-${days} days`]
+})
+
+// ── Daily orders + revenue over the last `days` days ─────────
+// revenue counts only paid/shipped orders; orders counts every status.
+export const dailySalesQuery = (days: number): Stmt => ({
+  sql:
+    "SELECT strftime('%Y-%m-%d', created_at) AS day, " +
+    "COUNT(*) AS orders, " +
+    "ROUND(COALESCE(SUM(CASE WHEN status IN ('paid','shipped') THEN total ELSE 0 END), 0), 2) AS revenue " +
+    'FROM "orders" WHERE created_at >= date(\'now\', ?) GROUP BY day ORDER BY day',
+  args: [`-${days - 1} days`]
+})
+
+// ── Order-status breakdown (all statuses) ────────────────────
+export const statusBreakdownQuery = (): Stmt => ({
+  sql: 'SELECT status, COUNT(*) AS c FROM "orders" GROUP BY status',
+  args: []
+})
+
+// ── Top categories by product count (products ⋈ categories) ──
+export const topCategoriesQuery = (limit: number): Stmt => ({
+  sql:
+    'SELECT c.name AS label, COUNT(*) AS value ' +
+    'FROM "products" p JOIN "categories" c ON c.id = p.category_id ' +
+    "GROUP BY p.category_id ORDER BY value DESC LIMIT ?",
+  args: [limit]
+})
+
+// ── Latest orders for the activity list ──────────────────────
+export const recentOrdersQuery = (limit: number): Stmt => ({
+  sql:
+    'SELECT id, customer_id, total, status, created_at ' +
+    'FROM "orders" ORDER BY id DESC LIMIT ?',
+  args: [limit]
+})
+
+// ── Pure transforms (testable without a DB) ──────────────────
+
+/** UTC `YYYY-MM-DD` axis of the last `days` days ending at `end` (inclusive). */
+export function buildDayAxis(end: Date, days: number): string[] {
+  const DAY = 86_400_000
+  const endUTC = Date.UTC(end.getUTCFullYear(), end.getUTCMonth(), end.getUTCDate())
+  const axis: string[] = []
+  for (let i = days - 1; i >= 0; i--) {
+    axis.push(new Date(endUTC - i * DAY).toISOString().slice(0, 10))
+  }
+  return axis
+}
+
+/** Project DB day-rows onto a continuous axis, 0-filling missing days. */
+export function mergeDailySeries(
+  rows: Array<Record<string, any>>,
+  axis: string[],
+  field: string
+): number[] {
+  const byDay = new Map<string, number>()
+  for (const r of rows) byDay.set(String(r.day), Number(r[field]) || 0)
+  return axis.map(d => byDay.get(d) ?? 0)
+}
+
+/**
+ * Percentage change of the last `window` values vs the `window` before them.
+ * Returns a rounded pct and a trend direction (for KPI deltas/sparkline color).
+ */
+export function computeDelta(
+  values: number[],
+  window: number
+): { pct: number; trend: "up" | "down" | "neutral" } {
+  if (values.length < window * 2) {
+    // Not enough history for a clean prior period.
+    const recent = values.slice(-window).reduce((s, v) => s + v, 0)
+    return { pct: 0, trend: recent > 0 ? "up" : "neutral" }
+  }
+  const recent = values.slice(-window).reduce((s, v) => s + v, 0)
+  const prior = values.slice(-window * 2, -window).reduce((s, v) => s + v, 0)
+  if (prior === 0) return { pct: recent > 0 ? 100 : 0, trend: recent > 0 ? "up" : "neutral" }
+  const pct = Math.round(((recent - prior) / prior) * 100)
+  return { pct, trend: pct > 0 ? "up" : pct < 0 ? "down" : "neutral" }
+}

--- a/packages/dashin/src/pages/index.tsx
+++ b/packages/dashin/src/pages/index.tsx
@@ -1,29 +1,7 @@
 import React from "react"
-import { ENV, ProTip } from "@dashin-dev/dashin"
+import Dashboard from "@/components/dashboard/Dashboard"
 
-function Copyright() {
-  return (
-    <p className="text-center text-sm text-icon-muted">
-      {"Copyright © "}
-      <a href="#" className="text-inherit hover:underline">
-        {ENV.SITE_NAME}
-      </a>{" "}
-      {new Date().getFullYear()}
-      {"."}
-    </p>
-  )
-}
-
+/** Landing page → the e-commerce dashboard (rendered inside DefaultLayout). */
 export default function Index() {
-  return (
-    <div className="mx-auto max-w-xl">
-      <div className="my-8 p-6">
-        <h1 className="mb-2 text-2xl font-medium">
-          Welcome to {ENV.SITE_NAME}
-        </h1>
-        <ProTip />
-        <Copyright />
-      </div>
-    </div>
-  )
+  return <Dashboard />
 }


### PR DESCRIPTION
PR (c) of the pro e-commerce demo. Replaces the Welcome card with a real overview **dashboard** (inside DefaultLayout, so it keeps the sidebar). Everything is live from D1 via `@dashin-dev/source-d1` aggregate queries.

**Dashboard**
- KPI band (reuses `StatBand`): Revenue / Orders last 30d (7d-vs-prior-7d delta + sparkline), Customers (+new), Products (+active).
- Revenue **trend** (area+line, 30d), order-status **donut**, products-by-category **bars**, recent-orders list with status pills.

**New hand-rolled SVG charts** (no chart lib, design-token styled): `TrendChart`, `BarChart`, `Donut`.

**Testable core**: aggregate SQL + transforms (`buildDayAxis` / `mergeDailySeries` / `computeDelta`) in a pure `dashboard/queries.ts`.

**Verified**
- 15 new query/transform unit tests; full suite **117 green**.
- typecheck + `vite build` clean.
- Live local **Playwright** (`e2e/ecommerce.spec.ts`, opt-in `E2E_LIVE=1`) drives login → dashboard KPIs/charts → entity tables against a local `wrangler dev` D1 — all pass.

Screenshot reviewed (KPIs, 30-day revenue area chart with peak/latest markers, status donut, category bars, recent orders).

🤖 Generated with [Claude Code](https://claude.com/claude-code)