### PR TITLE
feat(demo): turn the dead "Upgrade Now" into a Pro waitlist

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -48,6 +48,7 @@ export default defineConfig({
       { text: "Features", link: "/features/tables" },
       { text: "AI Generation", link: "/ai/" },
       { text: "Connectors", link: "/connectors/" },
+      { text: "Pro", link: "/pro" },
       { text: "GitHub", link: "https://github.com/dashindev/dashin" }
     ],
     sidebar: [

--- a/docs/pro.md
+++ b/docs/pro.md
@@ -1,0 +1,49 @@
+---
+title: Dashin Pro
+description: Dashin stays open-source and free. Dashin Pro (coming) adds what teams need to run a React admin in production — SSO, audit logs, premium connectors, white-label, and priority support. Register your interest.
+---
+
+# Dashin Pro — coming for teams
+
+::: tip Dashin is, and stays, open-source and free.
+The whole scaffold, CLI, every open connector, AI generation (BYOK), theming, i18n —
+**and full RBAC / permissions** — are free and MIT-spirited forever. An individual builder
+never hits a paywall. **Dashin Pro** is a separate, optional tier for **teams and companies**
+that need to run Dashin in production.
+:::
+
+## What Pro will add
+
+The things teams expense to operate an admin at work — none of which cripple the free product:
+
+| | |
+| --- | --- |
+| **SSO / SAML** | Enterprise sign-in beyond the open auth plugins |
+| **Audit log** | Change history / who-did-what over your data |
+| **Premium connectors** | Salesforce, Dynamics, SAP, MSSQL, and more |
+| **White-label** | Remove branding, advanced theming |
+| **Premium templates** | Production starter kits (e-commerce, CRM, SaaS) |
+| **Priority support + SLA** | Direct help, private channel |
+
+> Pricing is planned as a **perpetual license + 1 year of updates** (no subscription lock-in).
+> Hosted AI generation may follow later.
+
+## What stays free (the core)
+
+- Full project scaffold + CLI (`dashin new`, `dashin plugin`, `dashin schema`)
+- Every open data-source connector (PocketBase, Supabase/Postgres, Appwrite, Directus, Strapi,
+  Turso, Payload, Cloudflare D1, GraphQL/REST)
+- AI-assisted generation (bring your own key)
+- **RBAC / permissions**, theming, i18n, the plugin system
+- The live [demo](https://demo.dashin.dev) and these docs
+
+## Register your interest
+
+Pro is **not for sale yet** — it's being designed *with* its first users. If you'd want it for
+your team (or want to shape what's in it):
+
+- 💬 **[Tell us on GitHub Discussions →](https://github.com/dashindev/dashin/discussions)** — say
+  what you'd need; it directly informs what gets built first.
+- ⭐ **[Star the repo](https://github.com/dashindev/dashin)** and **Watch** for the launch.
+
+No email required, no spam — just a signal that helps prioritize the build.

--- a/packages/dashin/src/pages/[group]-[name].tsx
+++ b/packages/dashin/src/pages/[group]-[name].tsx
@@ -72,8 +72,10 @@ const DynamicGroupNamePage = ({
       layout={layout}
       sidebarUpgrade={{
         title: "Dashin Pro",
-        description: "Unlock advanced features and premium components.",
-        cta: "Upgrade Now"
+        description: "Advanced features for teams — coming soon.",
+        cta: "Join the waitlist",
+        onClick: () =>
+          window.open("https://dashin.dev/pro", "_blank", "noopener")
       }}
     >
       {render}


### PR DESCRIPTION
The demo sidebar's **Dashin Pro / Upgrade Now** was a dead button advertising a tier that doesn't exist. Per the locked strategy (monetization deferred; capture intent first), repurpose it into a real **waitlist** rather than remove it:

- **New `docs/pro.md` → `dashin.dev/pro`**: honest *"Dashin stays free + open-source (RBAC included)"* + what Pro adds for teams (SSO, audit, premium connectors, white-label, templates, priority support) + **register-interest via GitHub Discussions** (enabled).
- **Demo CTA** → "Join the waitlist", wired to open `dashin.dev/pro`.
- **Pro** added to the docs nav.

Only the **demo** opts in — CLI templates don't inject it, so scaffolded user apps stay clean (verified). Docs build + app typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)