### PR TITLE
feat(dashin): batteries-included CrudTable component

### DIFF
--- a/packages/dashin/src/components/CrudTable/__tests__/CrudTable.test.tsx
+++ b/packages/dashin/src/components/CrudTable/__tests__/CrudTable.test.tsx
@@ -1,0 +1,67 @@
+import React from "react"
+import { describe, it, expect, vi } from "vitest"
+import { render, screen, fireEvent } from "@testing-library/react"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (k: string) => k, i18n: { language: "en" } })
+}))
+
+// Light stand-ins for the heavy children (Table pulls in router/redux). We only
+// assert CrudTable's own contribution: the view/create/edit state machine, the
+// appended per-row action column, and how it wires onRowClick/onAdd.
+vi.mock("../../Table", () => ({
+  __esModule: true,
+  default: ({ columns, data, onRowClick, onAdd }: any) => (
+    <div>
+      <button onClick={() => onAdd && onAdd()} disabled={!onAdd}>
+        __add
+      </button>
+      {(Array.isArray(data) ? data : []).map((row: any, i: number) => (
+        <div key={i} data-testid="row" onClick={e => onRowClick && onRowClick(e, row)}>
+          {columns.map((c: any, j: number) => (
+            <span key={j}>{c.render ? c.render(row) : row[c.field]}</span>
+          ))}
+        </div>
+      ))}
+    </div>
+  ),
+  TableHead: ({ title }: any) => <h1>{title}</h1>
+}))
+vi.mock("../../DetailDrawer", () => ({
+  __esModule: true,
+  default: ({ row, mode }: any) =>
+    row || mode === "create" ? <div data-testid="drawer">drawer:{mode}</div> : null
+}))
+
+import CrudTable from ".."
+
+const columns: any[] = [{ title: "Name", field: "name" }]
+const data = [{ id: 1, name: "Alice" }]
+
+describe("CrudTable", () => {
+  it("opens the drawer in view on row click", () => {
+    render(<CrudTable title="People" columns={columns} data={data as any} editable={{ onRowUpdate: async () => {} } as any} />)
+    expect(screen.getByText("Alice")).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId("row"))
+    expect(screen.getByTestId("drawer")).toHaveTextContent("drawer:view")
+  })
+
+  it("per-row Edit opens the drawer straight into edit mode", () => {
+    render(<CrudTable title="People" columns={columns} data={data as any} editable={{ onRowUpdate: async () => {} } as any} />)
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }))
+    expect(screen.getByTestId("drawer")).toHaveTextContent("drawer:edit")
+  })
+
+  it("Add opens the drawer in create mode", () => {
+    render(<CrudTable title="People" columns={columns} data={data as any} editable={{ onRowAdd: async () => {} } as any} />)
+    fireEvent.click(screen.getByRole("button", { name: "__add" }))
+    expect(screen.getByTestId("drawer")).toHaveTextContent("drawer:create")
+  })
+
+  it("is read-only (no action column, Add disabled) when no editable is given", () => {
+    render(<CrudTable title="People" columns={columns} data={data as any} />)
+    expect(screen.getByText("Alice")).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Edit" })).toBeNull()
+    expect(screen.getByRole("button", { name: "__add" })).toBeDisabled()
+  })
+})

--- a/packages/dashin/src/components/CrudTable/index.tsx
+++ b/packages/dashin/src/components/CrudTable/index.tsx
@@ -1,0 +1,157 @@
+import React, { createRef, useMemo, useState } from "react"
+import { useTranslation } from "react-i18next"
+import Table, { TableHead } from "../Table"
+import tableIcons from "../Table/models/tableIcons"
+import { TableDefaultProps } from "../Table/models/defaultProps"
+import { Action, Column, EditableData, Query, QueryResult } from "../Table/models/material-table-shim"
+import DetailDrawer from "../DetailDrawer"
+
+const theme = { dashin: { iconColor: "#8f9bb3" } }
+
+export interface CrudTableProps<T extends object> {
+  title: string
+  columns: Column<T>[]
+  /** Row source — the same shape <Table/> accepts (array, or an async query fn
+   *  such as an adapter's data controller). */
+  data: T[] | ((query: Query<T>) => Promise<QueryResult<T>>)
+  /** CRUD handlers (e.g. from an adapter's editable controller). Omit for a
+   *  read-only table (no per-row action column, no Add). */
+  editable?: EditableData<T>
+  /** Extra toolbar actions (e.g. a bulk-delete action). */
+  actions?: (Action<T> | ((rowData: T) => Action<T>))[]
+  /** Hide the built-in Add button even when `editable.onRowAdd` exists. */
+  disableAdd?: boolean
+  /** Map a failed-save error to the drawer's inline banner message. */
+  formatError?: (e: unknown) => string
+}
+
+/**
+ * A batteries-included CRUD table: a `<Table/>` plus a `<DetailDrawer/>` and the
+ * view / create / edit / delete state machine every plugin otherwise hand-rolls.
+ * Row click → view; a per-row **Edit** opens the drawer straight into edit;
+ * **Delete** removes inline (with confirm); **Add** opens create. Editing is done
+ * in the roomy drawer (where custom field editors live), not in-cell.
+ *
+ * Adapter-agnostic: pass a `data` source and `editable` handlers from whichever
+ * source package you use (e.g. `dataCtrl`/`editableCtrl` for Payload).
+ */
+export default function CrudTable<T extends object>({
+  title,
+  columns,
+  data,
+  editable,
+  actions,
+  disableAdd,
+  formatError
+}: CrudTableProps<T>) {
+  const { t } = useTranslation("table")
+  const tableRef = createRef<any>()
+  const [drawerRow, setDrawerRow] = useState<T | null>(null)
+  const [drawerMode, setDrawerMode] = useState<"view" | "edit" | "create">("view")
+  const [refreshKey, setRefreshKey] = useState(0)
+
+  const reload = () => setRefreshKey(k => k + 1)
+  const openCreate = () => {
+    setDrawerRow(null)
+    setDrawerMode("create")
+  }
+  const openRow = (row: T) => {
+    setDrawerMode("view")
+    setDrawerRow(row)
+  }
+  const openEdit = (row: T) => {
+    setDrawerMode("edit")
+    setDrawerRow(row)
+  }
+  const closeDrawer = () => {
+    setDrawerRow(null)
+    setDrawerMode("view")
+  }
+
+  const deleteRow = async (row: T) => {
+    if (!editable?.onRowDelete) return
+    if (typeof window !== "undefined" && !window.confirm(t("Delete this record? This cannot be undone."))) return
+    try {
+      await editable.onRowDelete(row)
+      reload()
+    } catch {
+      // the delete controller surfaces its own error notice
+    }
+  }
+
+  // Per-row action column: keep inline buttons, but Edit opens the drawer (no
+  // cramped in-cell editing). Shown on the table only — not in the drawer's own
+  // column list. stopPropagation so the buttons don't also fire the row click.
+  const actionColumn = useMemo<Column<T>>(
+    () => ({
+      title: t("Actions"),
+      field: "__actions" as any,
+      editable: "never",
+      sorting: false,
+      filtering: false,
+      width: 120,
+      render: (row: T) => (
+        <div className="flex items-center gap-3" onClick={e => e.stopPropagation()}>
+          {editable?.onRowUpdate && (
+            <button
+              type="button"
+              className="text-sm font-medium text-primary hover:underline"
+              onClick={() => openEdit(row)}
+            >
+              {t("Edit")}
+            </button>
+          )}
+          {editable?.onRowDelete && (
+            <button
+              type="button"
+              className="text-sm font-medium text-danger hover:underline"
+              onClick={() => deleteRow(row)}
+            >
+              {t("Delete")}
+            </button>
+          )}
+        </div>
+      )
+    }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [editable, t]
+  )
+
+  const hasRowActions = !!(editable?.onRowUpdate || editable?.onRowDelete)
+  const tableColumns = useMemo(
+    () => (hasRowActions ? [...columns, actionColumn] : columns),
+    [columns, actionColumn, hasRowActions]
+  )
+
+  return (
+    <>
+      <TableHead title={title} />
+      <Table<T>
+        key={refreshKey}
+        tableRef={tableRef}
+        title={title}
+        columns={tableColumns}
+        style={TableDefaultProps.style}
+        icons={tableIcons({ theme })}
+        options={{ ...TableDefaultProps.options, filtering: true }}
+        data={data}
+        actions={actions}
+        // `editable` is intentionally NOT passed to the table → no in-cell editing;
+        // editing happens in the drawer. The per-row Edit button opens it.
+        onRowClick={(_e, row) => {
+          if (row) openRow(row)
+        }}
+        onAdd={disableAdd || !editable?.onRowAdd ? undefined : openCreate}
+      />
+      <DetailDrawer<T>
+        row={drawerRow}
+        columns={columns}
+        editable={editable}
+        mode={drawerMode}
+        onClose={closeDrawer}
+        onSaved={reload}
+        formatError={formatError}
+      />
+    </>
+  )
+}

--- a/packages/dashin/src/components/index.ts
+++ b/packages/dashin/src/components/index.ts
@@ -33,6 +33,9 @@ export { default as ProTip } from "./ProTip"
 export { default as DetailDrawer } from "./DetailDrawer"
 export type { DetailDrawerProps } from "./DetailDrawer"
 
+export { default as CrudTable } from "./CrudTable"
+export type { CrudTableProps } from "./CrudTable"
+
 export { default as LeftMenu } from "./LeftMenu"
 export { default as NestedList } from "./NestedMenu"
 export { default as TopBar } from "./TopBar"


### PR DESCRIPTION
## What

A high-level **`CrudTable`** (`src/components/CrudTable`) that packages the boilerplate every plugin hand-rolls today (compose `Table` + `DetailDrawer` + drawer state): 

- Row click → **view**; a per-row **Edit** opens the drawer straight into edit (via DetailDrawer's new `"edit"` mode); **Delete** removes inline with a confirm; **Add** opens **create**. Editing is done in the roomy drawer (where custom field editors live), not in-cell.
- **Adapter-agnostic:** you pass a `data` source and `editable` handlers (e.g. `dataCtrl`/`editableCtrl` from a source package) plus optional toolbar `actions`. **Read-only** (no action column, Add disabled) when `editable` is omitted. `formatError` is forwarded to the drawer's error banner.

```tsx
<CrudTable
  title="Clients"
  columns={columns}
  data={q => dataCtrl({ t, tableQuery: q, path: "clients" })}
  editable={editableCtrl({ t, SchemaName: "clients" })}
  actions={[bulkDeleteCtrl({ t, SchemaName: "clients", tableRef })]}
/>
```

## Why

The survey of existing plugins shows this exact wiring copy-pasted into every table page (e.g. the `customers` plugin). No packaged `CrudTable` exists — only low-level `Table`/`DetailDrawer` + controllers.

## Tests

4 unit tests (`CrudTable/__tests__`) covering row-click→view, per-row Edit→edit, Add→create, and read-only. Children are mocked to isolate CrudTable's own state-machine logic from `Table`'s router/redux deps (Table/DetailDrawer are tested separately). Core `typecheck` clean.

> **Stacked on #145** (uses DetailDrawer's `"edit"` mode + `formatError`). Base is `feat/detaildrawer-edit-mode`; I'll retarget to `master` once #145 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)