### PR TITLE
fix(auth-payload): validate session via /me instead of always-authorized

### DIFF
--- a/plugins/auth-payload/index.ts
+++ b/plugins/auth-payload/index.ts
@@ -9,15 +9,17 @@ export { initData, SignIn }
 // Payload auth collection slug (the `auth: true` collection used for admins).
 export const AUTH_COLLECTION = "users"
 
+// Session check: dashin GETs authRequestUrl with the stored Bearer token (prefix
+// = ENV.AUTH_URL, the API origin) and treats the user as logged-in only when
+// response[authResponseKey] is truthy. Payload `/api/{collection}/me` returns
+// { user: {...} } when authed and { user: null } when not — so the key is
+// "user". Do NOT set authorizationOverwrite: that bypasses this check entirely,
+// leaving signed-out users on empty pages instead of the sign-in screen.
 const authPlugin: IAuthPlugin = {
-  authResponseKey: "id",
-  // Verify/refresh the current session. prefix is MAIN_URL (the API origin),
-  // so include the Payload `/api` segment.
+  authResponseKey: "user",
   authRequestUrl: `/api/${AUTH_COLLECTION}/me`,
-  authRequestMethod: "GET",
-  authorizationOverwrite: async () => true
+  authRequestMethod: "GET"
 }
 export const authResponseKey = authPlugin.authResponseKey
 export const authRequestUrl = authPlugin.authRequestUrl
 export const authRequestMethod = authPlugin.authRequestMethod
-export const authorizationOverwrite = authPlugin.authorizationOverwrite

--- a/plugins/auth-payload/sign-in/controllers/submitController.ts
+++ b/plugins/auth-payload/sign-in/controllers/submitController.ts
@@ -4,7 +4,6 @@ import {
   BA_DB,
   AuthPrimary as Primary,
   notice,
-  Router,
   SETTING_NAMES
 } from "@dashin-dev/dashin"
 import { TFunction } from "i18next"
@@ -13,10 +12,9 @@ interface Props {
   t: TFunction
   values: Values
   setSubmitting: (isSubmitting: boolean) => void
-  router: Router
 }
 
-const submitController = async ({ t, values, setSubmitting, router }: Props) => {
+const submitController = async ({ t, values, setSubmitting }: Props) => {
   const res = await userSignInService(values)
   setSubmitting(false)
 
@@ -44,7 +42,11 @@ const submitController = async ({ t, values, setSubmitting, router }: Props) => 
       updated_at: Date.now()
     })
     await notice({ title: t("Sign in successful") })
-    router.push("/")
+    // Full navigation (not router.push): dashin's App reads
+    // window.location.pathname and only re-checks auth when it changes, so a
+    // client-side push to "/" from "/" leaves the sign-in form mounted until a
+    // manual refresh. A real navigation re-inits and clears isProtected.
+    window.location.assign("/")
   } else {
     await notice({
       title: t("Sign in failed"),

--- a/plugins/auth-payload/sign-in/index.tsx
+++ b/plugins/auth-payload/sign-in/index.tsx
@@ -3,17 +3,16 @@ import { Form, Formik, Field, ErrorMessage } from "formik"
 import validateController from "./controllers/validateController"
 import submitController from "./controllers/submitController"
 import { Values } from "./types"
-import { ENV, useTranslation, useRouter } from "@dashin-dev/dashin"
+import { ENV, useTranslation } from "@dashin-dev/dashin"
 
 export default function SignInContainer() {
   const { t } = useTranslation("plugins")
-  const router = useRouter()
 
   const handleOnSubmit = async (
     values: Values,
     { setSubmitting }: { setSubmitting: (isSubmitting: boolean) => void }
   ) => {
-    await submitController({ t, values, setSubmitting, router })
+    await submitController({ t, values, setSubmitting })
   }
 
   const fieldClass =


### PR DESCRIPTION
Follow-up to #133.

`@dashin-dev/auth-payload` shipped with `authorizationOverwrite: async () => true`,
which makes dashin's `checkAuth()` treat **every** visit as authenticated. A
signed-out user is therefore never shown the sign-in screen and instead lands on
the dashboard, whose API calls 403 without a token — i.e. **every list renders
empty**. Expired tokens behave the same (blank pages instead of a redirect to
login).

Also `authResponseKey` was `"id"`, but Payload `/api/{collection}/me` returns
`{ user: {...} }` when authed and `{ user: null }` when not — so the
discriminator is `user`, not `id`.

## Fix
- Drop `authorizationOverwrite` so dashin's default `authorization()` runs (GET
  `authRequestUrl` with the stored Bearer token).
- Set `authResponseKey: "user"`.

Now signed-out users get the sign-in screen, and a valid token loads the app as
before. Verified against a live Payload backend (`/me` → `{user:null}` when
unauthenticated, `{user:{...}}` when authenticated) and in a deployed dashboard.

Unit tests still green (`mapPayloadAuth` 3/3); the package compiles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)