### PR TITLE
chore(demo): polish for the e-commerce demo

### DIFF
--- a/packages/dashin/e2e/crud.spec.ts
+++ b/packages/dashin/e2e/crud.spec.ts
@@ -43,9 +43,11 @@ test("sign-in form is reachable (best-effort) without fatal errors", async ({
   expect(errors.filter(e => fatalRe.test(e))).toHaveLength(0)
 })
 
-test("local table route renders without fatal errors", async ({ page }) => {
+test("entity table route renders without fatal errors", async ({ page }) => {
   const errors = collectErrors(page)
-  await page.goto("/myblog/local")
+  // A D1 demo resource route (data load needs a backend; here we only assert the
+  // route mounts without the fatal plugin-resolution error class).
+  await page.goto("/d1/orders")
   await page.waitForLoadState("networkidle")
   await page.waitForTimeout(1500)
   expect(errors.filter(e => fatalRe.test(e))).toHaveLength(0)

--- a/packages/dashin/src/components/TopBar/index.tsx
+++ b/packages/dashin/src/components/TopBar/index.tsx
@@ -86,7 +86,7 @@ export default function TopBar(props: TopBarProps) {
           <div className="flex-1 flex justify-center">
             <div className="w-full max-w-xl flex items-center gap-2 rounded-full border border-bn-border bg-content-bg px-4 py-2 text-sm text-icon-muted">
               <svg viewBox="0 0 24 24" className="h-4 w-4 fill-current shrink-0"><path d="M15.5 14h-.79l-.28-.27a6.5 6.5 0 10-.7.7l.27.28v.79l5 5 1.49-1.5-5-5zm-6 0A4.5 4.5 0 1114 9.5 4.5 4.5 0 019.5 14z"/></svg>
-              <span className="flex-1">Search posts, categories, users...</span>
+              <span className="flex-1">Search products, orders, customers...</span>
               <kbd className="text-xs text-icon-muted border border-bn-border rounded px-1.5 py-0.5">⌘K</kbd>
             </div>
           </div>

--- a/workers/d1-demo-api/README.md
+++ b/workers/d1-demo-api/README.md
@@ -17,7 +17,7 @@ This is what makes a **100%-free, all-Cloudflare** Dashin demo possible: D1
 
 **Safety / anti-abuse (this is a public, write-enabled API):**
 - **Per-IP rate limit** — `RATE_LIMITER` binding, 30 POSTs / 10s per client IP (429 over that). Caps request floods; Cloudflare's automatic DDoS protection covers volumetric attacks.
-- **SQL guard** — only `SELECT/INSERT/UPDATE/DELETE` on `posts`/`products`; no DDL, multi-statements or comments; statement length ≤ 2000; **`SELECT` must carry a `LIMIT` ≤ 200** (no full-table scans); ≤ 64 bound args.
+- **SQL guard** — only `SELECT/INSERT/UPDATE/DELETE` on the allow-listed store tables (`categories`, `products`, `customers`, `orders`); no DDL, multi-statements or comments; statement length ≤ 2000; an oversized literal `LIMIT` (> 200) is rejected; ≤ 64 bound args.
 - **Write cap** — `INSERT` is refused once a table hits 500 rows, so storage / the D1 write budget can't be inflated.
 - **`/reset` requires `RESET_TOKEN`** (Bearer); the cron resets without it.
 - **30-min re-seed cron** reverts any change.
@@ -54,5 +54,5 @@ npm install
 npx wrangler d1 execute dashin-demo --local --file=schema.sql   # create local tables
 npx wrangler dev                                                # http://localhost:8787
 curl -X POST localhost:8787/reset                               # seed (no token locally)
-curl -X POST localhost:8787/query -d '{"sql":"SELECT * FROM \"posts\"","args":[]}'
+curl -X POST localhost:8787/query -d '{"sql":"SELECT * FROM \"orders\" LIMIT 5","args":[]}'
 ```

--- a/wrangler.demo.jsonc
+++ b/wrangler.demo.jsonc
@@ -1,11 +1,13 @@
 // Cloudflare Workers (static assets) config for the Dashin DEMO app.
-// The demo is the admin SPA built from packages/dashin with the default
-// auth-local plugin — fully self-contained (no backend; login admin / dashin,
-// data seeded into the browser's IndexedDB).
+// The demo is the admin SPA built from packages/dashin (login admin / dashin via
+// the client-side auth-local plugin). It runs as a live e-commerce store backed
+// by Cloudflare D1 through the d1-demo-api gateway Worker — point the build at it
+// with VITE_MAIN_URL in a gitignored packages/dashin/.env.local (account-specific
+// URL stays out of git). Without that var the SPA simply has no remote data.
 //
 // Deploy (from the repo root):
 //   yarn install
-//   yarn tsc:build && yarn workspace @dashin-dev/dashin build
+//   yarn tsc:build && yarn workspace @dashin-dev/dashin build   # reads .env.local
 //   npx wrangler deploy -c wrangler.demo.jsonc
 //
 // In the Cloudflare "Workers Builds" UI use:


### PR DESCRIPTION
PR (d, code) of the pro e-commerce demo — small polish, no behavior risk.

- **TopBar** search placeholder → `products, orders, customers` (posts is gone).
- **crud e2e**: replace the dead `/myblog/local` route with `/d1/orders`.
- **worker README**: correct the SQL-guard allow-list (the four store tables), drop the stale "SELECT must carry a LIMIT" wording, refresh the curl example.
- **wrangler.demo.jsonc**: describe the live D1 backend (`VITE_MAIN_URL` via gitignored `.env.local`) instead of "no backend".

Typecheck clean. The live redeploy + live E2E is handled separately (needs account access).

🤖 Generated with [Claude Code](https://claude.com/claude-code)