### PR TITLE
docs(seo): target "[backend] admin panel" searches + fix docs build

### DIFF
--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -57,7 +57,7 @@ Cloudflare project from the docs (suggested domain: `demo.dashin.dev`).
 
 Because it's a yarn-workspace build (not a single VitePress folder), the
 account's "Build output directory" field doesn't fit — use the committed
-[`wrangler.demo.jsonc`](../wrangler.demo.jsonc), which declares the output via
+[`wrangler.demo.jsonc`](https://github.com/dashindev/dashin/blob/master/wrangler.demo.jsonc), which declares the output via
 `assets.directory`.
 
 ## One-time setup (Cloudflare dashboard)

--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -1,4 +1,9 @@
-# AI-Assisted Admin Generation
+---
+title: "AI admin panel generator"
+description: "Generate a React admin panel with AI using Dashin. Point it at your backend, the AI reads your schema and produces a validated CRUD admin. BYOK; cheap models work."
+---
+
+# AI admin panel generator (schema-validated)
 
 > Point dashin at your backend → AI introspects the schema → generates a
 > working, **validated** admin. Bring your own key (BYOK); cheap models work

--- a/docs/appwrite/README.md
+++ b/docs/appwrite/README.md
@@ -1,4 +1,9 @@
-# Appwrite Connector
+---
+title: "Appwrite admin panel"
+description: "Build an Appwrite admin panel with Dashin, a React admin dashboard over Appwrite Databases. CRUD, filter, sort and bulk actions on your collections, no custom UI."
+---
+
+# Appwrite admin panel with Dashin
 
 `@dashin-dev/source-appwrite` — use [Appwrite](https://appwrite.io)
 Databases as the data source for any dashin schema (list / filter / sort /

--- a/docs/d1/README.md
+++ b/docs/d1/README.md
@@ -1,4 +1,9 @@
-# Cloudflare D1
+---
+title: "Cloudflare D1 admin panel"
+description: "Build a Cloudflare D1 admin panel with Dashin, a React admin dashboard with CRUD over your D1 serverless SQLite database. See the live demo at demo.dashin.dev."
+---
+
+# Cloudflare D1 admin panel with Dashin
 
 Run Dashin **100% free on Cloudflare** with a real SQL database.
 [`@dashin-dev/source-d1`](https://github.com/dashindev/dashin/tree/master/packages/dashin-source-d1)

--- a/docs/directus/README.md
+++ b/docs/directus/README.md
@@ -1,4 +1,9 @@
-# Directus Connector
+---
+title: "Directus custom admin panel"
+description: "Build a custom React admin panel on Directus with Dashin. CRUD tables, filtering and sorting over the Directus Items API, themeable and plugin-based."
+---
+
+# Custom Directus admin panel with Dashin
 
 `@dashin-dev/source-directus` — use [Directus](https://directus.io) as the
 data source (list / filter / sort / CRUD / bulk via the Items REST API).

--- a/docs/payload/README.md
+++ b/docs/payload/README.md
@@ -1,4 +1,9 @@
-# Payload Connector
+---
+title: "Payload CMS admin panel"
+description: "Build a Payload CMS admin panel with Dashin, a React admin dashboard with CRUD, filter and sort over Payload’s REST API. A custom front-end for your collections."
+---
+
+# Payload admin panel with Dashin
 
 `@dashin-dev/source-payload` — use [Payload CMS](https://payloadcms.com) as
 the data source (list / filter / sort / CRUD / bulk via the REST API).

--- a/docs/pocketbase/README.md
+++ b/docs/pocketbase/README.md
@@ -1,4 +1,9 @@
-# Using PocketBase with Dashin
+---
+title: "PocketBase admin panel"
+description: "Build a PocketBase admin panel with Dashin, an open-source React admin dashboard. Schema-validated CRUD, auth, filter and sort over PocketBase’s REST API."
+---
+
+# PocketBase admin panel with Dashin
 
 [PocketBase](https://pocketbase.io) is a single-binary backend (auth + collections
 + REST API, embedded SQLite) — a zero-build way to run a real auth + CMS backend

--- a/docs/supabase/README.md
+++ b/docs/supabase/README.md
@@ -1,4 +1,9 @@
-# Supabase / Postgres Connector
+---
+title: "Supabase admin panel (Postgres)"
+description: "Build a Supabase / Postgres admin panel with Dashin, a React admin dashboard with CRUD tables, filtering and sorting over PostgREST. Connect your tables and ship."
+---
+
+# Supabase admin panel with Dashin
 
 `@dashin-dev/source-supabase` — use [Supabase](https://supabase.com)
 (PostgREST) as the data source for any dashin schema. Same table UI, backed by

--- a/docs/turso/README.md
+++ b/docs/turso/README.md
@@ -1,4 +1,9 @@
-# Turso / libSQL Connector
+---
+title: "Turso / libSQL admin panel"
+description: "Build a Turso / libSQL admin panel with Dashin, a React admin dashboard with CRUD over your edge SQLite database. Filter, sort and edit your tables, no boilerplate."
+---
+
+# Turso / libSQL admin panel with Dashin
 
 `@dashin-dev/source-turso` — use [Turso](https://turso.tech) / libSQL
 (SQLite over HTTP) as the data source, with **full CRUD via SQL**.


### PR DESCRIPTION
Long-tail SEO for the connector/AI pages — high-intent, low-competition terms Dashin genuinely serves. Each gets frontmatter (`title` + meta `description`) and a retargeted H1: **PocketBase / Supabase (Postgres) / Appwrite / Directus / Turso·libSQL / Payload / Cloudflare D1 admin panel**, and **AI admin panel generator**. With the `titleTemplate` these render as e.g. "PocketBase admin panel | Dashin — React admin dashboard".

**Also fixes the docs build** 🔧 — a dead link (`../wrangler.demo.jsonc`) in `DEPLOY.md` was failing `vitepress build` (dead links are build errors), which is almost certainly why the docs **Cloudflare Pages deploy was broken** and `dashin.dev` didn't resolve. Repointed to a GitHub URL; docs now build clean (70s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)