### PR TITLE
fix(ci): valid YAML for the D1 deploy workflow reseed step

### DIFF
--- a/.github/workflows/deploy-d1-demo.yml
+++ b/.github/workflows/deploy-d1-demo.yml
@@ -46,4 +46,5 @@ jobs:
       # seeds within 30 min). Skipped unless GATEWAY_URL + RESET_TOKEN are set.
       - name: Reseed now (optional)
         if: ${{ env.GATEWAY_URL != '' && env.RESET_TOKEN != '' }}
-        run: curl -fsS -X POST "$GATEWAY_URL/reset" -H "Authorization: Bearer $RESET_TOKEN"
+        run: |
+          curl -fsS -X POST "$GATEWAY_URL/reset" -H "Authorization: Bearer $RESET_TOKEN"


### PR DESCRIPTION
The reseed `run:` was a plain scalar containing `Authorization: Bearer …`; the embedded colon-space made YAML parse it as a mapping, so GitHub rejected the whole workflow (and hid the `workflow_dispatch` trigger → the 422 on dispatch). Block scalar (`run: |`) fixes it. Verified with js-yaml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)