### PR TITLE
build(dashin): exclude tests from the published package

### DIFF
--- a/packages/dashin/tsconfig.pack.json
+++ b/packages/dashin/tsconfig.pack.json
@@ -27,6 +27,13 @@
     "src/serviceWorker.ts",
     "src/pages/**",
     "src/private/**",
-    "src/utils/pluginRegistry.ts"
+    "src/utils/pluginRegistry.ts",
+    "src/setupTests.ts",
+    "**/__tests__/**",
+    "**/__mocks__/**",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.spec.ts",
+    "**/*.spec.tsx"
   ]
 }


### PR DESCRIPTION
The pack tsconfig compiled `__tests__/*.test.tsx` into `lib/`, so `@dashin-dev/dashin` shipped 38 compiled test files. Exclude test/spec/mock files (+ setupTests) from `tsconfig.pack.json`.

Clean rebuild: 0 test files in lib, core exports (`index.js`, `App.js`) intact, tarball 329 files / 490 kB. Prep for the first npm publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)