### PR TITLE
feat(dashin): DetailDrawer edit mode, error banner, renderDetail, zBase

### DIFF
--- a/packages/dashin/src/components/DetailDrawer/index.tsx
+++ b/packages/dashin/src/components/DetailDrawer/index.tsx
@@ -5,13 +5,32 @@ import Input from "../ui/Input"
 import Select from "../ui/Select"
 import Label from "../ui/Label"
 
+/** Best-effort human-readable message from a failed save — walks the Payload
+ *  nested error shape (`errors[0].data.errors[0].message`) plus common shapes.
+ *  Override via the `formatError` prop. */
+function defaultErrorMessage(e: any): string {
+  const body = (e && (e.response?.data ?? e.data)) ?? e
+  const outer = body?.errors?.[0]
+  const msg =
+    outer?.data?.errors?.[0]?.message ||
+    outer?.message ||
+    body?.message ||
+    (typeof e?.message === "string" ? e.message : "")
+  return String(msg || "").trim() || "Something went wrong"
+}
+
 export interface DetailDrawerProps<RowData extends object> {
   row: RowData | null
   columns: Column<RowData>[]
   editable?: EditableData<RowData>
-  mode?: "view" | "create"
+  /** `"edit"` opens straight into the edit form (e.g. an inline row Edit button). */
+  mode?: "view" | "create" | "edit"
   onClose: () => void
   onSaved?: () => void
+  /** Base z-index; overlay = zBase, panel = zBase + 100. Raise it to stack drawers. */
+  zBase?: number
+  /** Map a failed-save error to the inline banner message (default: generic extractor). */
+  formatError?: (e: unknown) => string
 }
 
 export default function DetailDrawer<RowData extends object>({
@@ -20,25 +39,30 @@ export default function DetailDrawer<RowData extends object>({
   editable,
   mode = "view",
   onClose,
-  onSaved
+  onSaved,
+  zBase = 1200,
+  formatError
 }: DetailDrawerProps<RowData>) {
   const isCreate = mode === "create"
-  const [editing, setEditing] = useState(isCreate)
+  const startEditing = isCreate || mode === "edit"
+  const [editing, setEditing] = useState(startEditing)
   const [draft, setDraft] = useState<RowData | null>(isCreate ? {} as RowData : row ? { ...row } : null)
   const [saving, setSaving] = useState(false)
   const [confirmDelete, setConfirmDelete] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
 
   useEffect(() => {
     setConfirmDelete(false)
     setSaving(false)
+    setErr(null)
     if (isCreate) {
       setEditing(true)
       setDraft({} as RowData)
     } else {
-      setEditing(false)
+      setEditing(mode === "edit")
       setDraft(row ? { ...row } : null)
     }
-  }, [row, isCreate])
+  }, [row, mode])
 
   const open = isCreate || !!row
 
@@ -67,6 +91,7 @@ export default function DetailDrawer<RowData extends object>({
   const handleSave = async () => {
     if (!draft) return
     setSaving(true)
+    setErr(null)
     try {
       if (isCreate) {
         if (!editable?.onRowAdd) return
@@ -78,6 +103,9 @@ export default function DetailDrawer<RowData extends object>({
       setEditing(false)
       onClose()
       onSaved?.()
+    } catch (e) {
+      // Keep the drawer open and show why the save failed (e.g. a duplicate).
+      setErr((formatError ?? defaultErrorMessage)(e))
     } finally {
       setSaving(false)
     }
@@ -106,12 +134,14 @@ export default function DetailDrawer<RowData extends object>({
     <>
       {/* Backdrop */}
       <div
-        className="fixed inset-0 bg-black/40 z-[1200] transition-opacity"
+        className="fixed inset-0 bg-black/40 transition-opacity"
+        style={{ zIndex: zBase }}
         onClick={onClose}
       />
       {/* Panel */}
       <aside
-        className="fixed inset-y-0 right-0 z-[1300] w-full max-w-md bg-content-box shadow-xl flex flex-col transition-transform duration-300 ease-in-out"
+        className="fixed inset-y-0 right-0 w-full max-w-md bg-content-box shadow-xl flex flex-col transition-transform duration-300 ease-in-out"
+        style={{ zIndex: zBase + 100 }}
       >
         {/* Header */}
         <div className="flex items-center justify-between border-b border-bn-border px-6 py-4">
@@ -155,7 +185,13 @@ export default function DetailDrawer<RowData extends object>({
 
         {/* Footer */}
         {editing && (
-          <div className="flex items-center justify-between border-t border-bn-border px-6 py-4">
+          <>
+            {err && (
+              <div className="mx-6 mb-1 mt-2 rounded-bn border border-danger/40 bg-danger/10 px-3 py-2 text-sm text-danger">
+                {err}
+              </div>
+            )}
+            <div className="flex items-center justify-between border-t border-bn-border px-6 py-4">
             <div className="flex items-center gap-2">
               {canDelete && !confirmDelete && (
                 <button
@@ -191,9 +227,10 @@ export default function DetailDrawer<RowData extends object>({
             <div className="flex items-center gap-2">
               <button
                 onClick={() => {
-                  if (isCreate) { onClose(); return }
+                  if (isCreate || mode === "edit") { onClose(); return }
                   setEditing(false)
                   setDraft(row ? { ...row } : null)
+                  setErr(null)
                 }}
                 disabled={saving}
                 className="rounded-bn px-3 py-1.5 text-sm font-medium text-icon-muted hover:bg-content-bg transition-colors disabled:opacity-50"
@@ -209,6 +246,7 @@ export default function DetailDrawer<RowData extends object>({
               </button>
             </div>
           </div>
+          </>
         )}
       </aside>
     </>
@@ -229,7 +267,9 @@ function PreviewFields<RowData extends object>({
           <dt className="text-xs font-medium text-icon-muted uppercase tracking-wide mb-1">
             {col.title}
           </dt>
-          <dd className="text-sm text-foreground">{display(col, row) ?? "—"}</dd>
+          <dd className="text-sm text-foreground">
+            {col.renderDetail ? col.renderDetail(row) : display(col, row) ?? "—"}
+          </dd>
         </div>
       ))}
     </dl>
@@ -262,7 +302,7 @@ function EditForm<RowData extends object>({
             <Label className="mb-1 block">{col.title}</Label>
             {readOnly ? (
               <div className="rounded-bn border border-bn-border bg-content-bg px-2.5 py-1.5 text-sm text-icon-muted">
-                {display(col, data) ?? "—"}
+                {col.renderDetail ? col.renderDetail(data) : display(col, data) ?? "—"}
               </div>
             ) : col.editComponent ? (
               <EditComponentWrapper col={col} data={data} value={value} setField={setField} />

--- a/packages/dashin/src/components/Table/models/material-table-shim.ts
+++ b/packages/dashin/src/components/Table/models/material-table-shim.ts
@@ -25,6 +25,9 @@ export interface Column<RowData extends object> {
     | "currency"
   lookup?: { [key: string]: any }
   render?: (rowData: RowData) => any
+  /** Richer read-only view used only in the DetailDrawer (view / read-only
+   *  fields), while `render` stays a compact table cell. */
+  renderDetail?: (rowData: RowData) => ReactNode
   editComponent?: (props: EditComponentProps<RowData>) => ReactNode
   filterComponent?: (props: FilterComponentProps<RowData>) => ReactNode
   // material-table internal row metadata used by selectors

--- a/packages/dashin/src/components/__tests__/DetailDrawer.test.tsx
+++ b/packages/dashin/src/components/__tests__/DetailDrawer.test.tsx
@@ -1,0 +1,64 @@
+import React from "react"
+import { describe, it, expect, vi } from "vitest"
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+import DetailDrawer from "../DetailDrawer"
+
+const columns: any[] = [
+  { title: "Name", field: "name" },
+  { title: "Contract", field: "client", renderDetail: (r: any) => <span>card:{r.client}</span> }
+]
+
+describe("DetailDrawer enhancements", () => {
+  it("mode='edit' opens straight into the edit form", () => {
+    render(
+      <DetailDrawer
+        row={{ name: "A", client: "X" } as any}
+        columns={columns}
+        mode="edit"
+        editable={{ onRowUpdate: async () => {} } as any}
+        onClose={() => {}}
+      />
+    )
+    expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument()
+    expect(screen.getByDisplayValue("A")).toBeInTheDocument()
+  })
+
+  it("shows an error banner when the save fails and keeps the drawer open", async () => {
+    const onClose = vi.fn()
+    const onRowUpdate = vi
+      .fn()
+      .mockRejectedValue({ errors: [{ data: { errors: [{ message: "Value must be unique" }] } }] })
+    render(
+      <DetailDrawer
+        row={{ name: "A" } as any}
+        columns={columns}
+        mode="edit"
+        editable={{ onRowUpdate } as any}
+        onClose={onClose}
+      />
+    )
+    fireEvent.click(screen.getByRole("button", { name: "Save" }))
+    await waitFor(() => expect(screen.getByText("Value must be unique")).toBeInTheDocument())
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it("renderDetail overrides the plain cell in view mode", () => {
+    render(
+      <DetailDrawer row={{ name: "A", client: "42" } as any} columns={columns} mode="view" onClose={() => {}} />
+    )
+    expect(screen.getByText("card:42")).toBeInTheDocument()
+  })
+
+  it("view mode still shows the Edit button (no regression)", () => {
+    render(
+      <DetailDrawer
+        row={{ name: "A" } as any}
+        columns={columns}
+        mode="view"
+        editable={{ onRowUpdate: async () => {} } as any}
+        onClose={() => {}}
+      />
+    )
+    expect(screen.getByRole("button", { name: "Edit" })).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## What

Four **additive** enhancements to `DetailDrawer` (no breaking changes to existing props/behavior):

1. **`mode: "edit"`** — open straight into the edit form (for an inline row *Edit* button), instead of only reaching edit via the header toggle from view. `"view"`/`"create"` unchanged.
2. **Inline error banner on failed save** — the drawer stays open and shows *why* (previously a rejected `onRowAdd`/`onRowUpdate` was swallowed). Message comes from a default extractor that walks Payload's nested `errors[0].data.errors[0].message` shape (plus common shapes); override with a new **`formatError?: (e) => string`** prop.
3. **`renderDetail` column hook** — a richer read-only view inside the drawer (e.g. a related-record card) while `render` stays the compact table cell. Added to the `Column` shim.
4. **`zBase` prop** — base z-index (overlay = `zBase`, panel = `zBase + 100`) so multiple drawers can **stack** (needed by the upcoming related-preview PR).

## Why

These unblock two follow-ups (a packaged `CrudTable` and a stacked related-record preview) and fix a real papercut on their own — a failed save currently gives the user no feedback.

Foundation PR in the series (after #143, #144).

## Tests

4 new tests (`src/components/__tests__/DetailDrawer.test.tsx`): edit-mode entry, error banner on failed save, `renderDetail` override, and view-mode Edit button (regression). Core `typecheck` clean.

> Note: `Table.test.tsx` has 2 failing tests ("onRowDelete callback", "grouping") — verified **pre-existing on clean `master`**, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)