### PR TITLE
ci: GitHub Actions deploy for the demo frontend

### DIFF
--- a/.github/workflows/deploy-demo-frontend.yml
+++ b/.github/workflows/deploy-demo-frontend.yml
@@ -1,0 +1,42 @@
+name: Deploy demo frontend
+
+# Builds the Dashin demo SPA and deploys it to the Cloudflare Worker
+# `dashin-demo` (static assets) from GitHub's cloud — a reliable alternative to
+# the flaky Workers Builds connection. Auth is a Cloudflare API token in repo
+# secrets; the gateway URL is a secret too (no account values in this file).
+#
+# Manual-only (Actions tab -> Run workflow) to match ci.yml.
+#
+# Required repo secrets:
+#   CLOUDFLARE_API_TOKEN   token with Workers Scripts:Edit + Account:Read
+#   CLOUDFLARE_ACCOUNT_ID  the demo account's id
+#   VITE_MAIN_URL          the gateway Worker URL (https://<gateway>.workers.dev)
+on:
+  workflow_dispatch: {}
+
+concurrency:
+  group: deploy-demo-frontend-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      VITE_MAIN_URL: ${{ secrets.VITE_MAIN_URL }}
+      VITE_SITE_NAME: Dashin
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+      - run: yarn install --frozen-lockfile
+      # Build all package lib/ (the plugin generator requires it), then the SPA.
+      - run: yarn tsc:build
+      - name: Build SPA (Vite, reads VITE_MAIN_URL / VITE_SITE_NAME)
+        working-directory: packages/dashin
+        run: yarn build
+      - name: Deploy to Cloudflare (dashin-demo)
+        run: npx --yes wrangler@^3.99.0 deploy -c wrangler.demo.jsonc


### PR DESCRIPTION
The frontend's Workers Builds deploy went stale (last deploy 2026-06-05 01:52 UTC, before the dashboard/sidebar/polish PRs), so the live site still shows the old Welcome page. This adds a manual workflow that builds the SPA and deploys `dashin-demo` via a Cloudflare API token — reliable and off-local.

Needs one new secret: `VITE_MAIN_URL` (the gateway Worker URL). Reuses `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)