### PR TITLE
docs(seo): optimize discoverability — README, npm metadata, docs meta

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Dashin
+# Dashin — AI-assisted React admin dashboard scaffold
 
-![Dashin — the plugin-based React admin scaffold](assets/banner.png)
+![Dashin — AI-assisted, plugin-based React admin dashboard scaffold (Vite + Tailwind)](assets/banner.png)
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Live demo](https://img.shields.io/badge/live%20demo-demo.dashin.dev-6366f1.svg)](https://demo.dashin.dev)
@@ -11,7 +11,7 @@
 > admin (dashboard + charts, products, orders, customers) running 100% free on Cloudflare D1.
 > Log in with `admin` / `dashin`; it's fully editable and resets every 30 minutes.
 
-**Dashin** is a scaffold to quickly build a `React` background management system. It is easy to use and can help you build a powerful background management panel. The app is powered by **Vite**, styled with **Tailwind CSS** + **Headless UI**, and uses **TipTap** for rich-text editing. If you have not used these before, don't worry — you can learn them quickly during actual use.
+**Dashin** is an open-source, plugin-based **React admin dashboard** scaffold built on **Vite + Tailwind CSS + Headless UI**. Point it at your backend — **PocketBase, Supabase, Appwrite, Directus, Strapi, or GraphQL/REST** — and Dashin gives you a **schema-validated CRUD admin panel**: tables, forms, filtering/sorting, auth, and i18n, ready to ship. It also supports **AI generation** whose output is validated against your real schema, so even cheap models produce a working admin — never freeform code. Routes, menus, CRUD pages, and auth are all plugins, and TipTap powers rich-text editing.
 
 Dashin hopes to achieve as many function reuse as possible through simple development methods, so in each Dashin project, **common functions have been built**, such as dynamic routing, multi-level menus, **permission control, data management**, search filtering and sorting, CRUD, **file management, message notification**, documenting your code, etc. You only need to build your own plugin to call it, and the Dashin plugin is also easy to learn and use.
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -2,8 +2,9 @@ import { defineConfig } from "vitepress"
 
 export default defineConfig({
   title: "Dashin",
+  titleTemplate: ":title | Dashin — React admin dashboard",
   description:
-    "Vite + Tailwind React admin scaffold with AI-assisted, schema-validated generation.",
+    "Open-source React admin dashboard scaffold — Vite + Tailwind, plugin-based, with schema-validated CRUD and AI generation. Connectors for PocketBase, Supabase, Appwrite, Directus, Strapi & GraphQL.",
   lastUpdated: true,
   cleanUrls: true,
 
@@ -13,13 +14,13 @@ export default defineConfig({
     ["link", { rel: "icon", type: "image/svg+xml", href: "/logo.svg" }],
     ["meta", { name: "theme-color", content: "#3366ff" }],
     ["meta", { property: "og:type", content: "website" }],
-    ["meta", { property: "og:title", content: "Dashin" }],
+    ["meta", { property: "og:title", content: "Dashin — AI-assisted React admin dashboard scaffold" }],
     [
       "meta",
       {
         property: "og:description",
         content:
-          "Vite + Tailwind React admin scaffold with AI-assisted, schema-validated generation."
+          "Open-source React admin dashboard scaffold — Vite + Tailwind, plugin-based, with schema-validated CRUD and AI generation. Connectors for PocketBase, Supabase, Appwrite, Directus, Strapi & GraphQL."
       }
     ],
     ["meta", { property: "og:image", content: "https://dashin.dev/og.png" }],

--- a/packages/dashin-cli/package.json
+++ b/packages/dashin-cli/package.json
@@ -63,5 +63,20 @@
     "rules": {
       "react/prop-types": "off"
     }
-  }
+  },
+  "description": "Dashin CLI — scaffold an AI-assisted React admin dashboard (Vite + Tailwind) and generate plugins & schemas from your backend.",
+  "keywords": [
+    "dashin",
+    "react-admin",
+    "admin-dashboard",
+    "admin-panel",
+    "cli",
+    "scaffold",
+    "crud-generator",
+    "generator",
+    "react",
+    "vite",
+    "internal-tools",
+    "create-admin"
+  ]
 }

--- a/packages/dashin/package.json
+++ b/packages/dashin/package.json
@@ -1,8 +1,10 @@
 {
   "name": "@dashin-dev/dashin",
   "version": "2.0.0-alpha.0",
-  "publishConfig": { "access": "public" },
-  "description": "A simple graphql admin dashboard. Easy to expand with the flexible plugin. Graphql first, also supports api. Based on React, Redux, Tailwind CSS, Headless UI, Formik, I18N.",
+  "publishConfig": {
+    "access": "public"
+  },
+  "description": "AI-assisted, plugin-based React admin dashboard scaffold — Vite + Tailwind + Headless UI, with schema-validated CRUD and backend connectors for PocketBase, Supabase, Appwrite, Directus, Strapi & GraphQL.",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -87,15 +89,25 @@
     }
   },
   "keywords": [
-    "admin",
-    "graphql",
-    "react",
-    "react admin",
-    "tailwind",
-    "tailwind admin",
-    "plugin",
+    "react-admin",
+    "admin-dashboard",
+    "admin-panel",
+    "react-admin-dashboard",
+    "admin-ui",
     "dashboard",
-    "admin panel"
+    "crud",
+    "crud-generator",
+    "react",
+    "typescript",
+    "vite",
+    "tailwindcss",
+    "headless-ui",
+    "internal-tools",
+    "low-code",
+    "graphql",
+    "ai",
+    "plugin",
+    "scaffold"
   ],
   "homepage": "https://dashin.dev/",
   "browserslist": {


### PR DESCRIPTION
Research-driven SEO pass to attract search traffic (the distribution lever for the project).

**Research:** the niche leaders — [refine](https://github.com/refinedev/refine) (34.8k★), [react-admin](https://github.com/marmelab/react-admin) (26.7k★), Appsmith, ToolJet — rank on topics/keywords Dashin was missing (`admin-dashboard`, `admin-panel`, `admin-ui`, `internal-tools`, `crud`, `frontend-framework`, `low-code`, `headless`). And the **AI schema-validated generation** angle — a hot, low-competition search space ([ai admin/crud generators](https://refine.dev/blog/react-admin-dashboard/)) — wasn't surfaced anywhere.

**Changes**
- **README**: keyword-rich H1, banner alt, and a rewritten intro leading with searched terms (react admin dashboard/panel, CRUD, backend connectors, AI generation) — replacing vague "background management system" phrasing.
- **npm metadata**: rewrote `@dashin-dev/dashin`'s stale description (still named Redux/Formik/"graphql first") + 19 keywords; added a description + 12 keywords to `@dashin-dev/cli` (had neither). Applies on next publish.
- **docs (VitePress)**: keyword-rich meta description, `og:title`/`description`, and a `titleTemplate` for descriptive subpage `<title>`s.

**Also done via API** (live now): GitHub **About** rewritten + **20 topics** set (added the high-traffic ones, dropped `i18next`/`graphql-admin`/`dashin`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)