### PR TITLE
fix(cli,auth): make the published packages consumable end-to-end

### DIFF
--- a/packages/dashin-cli/package.json
+++ b/packages/dashin-cli/package.json
@@ -1,7 +1,9 @@
 {
   "name": "@dashin-dev/cli",
-  "version": "2.0.0-alpha.0",
-  "publishConfig": { "access": "public" },
+  "version": "2.0.0-alpha.1",
+  "publishConfig": {
+    "access": "public"
+  },
   "license": "MIT",
   "bin": {
     "dashin": "cli.js"

--- a/packages/dashin-cli/templates/typescript-nextjs/package.json
+++ b/packages/dashin-cli/templates/typescript-nextjs/package.json
@@ -11,8 +11,8 @@
     "postinstall": "node ./postinstall.js"
   },
   "dependencies": {
-    "@dashin-dev/dashin": "^1.3.4",
-    "@dashin-dev/auth-local": "^1.3.4",
+    "@dashin-dev/dashin": "^2.0.0-alpha.0",
+    "@dashin-dev/auth-local": "^2.0.0-alpha.0",
     "next": "12.1.6"
   },
   "devDependencies": {

--- a/packages/dashin-cli/templates/typescript-vite/package.json
+++ b/packages/dashin-cli/templates/typescript-vite/package.json
@@ -10,8 +10,8 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@dashin-dev/dashin": "^1.6.0-beta.0",
-    "@dashin-dev/auth-local": "^1.6.0-beta.0",
+    "@dashin-dev/dashin": "^2.0.0-alpha.0",
+    "@dashin-dev/auth-local": "^2.0.0-alpha.0",
     "notistack": "^3.0.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/packages/dashin-cli/utils/config.ts
+++ b/packages/dashin-cli/utils/config.ts
@@ -1,14 +1,11 @@
 import { resolve } from "path"
 
-/** Home path
-  OS X - '/Users/user/Library/Preferences'
-  Windows 8 - 'C:\Users\user\AppData\Roaming'
-  Windows XP - 'C:\Documents and Settings\user\Application Data'
-  Linux - '/home/user/.local/share'
+/**
+ * Absolute path to this CLI package's root — the directory that contains
+ * `templates/`. Resolved from the compiled file's own location (this file ships
+ * as `lib/utils/config.js`, so `../..` is the package root), which works for
+ * every install method: `npx`, global, and local. The previous hardcoded global
+ * path (`<home>/npm/node_modules/dashin-cli`) only resolved in one specific
+ * layout and broke `dashin new` / `plugin` / `schema` from npm.
  */
-const homePath = process.env.APPDATA || process.env.HOME + "/.local/share"
-
-export const DASHIN_CLI_PATH =
-  process.platform == "darwin"
-    ? "/usr/local/lib/node_modules/dashin-cli"
-    : resolve(homePath, "npm/node_modules/dashin-cli")
+export const DASHIN_CLI_PATH = resolve(__dirname, "..", "..")

--- a/plugins/auth-local/package.json
+++ b/plugins/auth-local/package.json
@@ -1,9 +1,16 @@
 {
   "name": "@dashin-dev/auth-local",
-  "version": "2.0.0-alpha.0",
-  "publishConfig": { "access": "public" },
+  "version": "2.0.0-alpha.1",
+  "publishConfig": {
+    "access": "public"
+  },
   "license": "Apache-2.0",
   "main": "lib/index.js",
+  "exports": {
+    ".": "./lib/index.js",
+    "./*": "./lib/*/index.js",
+    "./package.json": "./package.json"
+  },
   "types": "lib/index.d.ts",
   "files": [
     "lib"

--- a/plugins/auth-pocketbase/package.json
+++ b/plugins/auth-pocketbase/package.json
@@ -1,9 +1,16 @@
 {
   "name": "@dashin-dev/auth-pocketbase",
-  "version": "2.0.0-alpha.0",
-  "publishConfig": { "access": "public" },
+  "version": "2.0.0-alpha.1",
+  "publishConfig": {
+    "access": "public"
+  },
   "license": "Apache-2.0",
   "main": "lib/index.js",
+  "exports": {
+    ".": "./lib/index.js",
+    "./*": "./lib/*/index.js",
+    "./package.json": "./package.json"
+  },
   "types": "lib/index.d.ts",
   "files": [
     "lib"

--- a/plugins/auth-strapi/package.json
+++ b/plugins/auth-strapi/package.json
@@ -1,9 +1,16 @@
 {
   "name": "@dashin-dev/auth-strapi",
-  "version": "2.0.0-alpha.0",
-  "publishConfig": { "access": "public" },
+  "version": "2.0.0-alpha.1",
+  "publishConfig": {
+    "access": "public"
+  },
   "license": "Apache-2.0",
   "main": "lib/index.js",
+  "exports": {
+    ".": "./lib/index.js",
+    "./*": "./lib/*/index.js",
+    "./package.json": "./package.json"
+  },
   "types": "lib/index.d.ts",
   "files": [
     "lib"


### PR DESCRIPTION
A smoke test of the published `2.0.0-alpha.0` (`npx @dashin-dev/cli new` → install → build) failed at **every** step. Three bugs, all fixed; affected packages bumped to `2.0.0-alpha.1` for republish.

1. **`dashin new` ENOENT** — `DASHIN_CLI_PATH` hardcoded to `<home>/npm/node_modules/dashin-cli` (old name, one global layout). Now resolved from the compiled file's own `__dirname` → works for npx / global / local.
2. **Scaffolds installed nothing** — templates pinned `@dashin-dev/* ^1.6.0-beta.0` / `^1.3.4` (never published). Bumped to `^2.0.0-alpha.0`.
3. **Scaffold build failed** — `@dashin-dev/auth-local/sign-in` didn't resolve (no `exports`; file at `lib/sign-in`). Added an `exports` map to auth-local, auth-pocketbase, auth-strapi.

**Verified**: scaffold + `npm install` (254 pkgs) + `vite build` all green; monorepo build unaffected (1970 modules).

🤖 Generated with [Claude Code](https://claude.com/claude-code)