### PR TITLE
feat(dashin): stacked related-record preview + nested edit

### DIFF
--- a/packages/dashin/src/components/RelatedPreview/PreviewStack.tsx
+++ b/packages/dashin/src/components/RelatedPreview/PreviewStack.tsx
@@ -1,0 +1,208 @@
+import React, { useCallback, useContext, useEffect, useRef, useState } from "react"
+import { CollectionsContext, OpenPreview, PreviewContext } from "./context"
+import { CollectionRegistry } from "./types"
+import { RelatedCard, RelatedList } from "./RelatedCard"
+import DetailDrawer from "../DetailDrawer"
+
+type Frame = { key: number; slug: string; value: any }
+const idOf = (v: any) => (v && typeof v === "object" ? v.id : v)
+
+/**
+ * Provides the collection registry + a stacked related-record preview. Any
+ * RelatedCard (or a DetailDrawer `renderDetail` card) rendered under this
+ * provider becomes clickable: it opens a preview drawer (summary + drill-in to
+ * that record's own relations); its **Edit** opens the collection's real
+ * DetailDrawer nested on top (needs the entry's `columns` + `editable`). A
+ * breadcrumb, loop guard, and depth `cap` keep nesting sane. `onChanged` fires
+ * after a nested save so the host (e.g. a CrudTable) can refresh.
+ */
+export function RelatedPreviewProvider({
+  collections,
+  children,
+  cap = 3,
+  onChanged
+}: {
+  collections: CollectionRegistry
+  children: React.ReactNode
+  cap?: number
+  onChanged?: () => void
+}) {
+  const [stack, setStack] = useState<Frame[]>([])
+  const keyRef = useRef(1)
+
+  const open: OpenPreview = useCallback(
+    (slug, value) => {
+      setStack(s => {
+        const id = idOf(value)
+        // loop guard — don't reopen a record already in the trail
+        if (id != null && s.some(f => f.slug === slug && String(idOf(f.value)) === String(id))) return s
+        if (s.length >= cap) return s // depth cap
+        return [...s, { key: keyRef.current++, slug, value }]
+      })
+    },
+    [cap]
+  )
+
+  const popTo = (index: number) => setStack(s => s.slice(0, index))
+
+  return (
+    <CollectionsContext.Provider value={collections}>
+      <PreviewContext.Provider value={open}>
+        {children}
+        {stack.map((f, i) => (
+          <PreviewFrame
+            key={f.key}
+            frame={f}
+            index={i}
+            stack={stack}
+            onBack={() => popTo(i)}
+            onCloseAll={() => setStack([])}
+            onChanged={onChanged}
+          />
+        ))}
+      </PreviewContext.Provider>
+    </CollectionsContext.Provider>
+  )
+}
+
+function PreviewFrame({
+  frame,
+  index,
+  stack,
+  onBack,
+  onCloseAll,
+  onChanged
+}: {
+  frame: Frame
+  index: number
+  stack: Frame[]
+  onBack: () => void
+  onCloseAll: () => void
+  onChanged?: () => void
+}) {
+  const registry = useContext(CollectionsContext)
+  const entry = registry[frame.slug]
+  const meta = entry?.meta
+  const [rec, setRec] = useState<any>(frame.value && typeof frame.value === "object" ? frame.value : null)
+  const [editing, setEditing] = useState(false)
+  const [tick, setTick] = useState(0)
+  const id = idOf(frame.value)
+
+  useEffect(() => {
+    let on = true
+    if (id != null && entry?.fetch) {
+      entry.fetch(id).then(r => on && setRec(r)).catch(() => {})
+    } else if (frame.value && typeof frame.value === "object") {
+      setRec(frame.value)
+    }
+    return () => {
+      on = false
+    }
+  }, [id, entry, tick])
+
+  const zBase = 1400 + index * 60
+  const canEdit = !!(entry?.columns && entry.editable?.onRowUpdate && rec)
+
+  return (
+    <>
+      <div className="fixed inset-0 bg-black/30" style={{ zIndex: zBase }} onClick={onBack} />
+      <aside
+        className="fixed inset-y-0 right-0 flex w-full max-w-md flex-col bg-content-box shadow-xl"
+        style={{ zIndex: zBase + 10 }}
+      >
+        <div className="flex items-center justify-between gap-2 border-b border-bn-border px-5 py-3">
+          <div className="flex min-w-0 items-center gap-1 text-xs">
+            {stack.slice(0, index + 1).map((f, i) => (
+              <React.Fragment key={f.key}>
+                {i > 0 && <span className="text-icon-muted">›</span>}
+                <span className={i === index ? "truncate font-medium text-foreground" : "truncate text-icon-muted"}>
+                  {registry[f.slug]?.meta.label || f.slug}
+                </span>
+              </React.Fragment>
+            ))}
+          </div>
+          <button onClick={onCloseAll} className="shrink-0 p-1 text-icon-muted hover:text-foreground" aria-label="Close">
+            ✕
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-5 py-4">
+          {!rec || !meta ? (
+            <div className="text-sm text-icon-muted">Loading…</div>
+          ) : (
+            <>
+              <div className="flex items-center gap-3">
+                {meta.avatarUrl &&
+                  (meta.avatarUrl(rec) ? (
+                    <img
+                      src={meta.avatarUrl(rec) as string}
+                      alt=""
+                      className="h-14 w-14 rounded-full object-cover ring-1 ring-bn-border"
+                    />
+                  ) : (
+                    <div className="h-14 w-14 rounded-full bg-content-bg" />
+                  ))}
+                <div className="min-w-0">
+                  <div className="truncate text-lg font-semibold text-foreground">{meta.title(rec)}</div>
+                  {meta.subtitle && <div className="truncate text-sm text-icon-muted">{meta.subtitle(rec)}</div>}
+                </div>
+              </div>
+
+              {meta.summary && (
+                <dl className="mt-4 space-y-2.5">
+                  {meta.summary.map(s => (
+                    <div key={s.label}>
+                      <dt className="text-xs uppercase tracking-wide text-icon-muted">{s.label}</dt>
+                      <dd className="text-sm text-foreground">{s.value(rec)}</dd>
+                    </div>
+                  ))}
+                </dl>
+              )}
+
+              {meta.relations?.map(rel => (
+                <div key={rel.label} className="mt-5">
+                  <div className="mb-1.5 text-xs uppercase tracking-wide text-icon-muted">{rel.label}</div>
+                  {rel.list ? (
+                    <RelatedList slug={rel.slug} value={rel.value(rec)} />
+                  ) : (
+                    <RelatedCard slug={rel.slug} value={rel.value(rec)} />
+                  )}
+                </div>
+              ))}
+            </>
+          )}
+        </div>
+
+        <div className="flex items-center justify-between border-t border-bn-border px-5 py-3">
+          <button onClick={onBack} className="text-sm text-icon-muted hover:text-foreground">
+            Back
+          </button>
+          {canEdit && (
+            <button
+              onClick={() => setEditing(true)}
+              className="rounded-bn bg-primary-gradient px-4 py-1.5 text-sm font-medium text-primary-foreground shadow-bn hover:opacity-90"
+            >
+              Edit
+            </button>
+          )}
+        </div>
+      </aside>
+
+      {editing && rec && entry?.columns && (
+        <DetailDrawer
+          row={rec}
+          columns={entry.columns}
+          editable={entry.editable}
+          mode="edit"
+          zBase={zBase + 40}
+          onClose={() => setEditing(false)}
+          onSaved={() => {
+            setEditing(false)
+            setTick(x => x + 1) // refresh this preview
+            onChanged?.() // refresh the host (e.g. a CrudTable)
+          }}
+        />
+      )}
+    </>
+  )
+}

--- a/packages/dashin/src/components/RelatedPreview/RelatedCard.tsx
+++ b/packages/dashin/src/components/RelatedPreview/RelatedCard.tsx
@@ -1,0 +1,81 @@
+import React, { useEffect, useState } from "react"
+import { useCollection, usePreviewOpen } from "./context"
+
+const idOf = (v: any) => (v && typeof v === "object" ? v.id : v)
+
+/**
+ * A related record rendered as a compact summary card (avatar / title /
+ * subtitle / key fields), driven by the collection registry's `meta`. Renders
+ * instantly from a populated object, or lazy-fetches by id via the entry's
+ * `fetch`. Under a RelatedPreviewProvider a click opens a stacked preview;
+ * without one it's read-only.
+ */
+export function RelatedCard({ slug, value }: { slug: string; value: any }) {
+  const entry = useCollection(slug)
+  const open = usePreviewOpen()
+  const [rec, setRec] = useState<any>(value && typeof value === "object" ? value : null)
+
+  useEffect(() => {
+    let on = true
+    if (value && typeof value === "object") {
+      setRec(value)
+    } else if (value != null && entry?.fetch) {
+      entry.fetch(value).then(r => on && setRec(r)).catch(() => {})
+    }
+    return () => {
+      on = false
+    }
+  }, [slug, value, entry])
+
+  if (value == null) return <span className="text-icon-muted">—</span>
+  const meta = entry?.meta
+  if (!meta) return <span className="text-icon-muted">{String(idOf(value) ?? "")}</span>
+  if (!rec) return <span className="text-icon-muted">…</span>
+
+  const thumb = meta.avatarUrl ? meta.avatarUrl(rec) : null
+  const clickable = !!open
+  return (
+    <div
+      role={clickable ? "button" : undefined}
+      onClick={clickable ? () => open!(slug, rec) : undefined}
+      className={`flex items-center gap-2.5 rounded-bn border border-bn-border bg-content-bg px-2.5 py-2${
+        clickable ? " cursor-pointer transition hover:border-primary hover:bg-content-box" : ""
+      }`}
+    >
+      {meta.avatarUrl &&
+        (thumb ? (
+          <img src={thumb} alt="" className="h-9 w-9 shrink-0 rounded-full object-cover ring-1 ring-bn-border" />
+        ) : (
+          <div className="h-9 w-9 shrink-0 rounded-full bg-content-box" />
+        ))}
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-sm font-medium text-foreground">{meta.title(rec)}</div>
+        {meta.subtitle && <div className="truncate text-xs text-icon-muted">{meta.subtitle(rec)}</div>}
+        {meta.summary && (
+          <div className="mt-1 space-y-0.5">
+            {meta.summary.map(s => (
+              <div key={s.label} className="flex gap-1 text-xs">
+                <span className="shrink-0 text-icon-muted">{s.label}:</span>
+                <span className="truncate text-foreground">{s.value(rec)}</span>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+/** Read-only list of related records (a hasMany / join value: an array, or a
+ *  `{ docs }` page). */
+export function RelatedList({ slug, value }: { slug: string; value: any }) {
+  const docs = Array.isArray(value) ? value : value?.docs || []
+  if (!docs.length) return <span className="text-icon-muted">—</span>
+  return (
+    <div className="space-y-1.5">
+      {docs.map((doc: any, i: number) => (
+        <RelatedCard key={doc?.id ?? i} slug={slug} value={doc} />
+      ))}
+    </div>
+  )
+}

--- a/packages/dashin/src/components/RelatedPreview/__tests__/RelatedPreview.test.tsx
+++ b/packages/dashin/src/components/RelatedPreview/__tests__/RelatedPreview.test.tsx
@@ -1,0 +1,85 @@
+import React from "react"
+import { describe, it, expect, vi } from "vitest"
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+import { RelatedPreviewProvider, RelatedCard } from ".."
+
+const clientRec = { id: 5, name: "Alice", contracts: { docs: [{ id: 1, number: "C-1" }] } }
+const contractRec = { id: 1, number: "C-1", client: { id: 5, name: "Alice" } }
+
+function makeRegistry(overrides: any = {}) {
+  return {
+    clients: {
+      meta: {
+        label: "Client",
+        title: (r: any) => r.name,
+        subtitle: (r: any) => `#${r.id}`,
+        relations: [{ label: "Contracts", slug: "contracts", list: true, value: (r: any) => r.contracts }]
+      },
+      fetch: async () => clientRec,
+      columns: [{ title: "Name", field: "name" }],
+      editable: { onRowUpdate: vi.fn().mockResolvedValue({}) }
+    },
+    contracts: {
+      meta: {
+        label: "Contract",
+        title: (r: any) => r.number,
+        relations: [{ label: "Client", slug: "clients", value: (r: any) => r.client }]
+      },
+      fetch: async () => contractRec,
+      columns: [{ title: "Number", field: "number" }],
+      editable: { onRowUpdate: vi.fn().mockResolvedValue({}), ...(overrides.contractsEditable || {}) }
+    }
+  }
+}
+
+describe("RelatedPreview", () => {
+  it("clicking a card opens a preview with its summary + relations", async () => {
+    render(
+      <RelatedPreviewProvider collections={makeRegistry() as any}>
+        <RelatedCard slug="contracts" value={contractRec} />
+      </RelatedPreviewProvider>
+    )
+    fireEvent.click(screen.getByText("C-1")) // the card
+    expect(await screen.findByText("Back")).toBeInTheDocument() // preview frame opened
+    expect(screen.getByText("Client")).toBeInTheDocument() // relation section label
+    expect(screen.getByText("Alice")).toBeInTheDocument() // related card inside the preview
+  })
+
+  it("drills into a relation (opens a second, deeper frame)", async () => {
+    render(
+      <RelatedPreviewProvider collections={makeRegistry() as any}>
+        <RelatedCard slug="contracts" value={contractRec} />
+      </RelatedPreviewProvider>
+    )
+    fireEvent.click(screen.getByText("C-1"))
+    fireEvent.click(await screen.findByText("Alice"))
+    // the client frame shows the client's own "Contracts" relation — unique to frame 2
+    expect(await screen.findByText("Contracts")).toBeInTheDocument()
+  })
+
+  it("Edit opens the nested drawer; Save calls editable + onChanged", async () => {
+    const onChanged = vi.fn()
+    const onRowUpdate = vi.fn().mockResolvedValue({})
+    render(
+      <RelatedPreviewProvider collections={makeRegistry({ contractsEditable: { onRowUpdate } }) as any} onChanged={onChanged}>
+        <RelatedCard slug="contracts" value={contractRec} />
+      </RelatedPreviewProvider>
+    )
+    fireEvent.click(screen.getByText("C-1"))
+    fireEvent.click(await screen.findByRole("button", { name: "Edit" }))
+    fireEvent.click(await screen.findByRole("button", { name: "Save" }))
+    await waitFor(() => expect(onRowUpdate).toHaveBeenCalled())
+    await waitFor(() => expect(onChanged).toHaveBeenCalled())
+  })
+
+  it("respects the depth cap (deeper clicks are no-ops)", async () => {
+    render(
+      <RelatedPreviewProvider collections={makeRegistry() as any} cap={1}>
+        <RelatedCard slug="contracts" value={contractRec} />
+      </RelatedPreviewProvider>
+    )
+    fireEvent.click(screen.getByText("C-1")) // frame 1 (cap reached)
+    fireEvent.click(await screen.findByText("Alice")) // would be frame 2 → blocked
+    expect(screen.queryByText("Contracts")).toBeNull()
+  })
+})

--- a/packages/dashin/src/components/RelatedPreview/context.ts
+++ b/packages/dashin/src/components/RelatedPreview/context.ts
@@ -1,0 +1,13 @@
+import { createContext, useContext } from "react"
+import { CollectionEntry, CollectionRegistry } from "./types"
+
+/** The collection registry (slug → entry), provided by RelatedPreviewProvider. */
+export const CollectionsContext = createContext<CollectionRegistry>({})
+export const useCollection = (slug: string): CollectionEntry | undefined =>
+  useContext(CollectionsContext)[slug]
+
+/** Opening a related-record preview. Null when rendered outside a provider — in
+ *  which case cards stay read-only (non-clickable). */
+export type OpenPreview = (slug: string, value: any) => void
+export const PreviewContext = createContext<OpenPreview | null>(null)
+export const usePreviewOpen = (): OpenPreview | null => useContext(PreviewContext)

--- a/packages/dashin/src/components/RelatedPreview/index.ts
+++ b/packages/dashin/src/components/RelatedPreview/index.ts
@@ -1,0 +1,10 @@
+export { RelatedPreviewProvider } from "./PreviewStack"
+export { RelatedCard, RelatedList } from "./RelatedCard"
+export {
+  CollectionsContext,
+  PreviewContext,
+  useCollection,
+  usePreviewOpen
+} from "./context"
+export type { OpenPreview } from "./context"
+export type { CollectionMeta, CollectionEntry, CollectionRegistry } from "./types"

--- a/packages/dashin/src/components/RelatedPreview/types.ts
+++ b/packages/dashin/src/components/RelatedPreview/types.ts
@@ -1,0 +1,35 @@
+import { ReactNode } from "react"
+import { Column, EditableData } from "../Table/models/material-table-shim"
+
+/**
+ * How to summarize a record of a collection wherever it appears as a related
+ * item (cards, previews). Pure display — adapter-agnostic (URLs/values are
+ * plain, so no source-package coupling).
+ */
+export interface CollectionMeta {
+  label: string
+  title: (record: any) => ReactNode
+  subtitle?: (record: any) => ReactNode
+  /** Resolved avatar/thumbnail URL (the app/adapter computes it, e.g. from a
+   *  media object). Omit for no avatar. */
+  avatarUrl?: (record: any) => string | null | undefined
+  summary?: { label: string; value: (record: any) => ReactNode }[]
+  /** Related records reachable from this one — rendered as clickable cards so
+   *  you can drill in (A → its B → B's other A …). */
+  relations?: { label: string; slug: string; list?: boolean; value: (record: any) => any }[]
+}
+
+/** Everything the preview system needs to render (and optionally edit) a
+ *  collection's records, keyed by slug in the registry. */
+export interface CollectionEntry {
+  meta: CollectionMeta
+  /** Columns for the nested edit form. Omit → the preview is view-only. */
+  columns?: Column<any>[]
+  /** Resolve a record by id (adapter-provided; e.g. a depth>=1 GET). Omit →
+   *  only already-populated objects render, ids show a placeholder. */
+  fetch?: (id: string | number) => Promise<any>
+  /** CRUD handlers for the nested edit (adapter-provided, e.g. editableCtrl). */
+  editable?: EditableData<any>
+}
+
+export type CollectionRegistry = Record<string, CollectionEntry>

--- a/packages/dashin/src/components/index.ts
+++ b/packages/dashin/src/components/index.ts
@@ -36,6 +36,8 @@ export type { DetailDrawerProps } from "./DetailDrawer"
 export { default as CrudTable } from "./CrudTable"
 export type { CrudTableProps } from "./CrudTable"
 
+export * from "./RelatedPreview"
+
 export { default as LeftMenu } from "./LeftMenu"
 export { default as NestedList } from "./NestedMenu"
 export { default as TopBar } from "./TopBar"


### PR DESCRIPTION
## What

A generic, **adapter-agnostic** system for previewing and editing a record's linked/related items — the thing dashin has nothing like today (relationship fields come back as raw ids/objects with no preview UI).

Driven by an **injected registry** so core stays free of any source package:

```ts
type CollectionEntry = {
  meta: CollectionMeta                 // title/subtitle/avatarUrl/summary/relations (app)
  columns?: Column<any>[]              // nested edit form (app)
  fetch?: (id) => Promise<any>         // resolve by id (adapter, e.g. depth GET)
  editable?: EditableData<any>         // CRUD for nested edit (adapter)
}

<RelatedPreviewProvider collections={{ clients, contracts }} onChanged={reload}>
  … app (CrudTables, drawers) …
</RelatedPreviewProvider>
```

- **`RelatedCard` / `RelatedList`** — a related record as a summary card (avatar/title/subtitle/key fields), or a list from a hasMany/`{docs}` value. Renders from a populated object or lazy-fetches by id. Clickable under a provider, read-only without one. Pairs with DetailDrawer's `renderDetail` hook (#145) to show rich related cells.
- **`RelatedPreviewProvider`** — provides the registry + a stacked preview; `onChanged` fires after a nested save so the host (e.g. a `CrudTable`) can refresh.
- **`PreviewFrame`** — a stacked drawer (via DetailDrawer's `zBase`) with a **breadcrumb**, **loop guard**, and depth **cap**; drill into a record's own relations (contract → client → its other contracts …); **Edit** opens that collection's real `DetailDrawer` nested on top and refreshes on save.

Result: every relationship in an admin gets preview + nested-edit for free once its collection declares `meta` + `columns`.

## Tests

4 component tests (`RelatedPreview/__tests__`): open preview from a card, drill into a relation (deeper frame), Edit→Save calls `editable` + `onChanged`, and depth-cap enforcement. Core `typecheck` clean.

> **Stacked on #146 → #145.** Base is `feat/crud-table`; I'll retarget down the stack as each lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)