### PR TITLE
fix(template): bake VITE_* env into the bundle (define process.env object)

### DIFF
--- a/packages/dashin-cli/templates/typescript-vite/vite.config.ts
+++ b/packages/dashin-cli/templates/typescript-vite/vite.config.ts
@@ -42,6 +42,12 @@ export default defineConfig(({ mode }) => {
   for (const k of Object.keys(env)) {
     define[`process.env.${k}`] = JSON.stringify(env[k])
   }
+  // @dashin-dev/dashin reads env via a DYNAMIC lookup (process.env[`VITE_${k}`])
+  // so it can compile to CJS lib/. Vite's per-key static `define` above does NOT
+  // replace a computed access, so also define the whole process.env object —
+  // otherwise ENV.MAIN_URL/AUTH_URL are undefined in the browser bundle and
+  // requests hit the current origin instead of the configured API.
+  define["process.env"] = JSON.stringify({ NODE_ENV: mode, ...env })
   return {
     plugins: [dashinGenerator(mode), react()],
     define,


### PR DESCRIPTION
## Problem
A scaffolded app's `ENV.MAIN_URL` / `ENV.AUTH_URL` (etc.) come out **undefined in
the browser bundle**, so every request goes to the current origin instead of the
configured backend — e.g. sign-in does `POST <app-origin>/api/users/login` → **405**
on a static host, and all lists render empty.

## Cause
`@dashin-dev/dashin`'s config reads env via a **dynamic** lookup so it can compile
to CJS `lib/`:

```js
const v = (key) => process.env[`VITE_${key}`]
```

The template's `vite.config` only defines each key statically
(`define["process.env.VITE_X"] = …`). Vite's `define` is a textual replacement and
**does not** rewrite a computed member access (`process.env[`VITE_${key}`]`), so the
values are never inlined.

## Fix
Also define the whole `process.env` object so dynamic lookups resolve — matching
what the core app's own `vite.config` already does:

```js
define["process.env"] = JSON.stringify({ NODE_ENV: mode, ...env })
```

Verified in a real deployed app: before, `POST <origin>/api/users/login` → 405 and
the API host wasn't present in the bundle; after, the configured API host is baked
in and auth/data work.

Note: the `template-smoke` job (#133) uses `auth-local` (no backend URL), so it
doesn't exercise this path — this is a config fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)