### PR TITLE
fix: Payload support, prod-build CJS init, theme, ESM plugins (+ docs, tests, smoke)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,23 @@ jobs:
       - name: E2E smoke (Playwright)
         working-directory: packages/dashin
         run: yarn e2e
+
+  # Consumer prod-build smoke: scaffold the Vite template against locally-packed
+  # @dashin-dev/* tarballs, run a production `vite build`, and headless-load the
+  # preview. Catches prod-only regressions unit tests can't (CJS init crashes,
+  # i18n glob, unstyled shell). Manual-only like the rest.
+  template-smoke:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+      - run: yarn install --frozen-lockfile
+      - run: yarn tsc:build
+      - name: Install Playwright browser (chromium)
+        run: npx playwright install --with-deps chromium
+      - name: Template prod-build smoke
+        run: node scripts/smoke/template-prod-smoke.mjs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **`@dashin-dev/auth-payload`** — auth plugin for a Payload CMS backend
+  (email/password → JWT, stored for `@dashin-dev/source-payload`). The Payload
+  demo referenced this package but it didn't exist.
+
+### Fixed
+
+- **Production build crash** — the Vite template now sets
+  `build.commonjsOptions.strictRequires`, so production builds no longer throw
+  `Object.defineProperty called on non-object` (Rollup evaluating a CommonJS
+  module before its exports object exists; the dev/esbuild path tolerated it).
+- **Dev startup crash** — the template `pluginRegistry` excludes the CommonJS
+  core package from the plugin-i18n `import.meta.glob`, fixing
+  `exports is not defined` (core i18n init already runs via the optimized core
+  bundle).
+- **Template theme** — the template adopts the core token system
+  (`tailwind.config` + `--bn-*` CSS variables, light/dark), so a freshly
+  scaffolded app's shell renders fully styled (sidebar, borders, radius,
+  gradient logo) and the theme toggle works.
+- **`source-payload` double `/api`** — `apiBase()` strips a trailing `/api`
+  from the configured base, so `VITE_MAIN_URL` set to either the origin or
+  origin + `/api` works (no more `/api/api/…` and empty tables).
+- **ESM plugin packages** — the plugin generator loads plugins via `require()`
+  with a dynamic-import fallback, so ESM (not just CommonJS) plugin packages are
+  supported.
+
+### Docs
+
+- Document `@dashin-dev/auth-payload`, the `VITE_MAIN_URL` = origin convention,
+  and CORS in the Payload guide + demo; add Payload to the README backend list.
+
 ## 2.0.0-alpha.0
 
 ### BREAKING — Rebranded BunAdmin → Dashin (`@dashin-dev`)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 > admin (dashboard + charts, products, orders, customers) running 100% free on Cloudflare D1.
 > Log in with `admin` / `dashin`; it's fully editable and resets every 30 minutes.
 
-**Dashin** is an open-source, plugin-based **React admin dashboard** scaffold built on **Vite + Tailwind CSS + Headless UI**. Point it at your backend — **PocketBase, Supabase, Appwrite, Directus, Strapi, or GraphQL/REST** — and Dashin gives you a **schema-validated CRUD admin panel**: tables, forms, filtering/sorting, auth, and i18n, ready to ship. It also supports **AI generation** whose output is validated against your real schema, so even cheap models produce a working admin — never freeform code. Routes, menus, CRUD pages, and auth are all plugins, and TipTap powers rich-text editing.
+**Dashin** is an open-source, plugin-based **React admin dashboard** scaffold built on **Vite + Tailwind CSS + Headless UI**. Point it at your backend — **PocketBase, Payload CMS, Supabase, Appwrite, Directus, Turso, Strapi, or GraphQL/REST** — and Dashin gives you a **schema-validated CRUD admin panel**: tables, forms, filtering/sorting, auth, and i18n, ready to ship. It also supports **AI generation** whose output is validated against your real schema, so even cheap models produce a working admin — never freeform code. Routes, menus, CRUD pages, and auth are all plugins, and TipTap powers rich-text editing.
 
 Dashin hopes to achieve as many function reuse as possible through simple development methods, so in each Dashin project, **common functions have been built**, such as dynamic routing, multi-level menus, **permission control, data management**, search filtering and sorting, CRUD, **file management, message notification**, documenting your code, etc. You only need to build your own plugin to call it, and the Dashin plugin is also easy to learn and use.
 
@@ -54,9 +54,11 @@ Bring your own key: set `DASHIN_AI_PROVIDER` (openai | anthropic | ollama) +
 ## Backend connectors
 
 Swap data sources via plugins — same table/CRUD UI on any backend:
-**PocketBase** (`@dashin-dev/source-pocketbase`), **Appwrite**
-(`@dashin-dev/source-appwrite`), **Strapi**, **GraphQL**.
-See [`docs/pocketbase/`](docs/pocketbase/).
+**PocketBase** (`@dashin-dev/source-pocketbase`), **Payload CMS**
+(`@dashin-dev/source-payload` + `@dashin-dev/auth-payload`), **Appwrite**
+(`@dashin-dev/source-appwrite`), **Supabase**, **Directus**, **Turso**,
+**Strapi**, **GraphQL**.
+See [`docs/connectors/`](docs/connectors/) (or [`docs/payload/`](docs/payload/)).
 
 ## Online demo
 

--- a/docs/payload/README.md
+++ b/docs/payload/README.md
@@ -20,7 +20,34 @@ yarn add @dashin-dev/source-payload
 VITE_MAIN_URL=https://your-payload-app.example.com
 ```
 
-Auth uses the dashin stored token as `Authorization: Bearer …`.
+`VITE_MAIN_URL` is the API **origin** (no `/api`) — the connector appends the
+Payload `/api` segment itself. A trailing `/api` is tolerated (so
+`https://app.example.com/api` also works) and won't produce a `/api/api/…`
+double-prefix.
+
+## Auth (sign-in)
+
+Use **`@dashin-dev/auth-payload`** to sign in against a Payload auth collection
+and store the JWT — which `source-payload` then sends as `Authorization: Bearer …`
+on every request.
+
+```bash
+yarn add @dashin-dev/auth-payload
+```
+
+`.env`:
+
+```
+VITE_AUTH_PLUGIN=@dashin-dev/auth-payload
+VITE_AUTH_URL=https://your-payload-app.example.com
+```
+
+It posts `email` / `password` to `POST /api/{collection}/login` (default
+collection `users`) and persists the returned token. The sign-in screen is shown
+automatically for unauthenticated users.
+
+> CORS: a browser SPA on a different origin needs the Payload server to allow it.
+> Set `cors` in your Payload config (e.g. the dashboard origin, or `'*'`).
 
 ## Use in a schema
 

--- a/examples/payload-demo/README.md
+++ b/examples/payload-demo/README.md
@@ -26,11 +26,23 @@ docker compose up -d
 dashin new my-admin && cd my-admin
 ```
 
-`.env`:
+Install the Payload auth + data plugins:
+```bash
+yarn add @dashin-dev/auth-payload @dashin-dev/source-payload
+```
+
+`.env` (note: the URLs are the API **origin** — no `/api`. `source-payload` and
+`auth-payload` append the Payload `/api` segment themselves; setting
+`…/api` here causes a double `/api/api/...` and empty tables):
 ```
 VITE_AUTH_PLUGIN=@dashin-dev/auth-payload
+VITE_MAIN_URL=http://127.0.0.1:3001
 VITE_AUTH_URL=http://127.0.0.1:3001
 ```
+
+`@dashin-dev/auth-payload` signs in against a Payload auth collection
+(`POST /api/users/login` with email/password → JWT) and stores the token so
+`source-payload` sends it as a Bearer token on every request.
 
 Generate a validated admin table from the live `posts` collection (BYOK):
 ```bash

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "turbo:lint": "turbo run lint",
     "turbo:dev": "turbo run dev",
     "docs:dev": "npm run dev --prefix docs",
-    "docs:contributors": "bash scripts/gen-docs-contributors.sh"
+    "docs:contributors": "bash scripts/gen-docs-contributors.sh",
+    "smoke:template": "node scripts/smoke/template-prod-smoke.mjs"
   },
   "devDependencies": {
     "@esbuild/linux-x64": "0.21.5",

--- a/packages/dashin-cli/templates/typescript-vite/src/pluginRegistry.ts
+++ b/packages/dashin-cli/templates/typescript-vite/src/pluginRegistry.ts
@@ -17,9 +17,17 @@ const pluginsDataTs = import.meta.glob("./.dashin/dynamic/pluginsData.ts", {
 const dynamicLazy = import.meta.glob("./.dashin/dynamic/**/*/index.js")
 // Local override/customized plugins (src/plugins/**).
 const localPlugins = import.meta.glob("./plugins/**/index.{ts,tsx}")
-// Plugin i18n bundles (installed @dashin-dev packages), consumed synchronously.
+// Plugin i18n bundles (installed @dashin-dev *plugin* packages), consumed
+// synchronously. The dashin CORE package is excluded: it ships CommonJS and is
+// served raw via this absolute-path glob (Vite can't CJS->ESM-interop it, so
+// the browser throws "exports is not defined"), and its i18n init already runs
+// through the optimized core bundle (TopBar/I18nMenu -> utils/i18n), so loading
+// it here is both broken and redundant.
 const pluginI18n = import.meta.glob(
-  "/node_modules/@dashin-dev/*/lib/utils/i18n/*.js",
+  [
+    "/node_modules/@dashin-dev/*/lib/utils/i18n/*.js",
+    "!/node_modules/@dashin-dev/dashin/**"
+  ],
   { eager: true }
 )
 

--- a/packages/dashin-cli/templates/typescript-vite/src/tailwind.css
+++ b/packages/dashin-cli/templates/typescript-vite/src/tailwind.css
@@ -2,11 +2,65 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Design tokens — mirror @dashin-dev/dashin (default preset: "modern").
+   :root = light, .dark = dark. Keep in sync with the core package. */
+@layer base {
+  :root {
+    --bn-bg: #f8fafc;
+    --bn-surface: #ffffff;
+    --bn-sidebar: #ffffff;
+    --bn-foreground: #1e293b;
+    --bn-muted: #94a3b8;
+    --bn-border: #eef2f7;
+    --bn-primary: #6366f1;
+    --bn-primary-gradient: linear-gradient(135deg, #3b82f6, #8b5cf6);
+    --bn-primary-foreground: #ffffff;
+    --bn-success: #10b981;
+    --bn-warning: #f59e0b;
+    --bn-danger: #ef4444;
+    --bn-radius: 12px;
+    --bn-shadow: 0 4px 12px rgba(2, 6, 23, 0.08);
+    --bn-ring: #6366f1;
+    --bn-primary-hover: #4f46e5;
+  }
+  .dark {
+    --bn-bg: #0a0e1a;
+    --bn-surface: #111729;
+    --bn-sidebar: #0a0e1a;
+    --bn-foreground: #e5e7eb;
+    --bn-muted: #64748b;
+    --bn-border: #1e293b;
+    --bn-primary: #818cf8;
+    --bn-primary-gradient: linear-gradient(135deg, #3b82f6, #8b5cf6);
+    --bn-primary-foreground: #ffffff;
+    --bn-success: #34d399;
+    --bn-warning: #fbbf24;
+    --bn-danger: #f87171;
+    --bn-radius: 12px;
+    --bn-shadow: 0 6px 20px rgba(0, 0, 0, 0.5);
+    --bn-ring: #818cf8;
+    --bn-primary-hover: #6366f1;
+  }
+}
+
 @layer base {
   body {
-    background: #edf1f7;
+    background: var(--bn-bg);
+    color: var(--bn-foreground);
   }
   img {
     width: 100%;
+  }
+  *::-webkit-scrollbar {
+    width: 8px;
+  }
+  *::-webkit-scrollbar-track {
+    -webkit-box-shadow: inset 0 0 6px rgba(0, 0, 0, 0);
+  }
+  *::-webkit-scrollbar-thumb {
+    cursor: pointer;
+    border: 2px solid white;
+    border-radius: 4px;
+    background-color: rgba(0, 0, 0, 0.3);
   }
 }

--- a/packages/dashin-cli/templates/typescript-vite/tailwind.config.js
+++ b/packages/dashin-cli/templates/typescript-vite/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: "class",
   content: [
     "./index.html",
     "./src/**/*.{ts,tsx}",
@@ -8,13 +9,37 @@ module.exports = {
   ],
   theme: {
     extend: {
+      // Token-driven theme — mirrors @dashin-dev/dashin's tailwind.config +
+      // the --bn-* CSS variables in src/tailwind.css (light = :root, dark =
+      // .dark). Keep in sync with the core package so the app shell (TopBar,
+      // sidebar, cards, borders, radius, gradient logo) renders fully styled
+      // and the theme toggle works.
       colors: {
-        primary: "#36f",
-        secondary: "#00d68f",
-        danger: "#ff1744",
-        "content-bg": "#EDF1F7",
-        "content-box": "#FFF",
-        "icon-muted": "#8f9bb3"
+        primary: "var(--bn-primary)",
+        "primary-foreground": "var(--bn-primary-foreground)",
+        "primary-hover": "var(--bn-primary-hover)",
+        secondary: "var(--bn-success)",
+        success: "var(--bn-success)",
+        warning: "var(--bn-warning)",
+        danger: "var(--bn-danger)",
+        "content-bg": "var(--bn-bg)",
+        "content-box": "var(--bn-surface)",
+        sidebar: "var(--bn-sidebar)",
+        foreground: "var(--bn-foreground)",
+        "icon-muted": "var(--bn-muted)",
+        "bn-border": "var(--bn-border)"
+      },
+      borderRadius: {
+        bn: "var(--bn-radius)"
+      },
+      boxShadow: {
+        bn: "var(--bn-shadow)"
+      },
+      ringColor: {
+        bn: "var(--bn-ring)"
+      },
+      backgroundImage: {
+        "primary-gradient": "var(--bn-primary-gradient)"
       }
     }
   },

--- a/packages/dashin-cli/templates/typescript-vite/vite.config.ts
+++ b/packages/dashin-cli/templates/typescript-vite/vite.config.ts
@@ -46,6 +46,18 @@ export default defineConfig(({ mode }) => {
     plugins: [dashinGenerator(mode), react()],
     define,
     server: { port: 3000 },
-    resolve: { alias: { "@": path.resolve(__dirname, "src") } }
+    resolve: { alias: { "@": path.resolve(__dirname, "src") } },
+    build: {
+      // @dashin-dev/* packages ship CommonJS. Rollup's default
+      // strictRequires:'auto' can evaluate some transitive CJS modules before
+      // their exports object exists, throwing "Object.defineProperty called on
+      // non-object" at runtime in the production build (the dev/esbuild path
+      // tolerates it). Forcing strictRequires wraps every CJS module so it
+      // initializes lazily in the correct order.
+      commonjsOptions: {
+        strictRequires: true,
+        transformMixedEsModules: true
+      }
+    }
   }
 })

--- a/packages/dashin-source-payload/services/__tests__/plConfig.test.ts
+++ b/packages/dashin-source-payload/services/__tests__/plConfig.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from "vitest"
+
+vi.mock("@dashin-dev/dashin", () => ({
+  ENV: { MAIN_URL: "http://pl.test", AUTH_URL: "http://auth.test" },
+  storedToken: async () => "tok"
+}))
+
+import { apiBase, apiPath, plHeaders } from "../plConfig"
+
+describe("apiPath", () => {
+  it("builds the collection endpoint with the /api segment", () => {
+    expect(apiPath("posts")).toBe("/api/posts")
+  })
+  it("appends the id when provided", () => {
+    expect(apiPath("posts", "42")).toBe("/api/posts/42")
+  })
+})
+
+describe("apiBase", () => {
+  it("leaves a bare origin unchanged", () => {
+    expect(apiBase("https://x.com")).toBe("https://x.com")
+  })
+  it("strips a trailing /api (and /api/) so apiPath can't double it", () => {
+    expect(apiBase("https://x.com/api")).toBe("https://x.com")
+    expect(apiBase("https://x.com/api/")).toBe("https://x.com")
+  })
+  it("does not strip /api in the middle of the path", () => {
+    expect(apiBase("https://x.com/api/v2")).toBe("https://x.com/api/v2")
+  })
+  it("prefers the explicit prefix, else falls back to MAIN_URL", () => {
+    expect(apiBase("https://y.com/api")).toBe("https://y.com")
+    expect(apiBase()).toBe("http://pl.test")
+  })
+})
+
+describe("plHeaders", () => {
+  it("sends the stored token as a Bearer header", async () => {
+    expect(await plHeaders()).toEqual({ Authorization: "Bearer tok" })
+  })
+  it("merges extra headers", async () => {
+    expect(await plHeaders({ "X-Test": "1" })).toEqual({
+      Authorization: "Bearer tok",
+      "X-Test": "1"
+    })
+  })
+})

--- a/packages/dashin-source-payload/services/bulk.ts
+++ b/packages/dashin-source-payload/services/bulk.ts
@@ -1,5 +1,5 @@
-import { ENV, request, notice, BulkDeleteProps, BulkUpdateProps } from "@dashin-dev/dashin"
-import { plHeaders, apiPath } from "./plConfig"
+import { request, notice, BulkDeleteProps, BulkUpdateProps } from "@dashin-dev/dashin"
+import { plHeaders, apiPath, apiBase } from "./plConfig"
 
 async function batchNotice(t: any, n: number, ok: number, fail: number) {
   await notice({
@@ -18,7 +18,7 @@ export async function bulkDeleteSer<T extends object>({
   for (const item of data) {
     // @ts-ignore
     const res = await request(apiPath(SchemaName, item[primaryKey]), {
-      prefix: ENV.MAIN_URL || ENV.AUTH_URL, method: "DELETE", headers
+      prefix: apiBase(), method: "DELETE", headers
     })
     resList.push(res)
     res && res.errors ? fail++ : ok++
@@ -35,7 +35,7 @@ export async function bulkUpdateSer<T>({ t, SchemaName, changes }: BulkUpdatePro
   for (const c of list) {
     const { oldData, newData } = c as any
     const res = await request(apiPath(SchemaName, oldData.id), {
-      prefix: ENV.MAIN_URL || ENV.AUTH_URL, method: "PATCH", headers, data: newData
+      prefix: apiBase(), method: "PATCH", headers, data: newData
     })
     resList.push(res)
     res && res.errors ? fail++ : ok++

--- a/packages/dashin-source-payload/services/crud.ts
+++ b/packages/dashin-source-payload/services/crud.ts
@@ -1,5 +1,5 @@
-import { EditableCtrl, ENV, request, notice } from "@dashin-dev/dashin"
-import { plHeaders, apiPath } from "./plConfig"
+import { EditableCtrl, request, notice } from "@dashin-dev/dashin"
+import { plHeaders, apiPath, apiBase } from "./plConfig"
 
 interface Add<R> extends EditableCtrl { newData: R }
 interface Upd<R> extends EditableCtrl { newData: R; oldData: R; primaryKey?: string }
@@ -7,7 +7,7 @@ interface Del<R> extends EditableCtrl { oldData: R; primaryKey?: string }
 
 export async function addSer({ t, SchemaName, newData }: Add<any>) {
   const res = await request(apiPath(SchemaName), {
-    prefix: ENV.MAIN_URL || ENV.AUTH_URL, method: "POST", headers: await plHeaders(), data: newData
+    prefix: apiBase(), method: "POST", headers: await plHeaders(), data: newData
   })
   await notice(
     res && res.errors
@@ -19,7 +19,7 @@ export async function addSer({ t, SchemaName, newData }: Add<any>) {
 
 export async function updateSer({ t, SchemaName, newData, oldData, primaryKey = "id" }: Upd<any>) {
   const res = await request(apiPath(SchemaName, oldData[primaryKey]), {
-    prefix: ENV.MAIN_URL || ENV.AUTH_URL, method: "PATCH", headers: await plHeaders(), data: newData
+    prefix: apiBase(), method: "PATCH", headers: await plHeaders(), data: newData
   })
   await notice(
     res && res.errors
@@ -31,7 +31,7 @@ export async function updateSer({ t, SchemaName, newData, oldData, primaryKey = 
 
 export async function deleteSer({ t, SchemaName, oldData, primaryKey = "id" }: Del<any>) {
   const res = await request(apiPath(SchemaName, oldData[primaryKey]), {
-    prefix: ENV.MAIN_URL || ENV.AUTH_URL, method: "DELETE", headers: await plHeaders()
+    prefix: apiBase(), method: "DELETE", headers: await plHeaders()
   })
   await notice(
     res && res.errors

--- a/packages/dashin-source-payload/services/listSer.ts
+++ b/packages/dashin-source-payload/services/listSer.ts
@@ -2,10 +2,10 @@
  * Remote data controller (Payload CMS)
  * GET /api/{collection}?where[..]&sort&limit&page -> { docs, totalDocs }
  */
-import { ENV, request } from "@dashin-dev/dashin"
+import { request } from "@dashin-dev/dashin"
 import { ListService } from "../types"
 import { buildParams } from "./filter"
-import { plHeaders, apiPath } from "./plConfig"
+import { plHeaders, apiPath, apiBase } from "./plConfig"
 
 export default async function listSer<RowData extends object>({
   tableQuery,
@@ -26,7 +26,7 @@ export default async function listSer<RowData extends object>({
 
   const res = await request(apiPath(path), {
     params,
-    prefix: prefix || ENV.MAIN_URL || ENV.AUTH_URL,
+    prefix: apiBase(prefix),
     method: "GET",
     headers: await plHeaders()
   })

--- a/packages/dashin-source-payload/services/plConfig.ts
+++ b/packages/dashin-source-payload/services/plConfig.ts
@@ -1,9 +1,20 @@
-import { storedToken } from "@dashin-dev/dashin"
+import { ENV, storedToken } from "@dashin-dev/dashin"
 
-/** Payload collection endpoint. */
+/** Payload collection endpoint (always includes the `/api` segment). */
 export function apiPath(collection: string, id?: string): string {
   const base = `/api/${collection}`
   return id !== undefined ? `${base}/${id}` : base
+}
+
+/**
+ * Resolve the API base/origin for requests. Since apiPath() already adds the
+ * Payload `/api` segment, strip a trailing `/api` from the configured base so a
+ * `/api/api/...` double-prefix can't happen — works whether VITE_MAIN_URL is
+ * set to the origin or to origin + `/api`.
+ */
+export function apiBase(prefix?: string): string {
+  const base = prefix || ENV.MAIN_URL || ENV.AUTH_URL || ""
+  return base.replace(/\/api\/?$/, "")
 }
 
 /** Payload auth header (JWT Bearer) from the stored token. */

--- a/packages/dashin/plugin.js
+++ b/packages/dashin/plugin.js
@@ -3,8 +3,10 @@ const fs = require("fs")
 const del = require("del")
 const {
   findPlugins,
-  getPlugins,
-  getPluginNames
+  getPluginsAsync,
+  getPluginNames,
+  importPluginModule,
+  readInitData
 } = require("./lib/utils/node/plugin-action")
 
 /**
@@ -50,9 +52,9 @@ module.exports = async ({
     fs.mkdirSync(dynamicPath)
   }
 
-  // Find plugins in package.json
+  // Find plugins in package.json (supports CommonJS and ESM plugin packages)
   const pluginNames = getPluginNames(packagePath)
-  const pluginsData = getPlugins(pluginNames)
+  const pluginsData = await getPluginsAsync(pluginNames)
 
   /**
    * Generate `index.js` in `.dashin/dynamic/`
@@ -124,10 +126,12 @@ export const data: IPluginData[] = [${arrayLine}]
       throw "modulesPath needs to contain `node_modules`!"
     }
 
-    let plugin
+    let initData
     try {
-      plugin = require(pathItem)
-      if (!plugin || !plugin.initData || !plugin.initData.data) return
+      // Load by package specifier (supports CommonJS and ESM plugins).
+      const plugin = await importPluginModule(pluginName)
+      initData = plugin && readInitData(plugin)
+      if (!initData || !initData.data) return
     } catch (e) {
       console.error("\n*************")
       console.error(
@@ -147,7 +151,7 @@ export const data: IPluginData[] = [${arrayLine}]
      * create files [plugin]/[group]/[name].js
      */
     try {
-      if (!plugin) return
+      if (!initData) return
       let fileName = pathItem.replaceAll(/\\/g, "/") // Fixing the PATH on Windows
       fileName = fileName.replace(/.*\//g, "")
       /**
@@ -157,7 +161,7 @@ export const data: IPluginData[] = [${arrayLine}]
       if (!fs.existsSync(savePluginPath)) {
         fs.mkdirSync(savePluginPath)
       }
-      plugin.initData.data.map(async dataItem => {
+      initData.data.map(async dataItem => {
         if (dataItem["ignore_schema"] || !dataItem["name"]) return
         /**
          * Recreate directory dynamic/[plugin]/[name]

--- a/packages/dashin/src/utils/i18n/de.ts
+++ b/packages/dashin/src/utils/i18n/de.ts
@@ -1,9 +1,6 @@
+// German locale stub. Not yet listed in i18nMenus (see ./index.ts), so the app
+// falls back to English. Add `core` keys here (mirroring en.ts) to translate.
 const de = {
-  translations: {
-    "To get started, edit <1>src/App.js</1> and save to reload.":
-      "Starte in dem du, <1>src/App.js</1> editierst und speicherst.",
-    "Welcome to React": "Willkommen bei React und react-i18next",
-    welcome: "Hello <br/> <strong>World</strong>"
-  }
+  core: {}
 }
 export default de

--- a/packages/dashin/src/utils/node/__tests__/plugin-action.test.ts
+++ b/packages/dashin/src/utils/node/__tests__/plugin-action.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest"
+import { readInitData } from "../plugin-action"
+
+// readInitData normalizes where a plugin exposes its initData: at the module
+// root (CommonJS / re-export) or under `default` (ESM namespace). This is what
+// lets the generator support both CJS and ESM plugin packages.
+describe("readInitData", () => {
+  it("reads initData from the module root (CJS / re-export)", () => {
+    const data = [{ id: "a" } as any]
+    expect(readInitData({ initData: { data } })).toEqual({ data })
+  })
+
+  it("reads initData from default (ESM namespace)", () => {
+    const data = [{ id: "b" } as any]
+    expect(readInitData({ default: { initData: { data } } })).toEqual({ data })
+  })
+
+  it("prefers the root initData over default", () => {
+    expect(
+      readInitData({ initData: { data: [1] }, default: { initData: { data: [2] } } } as any)
+    ).toEqual({ data: [1] })
+  })
+
+  it("returns undefined when there is no initData", () => {
+    expect(readInitData({})).toBeUndefined()
+    expect(readInitData(null)).toBeUndefined()
+    expect(readInitData(undefined)).toBeUndefined()
+  })
+})

--- a/packages/dashin/src/utils/node/plugin-action.ts
+++ b/packages/dashin/src/utils/node/plugin-action.ts
@@ -132,3 +132,51 @@ export function getPlugins(pluginNames: string[]): PluginData[] {
 
   return pluginsData
 }
+
+/**
+ * NODE MODULE
+ * Load a plugin module supporting BOTH CommonJS and ESM packages. require() is
+ * tried first (fast, unchanged for CJS); if it throws (e.g. ERR_REQUIRE_ESM for
+ * an ESM plugin) we fall back to a dynamic import. The import is wrapped in
+ * Function() so tsc's CommonJS output doesn't down-level it back to require().
+ */
+const dynamicImport = (spec: string): Promise<any> =>
+  (Function("s", "return import(s)") as (s: string) => Promise<any>)(spec)
+
+export async function importPluginModule(spec: string): Promise<any> {
+  try {
+    return require("" + spec)
+  } catch (e) {
+    return await dynamicImport(spec)
+  }
+}
+
+/** initData lives at the module root (CJS / re-export) or under default (ESM). */
+export function readInitData(mod: any): { data?: PluginData[] } | undefined {
+  return (mod && mod.initData) || (mod && mod.default && mod.default.initData)
+}
+
+/**
+ * NODE MODULE
+ * Async variant of getPlugins that also supports ESM plugin packages.
+ */
+export async function getPluginsAsync(
+  pluginNames: string[]
+): Promise<PluginData[]> {
+  let pluginsData: PluginData[] = []
+  for (const pluginName of pluginNames) {
+    try {
+      const plugin = await importPluginModule(pluginName)
+      const initData = readInitData(plugin)
+      if (!initData || !initData.data) continue
+      pluginsData = [...pluginsData, ...initData.data]
+    } catch (e) {
+      console.error(
+        "cannot find 'initData' in the plugin, please export or check: " +
+          pluginName
+      )
+      console.error(e)
+    }
+  }
+  return pluginsData
+}

--- a/packages/dashin/src/utils/node/plugin-action.ts
+++ b/packages/dashin/src/utils/node/plugin-action.ts
@@ -153,7 +153,11 @@ export async function importPluginModule(spec: string): Promise<any> {
 
 /** initData lives at the module root (CJS / re-export) or under default (ESM). */
 export function readInitData(mod: any): { data?: PluginData[] } | undefined {
-  return (mod && mod.initData) || (mod && mod.default && mod.default.initData)
+  return (
+    (mod && mod.initData) ||
+    (mod && mod.default && mod.default.initData) ||
+    undefined
+  )
 }
 
 /**

--- a/plugins/auth-payload/index.ts
+++ b/plugins/auth-payload/index.ts
@@ -1,0 +1,23 @@
+import initData from "./utils/initData"
+export * from "./utils/types"
+
+import SignIn from "./sign-in"
+import { IAuthPlugin } from "@dashin-dev/dashin"
+
+export { initData, SignIn }
+
+// Payload auth collection slug (the `auth: true` collection used for admins).
+export const AUTH_COLLECTION = "users"
+
+const authPlugin: IAuthPlugin = {
+  authResponseKey: "id",
+  // Verify/refresh the current session. prefix is MAIN_URL (the API origin),
+  // so include the Payload `/api` segment.
+  authRequestUrl: `/api/${AUTH_COLLECTION}/me`,
+  authRequestMethod: "GET",
+  authorizationOverwrite: async () => true
+}
+export const authResponseKey = authPlugin.authResponseKey
+export const authRequestUrl = authPlugin.authRequestUrl
+export const authRequestMethod = authPlugin.authRequestMethod
+export const authorizationOverwrite = authPlugin.authorizationOverwrite

--- a/plugins/auth-payload/package.json
+++ b/plugins/auth-payload/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@dashin-dev/auth-payload",
+  "version": "2.0.0-alpha.0",
+  "publishConfig": {
+    "access": "public"
+  },
+  "license": "Apache-2.0",
+  "main": "lib/index.js",
+  "exports": {
+    ".": "./lib/index.js",
+    "./*": "./lib/*/index.js",
+    "./package.json": "./package.json"
+  },
+  "types": "lib/index.d.ts",
+  "files": [
+    "lib"
+  ],
+  "devDependencies": {
+    "@dashin-dev/dashin": "^2.0.0-alpha.0",
+    "prettier": "1.19.1",
+    "typescript": "4.8.3",
+    "vitest": "^1.6.0"
+  },
+  "scripts": {
+    "tsc:watch": "tsc -w",
+    "tsc:clean": "tsc --build --clean",
+    "tsc:build": "tsc",
+    "test": "vitest run"
+  }
+}

--- a/plugins/auth-payload/sign-in/controllers/submitController.ts
+++ b/plugins/auth-payload/sign-in/controllers/submitController.ts
@@ -1,0 +1,57 @@
+import { Values } from "../types"
+import userSignInService from "../services/signInService"
+import {
+  BA_DB,
+  AuthPrimary as Primary,
+  notice,
+  Router,
+  SETTING_NAMES
+} from "@dashin-dev/dashin"
+import { TFunction } from "i18next"
+
+interface Props {
+  t: TFunction
+  values: Values
+  setSubmitting: (isSubmitting: boolean) => void
+  router: Router
+}
+
+const submitController = async ({ t, values, setSubmitting, router }: Props) => {
+  const res = await userSignInService(values)
+  setSubmitting(false)
+
+  if (res && res.user) {
+    const db = BA_DB
+    const updated_at = Date.now()
+    // Persist the Payload JWT so @dashin-dev/source-payload sends it as a
+    // Bearer token on every request.
+    await db.users.put({
+      [Primary]: res.user.username,
+      token: res.token,
+      id: res.id,
+      role: res.user.role,
+      details: JSON.stringify(res),
+      updated_at
+    })
+    await db.settings.put({
+      name: Primary,
+      value: res.user.username,
+      updated_at: Date.now()
+    })
+    await db.settings.put({
+      name: SETTING_NAMES.role,
+      value: res.user.role,
+      updated_at: Date.now()
+    })
+    await notice({ title: t("Sign in successful") })
+    router.push("/")
+  } else {
+    await notice({
+      title: t("Sign in failed"),
+      severity: "error",
+      content: JSON.stringify(res)
+    })
+  }
+}
+
+export default submitController

--- a/plugins/auth-payload/sign-in/controllers/validateController.ts
+++ b/plugins/auth-payload/sign-in/controllers/validateController.ts
@@ -1,0 +1,19 @@
+import { Values } from "../types"
+import { TFunction } from "i18next"
+
+export default function validateController(values: Values, t: TFunction) {
+  const errors: Partial<Values> = {}
+  // email
+  if (!values.username) {
+    errors.username = "Required"
+  } else if (values.username.length < 3) {
+    errors.username = t("Username must be at least 3 characters long.")
+  }
+  // password
+  if (!values.password) {
+    errors.password = "Required"
+  } else if (values.password.length < 6) {
+    errors.password = t("Passwords must be at least 6 characters long.")
+  }
+  return errors
+}

--- a/plugins/auth-payload/sign-in/index.tsx
+++ b/plugins/auth-payload/sign-in/index.tsx
@@ -1,0 +1,74 @@
+import React from "react"
+import { Form, Formik, Field, ErrorMessage } from "formik"
+import validateController from "./controllers/validateController"
+import submitController from "./controllers/submitController"
+import { Values } from "./types"
+import { ENV, useTranslation, useRouter } from "@dashin-dev/dashin"
+
+export default function SignInContainer() {
+  const { t } = useTranslation("plugins")
+  const router = useRouter()
+
+  const handleOnSubmit = async (
+    values: Values,
+    { setSubmitting }: { setSubmitting: (isSubmitting: boolean) => void }
+  ) => {
+    await submitController({ t, values, setSubmitting, router })
+  }
+
+  const fieldClass =
+    "mt-4 w-full rounded border border-gray-300 px-3 py-2.5 text-sm outline-none focus:border-primary focus:ring-1 focus:ring-primary"
+
+  return (
+    <div className="relative flex h-screen w-full items-center justify-center bg-content-bg">
+      <div className="m-8 flex max-w-[400px] flex-col items-center rounded bg-white p-8 shadow">
+        <h1 className="text-xl font-medium">{t("Sign in")}</h1>
+        <p className="mt-1 text-xs text-icon-muted">Payload</p>
+        <div className="mt-2 w-full">
+          <Formik
+            initialValues={{ username: "", password: "" }}
+            validate={values => validateController(values, t)}
+            onSubmit={handleOnSubmit}
+          >
+            {({ isSubmitting }) => (
+              <Form>
+                <Field
+                  name="username"
+                  type="text"
+                  placeholder={t("Email")}
+                  className={fieldClass}
+                />
+                <ErrorMessage
+                  name="username"
+                  component="div"
+                  className="mt-1 text-xs text-danger"
+                />
+                <Field
+                  name="password"
+                  type="password"
+                  placeholder={t("Password")}
+                  className={fieldClass}
+                />
+                <ErrorMessage
+                  name="password"
+                  component="div"
+                  className="mt-1 text-xs text-danger"
+                />
+                <button
+                  type="submit"
+                  disabled={isSubmitting}
+                  className="mb-2 mt-6 w-full rounded bg-primary py-2.5 text-sm font-medium text-white hover:bg-primary/90 disabled:opacity-50"
+                >
+                  {t("Sign in")}
+                </button>
+              </Form>
+            )}
+          </Formik>
+          <p className="mt-6 text-center text-[0.8125rem] text-gray-500">
+            {ENV.SITE_NAME} {new Date().getFullYear()}
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/plugins/auth-payload/sign-in/services/__tests__/signInService.test.ts
+++ b/plugins/auth-payload/sign-in/services/__tests__/signInService.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest"
+import { mapPayloadAuth } from "../signInService"
+
+describe("mapPayloadAuth", () => {
+  it("maps a valid Payload login response to {id, token, user}", () => {
+    const res = {
+      token: "tok",
+      user: { id: 1, email: "admin@x.io", role: "admin" }
+    }
+    expect(mapPayloadAuth(res)).toEqual({
+      id: 1,
+      token: "tok",
+      user: { username: "admin@x.io", role: "admin" }
+    })
+  })
+
+  it("falls back email -> phone -> provided value, and defaults role to admin", () => {
+    expect(
+      mapPayloadAuth({ token: "t", user: { id: 1, phone: "13800001234" } }).user
+    ).toEqual({ username: "13800001234", role: "admin" })
+    expect(
+      mapPayloadAuth({ token: "t", user: { id: 1 } }, "fallback@x.io").user
+    ).toEqual({ username: "fallback@x.io", role: "admin" })
+  })
+
+  it("returns errors when token/user missing", () => {
+    expect(mapPayloadAuth({ message: "Unauthorized" }).errors).toBeTruthy()
+    expect(mapPayloadAuth(null).errors).toBeTruthy()
+  })
+})

--- a/plugins/auth-payload/sign-in/services/signInService.ts
+++ b/plugins/auth-payload/sign-in/services/signInService.ts
@@ -1,0 +1,46 @@
+import { ENV, request } from "@dashin-dev/dashin"
+
+export interface SignInParamsType {
+  username: string
+  password: string
+}
+
+const AUTH_COLLECTION = "users"
+
+/**
+ * Map a Payload login response to dashin's expected shape. Pure (no network)
+ * so it's unit-testable.
+ */
+export function mapPayloadAuth(res: any, fallbackEmail?: string) {
+  if (!res || !res.token || !res.user) {
+    return { errors: (res && (res.message || res.errors)) || "Sign in failed" }
+  }
+  return {
+    id: res.user.id,
+    token: res.token,
+    user: {
+      username: res.user.email || res.user.phone || fallbackEmail,
+      role: res.user.role || "admin"
+    }
+  }
+}
+
+/**
+ * Payload auth: POST /api/{collection}/login
+ *   body { email, password } -> { token, user, exp }
+ * Mapped to dashin's expected shape { id, token, user }.
+ *
+ * `username` is the email (Payload authenticates by email). AUTH_URL is the API
+ * origin; the `/api` segment is included here.
+ */
+export default async function userSignInService(params: SignInParamsType) {
+  const { username, password } = params
+
+  const res = await request(`/api/${AUTH_COLLECTION}/login`, {
+    prefix: ENV.AUTH_URL,
+    method: "POST",
+    data: { email: username, password }
+  })
+
+  return mapPayloadAuth(res, username)
+}

--- a/plugins/auth-payload/sign-in/types.ts
+++ b/plugins/auth-payload/sign-in/types.ts
@@ -1,0 +1,4 @@
+export interface Values {
+  username: string
+  password: string
+}

--- a/plugins/auth-payload/tsconfig.json
+++ b/plugins/auth-payload/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "extends": "../../tsconfig",
+  "compilerOptions": {
+    "jsx": "react",
+    "rootDir": "./",
+    "outDir": "./lib",
+    "declaration": true,
+    "declarationDir": "./lib",
+    "baseUrl": "./"
+  },
+  "exclude": [
+    "node_modules",
+    "lib",
+    "**/__tests__/**",
+    "**/*.test.ts",
+    "**/*.test.tsx"
+  ],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    "**/*.ts",
+    "**/*.tsx"
+  ]
+}

--- a/plugins/auth-payload/utils/initData.ts
+++ b/plugins/auth-payload/utils/initData.ts
@@ -1,0 +1,17 @@
+import { IPluginData } from "@dashin-dev/dashin"
+
+const plugin = "auth-payload"
+
+const data: IPluginData[] = [
+  {
+    id: "dashin_auth_payload_sign_in",
+    group: "auth-payload",
+    name: "sign-in",
+    label: "Sign-in",
+    team: "dashin",
+    customized: true,
+    ignore_menu: true
+  }
+]
+
+export default { plugin, data }

--- a/plugins/auth-payload/utils/types.ts
+++ b/plugins/auth-payload/utils/types.ts
@@ -1,0 +1,10 @@
+/** Payload user record (subset). */
+export interface IUser {
+  id: string | number
+  email?: string
+  phone?: string
+  role?: string
+  name?: string
+  createdAt?: string
+  updatedAt?: string
+}

--- a/scripts/smoke/template-prod-smoke.mjs
+++ b/scripts/smoke/template-prod-smoke.mjs
@@ -1,0 +1,147 @@
+/**
+ * Consumer prod-build smoke test.
+ *
+ * Scaffolds the Vite template into a temp dir, points its @dashin-dev/* deps at
+ * the LOCAL workspace packages (so it tests the built `lib/` a real consumer
+ * gets, not the published alpha), runs a production `vite build`, serves
+ * `vite preview`, and headless-loads it asserting the app mounts with no fatal
+ * runtime errors.
+ *
+ * This is the layer unit tests can't reach: it would have caught the prod-only
+ * "Object.defineProperty called on non-object" crash (commonjs strictRequires),
+ * the "exports is not defined" i18n-glob crash, and an unstyled shell.
+ *
+ * Build all package lib/ first (`yarn tsc:build`). Set SMOKE_BUILD_ONLY=1 to
+ * stop after `vite build` (skips installing a browser) for a quick local check.
+ */
+import { execSync, spawn } from "node:child_process"
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+
+const repo = process.cwd()
+const templateDir = path.join(
+  repo,
+  "packages/dashin-cli/templates/typescript-vite"
+)
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "dashin-smoke-"))
+const PORT = 4188
+const BUILD_ONLY = process.env.SMOKE_BUILD_ONLY === "1"
+
+// Fatal runtime errors that build/unit tests can't catch.
+const FATAL =
+  /Object\.defineProperty called on non-object|exports is not defined|require is not defined|does not provide an export|auth plugin is required|Failed to fetch dynamically imported module/i
+
+const log = (m) => console.log(`\n▸ ${m}`)
+
+// Pack a local workspace package to a tarball and return its path. Installing
+// the tarball mimics a real registry install (no symlink quirks; only `files`
+// are included; transitive deps resolve from the registry) — unlike a `file:`
+// dir dep, which can break Rollup's named-export resolution through symlinks.
+function packLocal(pkgDir, outDir) {
+  const out = execSync(`npm pack --silent --pack-destination "${outDir}"`, {
+    cwd: path.join(repo, pkgDir)
+  })
+    .toString()
+    .trim()
+    .split(/\r?\n/)
+    .pop()
+    .trim()
+  return "file:" + path.join(outDir, out)
+}
+
+let server
+function cleanup() {
+  try {
+    if (server && !server.killed) server.kill()
+  } catch {}
+  try {
+    fs.rmSync(tmp, { recursive: true, force: true })
+  } catch {}
+}
+
+async function waitForServer(url, timeoutMs = 60_000) {
+  const start = Date.now()
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const r = await fetch(url)
+      if (r.ok) return
+    } catch {}
+    await new Promise((r) => setTimeout(r, 500))
+  }
+  throw new Error(`server not ready at ${url}`)
+}
+
+async function main() {
+  log(`scaffolding template -> ${tmp}`)
+  fs.cpSync(templateDir, tmp, { recursive: true })
+
+  // Point @dashin-dev/* at locally-packed tarballs of the workspace packages.
+  const tgzDir = path.join(tmp, "_pkgs")
+  fs.mkdirSync(tgzDir)
+  log("npm pack local packages")
+  const pkgPath = path.join(tmp, "package.json")
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"))
+  pkg.dependencies["@dashin-dev/dashin"] = packLocal("packages/dashin", tgzDir)
+  pkg.dependencies["@dashin-dev/auth-local"] = packLocal("plugins/auth-local", tgzDir)
+  fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2))
+
+  // Materialize .env (default template auth-local — no backend needed).
+  fs.copyFileSync(path.join(tmp, ".env.example"), path.join(tmp, ".env"))
+
+  log("npm install (local @dashin-dev/* + deps)")
+  execSync("npm install --no-audit --no-fund --no-save=false", {
+    cwd: tmp,
+    stdio: "inherit"
+  })
+
+  log("vite build (production)")
+  execSync("npx vite build", { cwd: tmp, stdio: "inherit" })
+
+  if (BUILD_ONLY) {
+    log("SMOKE_BUILD_ONLY=1 — built OK, skipping browser check")
+    return
+  }
+
+  log("vite preview")
+  server = spawn(
+    "npx",
+    ["vite", "preview", "--port", String(PORT), "--strictPort"],
+    { cwd: tmp, stdio: "inherit", shell: process.platform === "win32" }
+  )
+  const base = `http://localhost:${PORT}/`
+  await waitForServer(base)
+
+  log("headless load + assert")
+  const { chromium } = await import("@playwright/test")
+  const browser = await chromium.launch()
+  const page = await browser.newPage()
+  const errors = []
+  page.on("pageerror", (e) => errors.push(e.message))
+  page.on("console", (m) => m.type() === "error" && errors.push(m.text()))
+
+  await page.goto(base, { waitUntil: "networkidle" })
+  const rootText = (await page.locator("#root").innerText().catch(() => "")) || ""
+  const rootHtml = (await page.locator("#root").innerHTML().catch(() => "")) || ""
+  await browser.close()
+
+  const fatal = errors.filter((e) => FATAL.test(e))
+  if (fatal.length) {
+    throw new Error(`fatal runtime errors:\n${fatal.join("\n")}`)
+  }
+  if (!rootHtml.trim()) {
+    throw new Error("#root is empty — app did not mount")
+  }
+  log(`OK — app mounted (root len ${rootHtml.length}), no fatal errors`)
+}
+
+main()
+  .then(() => {
+    cleanup()
+    process.exit(0)
+  })
+  .catch((e) => {
+    console.error("\n✗ SMOKE FAILED:", e.message)
+    cleanup()
+    process.exit(1)
+  })


### PR DESCRIPTION
Fixes everything that broke (or was missing) when scaffolding a real
Payload-backed admin from this template. Each item was hit and verified while
building a production app.

## Fixes
- **Prod build crash** — template `vite.config` sets
  `build.commonjsOptions.strictRequires`, so production builds no longer throw
  `Object.defineProperty called on non-object` (Rollup evaluating a CJS module
  before its exports object exists; dev/esbuild tolerated it).
- **Dev startup crash** — template `pluginRegistry` excludes the CJS core
  package from the plugin-i18n `import.meta.glob` (`exports is not defined`).
- **Template theme** — adopt the core token system (`tailwind.config` + `--bn-*`
  CSS vars, light/dark) so a fresh app's shell renders fully styled (sidebar,
  borders, radius, gradient logo) and the theme toggle works.
- **`source-payload` double `/api`** — `apiBase()` strips a trailing `/api`, so
  `VITE_MAIN_URL` as either origin or origin+`/api` works (no `/api/api/…`).
- **ESM plugin packages** — the generator loads plugins via `require()` with a
  dynamic-import fallback; CJS plugins unchanged (verified e2e).
- **i18n** — drop leftover CRA strings in `de.ts`.

## Added
- **`@dashin-dev/auth-payload`** — auth plugin for Payload (email/password →
  JWT, stored for `source-payload`). The Payload demo referenced it but it
  didn't exist. Mirrors `auth-pocketbase`.

## Docs
- Payload guide: auth-payload setup, `VITE_MAIN_URL` = origin convention, CORS.
- README: add Payload to the backend lists. CHANGELOG: Unreleased section.

## Tests
- `plConfig.test.ts` (apiBase dedup, apiPath, plHeaders) — 8 tests.
- `plugin-action.test.ts` (readInitData CJS/ESM) — 4 tests.
- `auth-payload` `signInService.test.ts` — 3 tests.
- **New CI `template-smoke` job** + `scripts/smoke/template-prod-smoke.mjs`:
  scaffolds the template against locally-packed tarballs, runs a prod
  `vite build`, and headless-loads the preview asserting no fatal runtime
  errors — the layer that would have caught the prod-only crash.

All suites green: source-payload 17/17, auth-payload 3/3, plugin-action 4/4.
CI is manual-only (`workflow_dispatch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)