### PR TITLE
fix(ui): dashboard wrapper, sidebar overflow, remove fake search

### DIFF
--- a/packages/dashin/src/components/TopBar/index.tsx
+++ b/packages/dashin/src/components/TopBar/index.tsx
@@ -81,16 +81,9 @@ export default function TopBar(props: TopBarProps) {
           </div>
         )}
 
-        {/* Centered search (mockup-3) */}
-        {!isDoc && (
-          <div className="flex-1 flex justify-center">
-            <div className="w-full max-w-xl flex items-center gap-2 rounded-full border border-bn-border bg-content-bg px-4 py-2 text-sm text-icon-muted">
-              <svg viewBox="0 0 24 24" className="h-4 w-4 fill-current shrink-0"><path d="M15.5 14h-.79l-.28-.27a6.5 6.5 0 10-.7.7l.27.28v.79l5 5 1.49-1.5-5-5zm-6 0A4.5 4.5 0 1114 9.5 4.5 4.5 0 019.5 14z"/></svg>
-              <span className="flex-1">Search products, orders, customers...</span>
-              <kbd className="text-xs text-icon-muted border border-bn-border rounded px-1.5 py-0.5">⌘K</kbd>
-            </div>
-          </div>
-        )}
+        {/* Center spacer. (A real global search / ⌘K command palette is a
+            planned feature — we don't ship a non-functional search box.) */}
+        {!isDoc && <div className="flex-1" />}
 
         <div className="flex items-center gap-1 shrink-0">
           {prependRight}

--- a/packages/dashin/src/components/dashboard/Dashboard.tsx
+++ b/packages/dashin/src/components/dashboard/Dashboard.tsx
@@ -77,10 +77,15 @@ export default function Dashboard() {
             run(newCustomersQuery(DAYS))
           ])
 
-        const firstErr = [daily, status, cats, recent, custTotal, prodTotal, prodActive, newCust]
-          .map(r => r.error)
-          .find(Boolean)
-        if (firstErr) throw new Error(typeof firstErr === "string" ? firstErr : JSON.stringify(firstErr))
+        // Degrade gracefully: a single transient failure (e.g. the gateway's
+        // per-IP rate limit on the query burst) shouldn't blank the whole
+        // dashboard — each section falls back to its empty data below. Only
+        // surface the error card if EVERY query failed (gateway unreachable).
+        const all = [daily, status, cats, recent, custTotal, prodTotal, prodActive, newCust]
+        if (all.every(r => r.error)) {
+          const e = all[0].error
+          throw new Error(typeof e === "string" ? e : JSON.stringify(e))
+        }
 
         const axis = buildDayAxis(new Date(), DAYS)
         const revSeries = mergeDailySeries(daily.rows, axis, "revenue")

--- a/packages/dashin/src/components/regions/SidebarFooter.tsx
+++ b/packages/dashin/src/components/regions/SidebarFooter.tsx
@@ -44,10 +44,12 @@ export default function SidebarFooter({
   // "upgrade"
   if (!upgrade) return null
   return (
-    <div className="m-3 p-4 rounded-bn border border-bn-border bg-primary/5">
+    <div className="m-3 p-4 rounded-bn border border-bn-border bg-primary/5 whitespace-normal">
       <div className="text-sm font-semibold text-foreground">{upgrade.title}</div>
       {upgrade.description && (
-        <p className="mt-1 text-xs text-icon-muted">{upgrade.description}</p>
+        <p className="mt-1 text-xs leading-snug text-icon-muted break-words">
+          {upgrade.description}
+        </p>
       )}
       {upgrade.cta && (
         <button

--- a/packages/dashin/src/pages/[group]-[name].tsx
+++ b/packages/dashin/src/pages/[group]-[name].tsx
@@ -60,6 +60,9 @@ const DynamicGroupNamePage = ({
   const layout = {
     ...LAYOUT_A,
     statBand: isListView,
+    // The dashboard (group undefined) carries its own cards — don't double-wrap
+    // it in the white content-box; let them sit on the page background.
+    contentCard: group !== undefined,
     sidebarFooter: "upgrade" as const,
     buttons: "labeled" as const
   }

--- a/packages/dashin/src/private/DefaultLayout/index.tsx
+++ b/packages/dashin/src/private/DefaultLayout/index.tsx
@@ -119,9 +119,13 @@ export default function DefaultLayout(props: DefaultLayoutProps) {
               ) : (
                 liveStats === null && <StatBandSkeleton />
               ))}
-            <div className="bg-content-box overflow-hidden rounded-bn h-full shadow">
-              {children}
-            </div>
+            {layout.contentCard === false ? (
+              children
+            ) : (
+              <div className="bg-content-box overflow-hidden rounded-bn h-full shadow">
+                {children}
+              </div>
+            )}
           </StatsContext.Provider>
         </div>
       </div>

--- a/packages/dashin/src/utils/themes/layouts.ts
+++ b/packages/dashin/src/utils/themes/layouts.ts
@@ -20,6 +20,12 @@ export interface LayoutConfig {
   buttons: "icon" | "labeled"
   /** Table row density. */
   density: "comfortable" | "compact"
+  /**
+   * Wrap page content in the white content-box card. Default (undefined/true)
+   * suits tables; set false for self-carded pages like the dashboard so their
+   * own cards sit on the page background instead of white-on-white.
+   */
+  contentCard?: boolean
 }
 
 export const LAYOUT_A: LayoutConfig = {


### PR DESCRIPTION
Demo-feedback polish — all **framework-level** (also fixes scaffolded user apps):

1. **Dashboard double-card** — content was wrapped in a white `content-box`, so the dashboard's own cards sat white-on-white. New `contentCard` layout flag (default = card, for tables); the dashboard sets it false so its cards sit on the page background.
2. **Sidebar "Pro" text clipped** — the `<aside>` has `whitespace-nowrap` (collapse animation) which cascaded into the footer; reset with `whitespace-normal` + `break-words` so it wraps in the box.
3. **Removed the fake search box** from the TopBar (spacer instead) — no shipping a non-functional control; a real ⌘K palette can come later.
4. **Dashboard resilience** — degrade gracefully on a transient query failure (the gateway's per-IP rate limit on the burst was making cards intermittently "not work"); only error the whole dashboard if *every* query fails.

Verified: typecheck + `vite build` clean; local screenshot against the live gateway confirms all four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)