### PR TITLE
feat(dashin): ImageEdit — generic image-upload editComponent

### DIFF
--- a/packages/dashin/src/components/__tests__/ImageEdit.test.tsx
+++ b/packages/dashin/src/components/__tests__/ImageEdit.test.tsx
@@ -1,0 +1,40 @@
+import React from "react"
+import { describe, it, expect, vi } from "vitest"
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+import ImageEdit from "../ui/ImageEdit"
+
+const pick = (input: HTMLInputElement, file: File) => fireEvent.change(input, { target: { files: [file] } })
+
+describe("ImageEdit", () => {
+  it("uploads a picked file and stores the mapped value + preview", async () => {
+    const onChange = vi.fn()
+    const upload = vi.fn().mockResolvedValue({ id: 7, url: "/u/7.png" })
+    const { container } = render(
+      <ImageEdit value={null} onChange={onChange} upload={upload} toValue={r => r.id} resultUrl={r => r.url} />
+    )
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement
+    const file = new File(["x"], "a.png", { type: "image/png" })
+    pick(input, file)
+    await waitFor(() => expect(upload).toHaveBeenCalledWith(file))
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith(7))
+    await waitFor(() => expect(container.querySelector("img")).toHaveAttribute("src", "/u/7.png"))
+  })
+
+  it("shows an existing preview and clears on Remove", () => {
+    const onChange = vi.fn()
+    const { container } = render(
+      <ImageEdit value={{ id: 1 }} onChange={onChange} upload={vi.fn()} previewUrl={() => "/existing.png"} />
+    )
+    expect(container.querySelector("img")).toHaveAttribute("src", "/existing.png")
+    fireEvent.click(screen.getByText("Remove"))
+    expect(onChange).toHaveBeenCalledWith(null)
+  })
+
+  it("surfaces an upload error", async () => {
+    const upload = vi.fn().mockRejectedValue(new Error("boom"))
+    const { container } = render(<ImageEdit value={null} onChange={() => {}} upload={upload} />)
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement
+    pick(input, new File(["x"], "a.png"))
+    await waitFor(() => expect(screen.getByText("boom")).toBeInTheDocument())
+  })
+})

--- a/packages/dashin/src/components/index.ts
+++ b/packages/dashin/src/components/index.ts
@@ -69,6 +69,8 @@ export { default as Textarea } from "./ui/Textarea"
 export type { TextareaProps } from "./ui/Textarea"
 export { default as Label } from "./ui/Label"
 export type { LabelProps } from "./ui/Label"
+export { default as ImageEdit } from "./ui/ImageEdit"
+export type { ImageEditProps } from "./ui/ImageEdit"
 
 export interface DefaultLayoutProps {
   children?: any

--- a/packages/dashin/src/components/ui/ImageEdit.tsx
+++ b/packages/dashin/src/components/ui/ImageEdit.tsx
@@ -1,0 +1,115 @@
+import React, { useEffect, useState } from "react"
+
+// A token-driven image-upload editComponent: shows the current image (round),
+// lets the user pick a new one (uploaded via the injected `upload`), remove it,
+// or click to enlarge. Adapter-agnostic — the upload + URL resolution are
+// injected, so it works with any backend (e.g. Payload media + photoThumb).
+export interface ImageEditProps {
+  value?: any
+  onChange: (value: any) => void
+  /** Upload a picked file; resolve the raw result (e.g. a created media doc). */
+  upload: (file: File) => Promise<any>
+  /** Map the upload result → the value to store (default: the result itself,
+   *  e.g. `doc => doc.id` for a relationship). */
+  toValue?: (result: any) => any
+  /** Existing value → preview URL (shown on open). */
+  previewUrl?: (value: any) => string | null | undefined
+  /** Upload result → preview URL (shown right after a fresh upload). */
+  resultUrl?: (result: any) => string | null | undefined
+  accept?: string
+  className?: string
+  chooseLabel?: string
+  removeLabel?: string
+}
+
+const ImageEdit: React.FC<ImageEditProps> = ({
+  value,
+  onChange,
+  upload,
+  toValue,
+  previewUrl,
+  resultUrl,
+  accept = "image/*",
+  className = "",
+  chooseLabel = "Choose image",
+  removeLabel = "Remove"
+}) => {
+  const [preview, setPreview] = useState<string | null>(previewUrl ? previewUrl(value) ?? null : null)
+  const [busy, setBusy] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
+  const [open, setOpen] = useState(false)
+
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => e.key === "Escape" && setOpen(false)
+    window.addEventListener("keydown", onKey)
+    return () => window.removeEventListener("keydown", onKey)
+  }, [open])
+
+  const onFile = async (file: File) => {
+    setBusy(true)
+    setErr(null)
+    try {
+      const result = await upload(file)
+      onChange(toValue ? toValue(result) : result)
+      setPreview((resultUrl ? resultUrl(result) : null) ?? null)
+    } catch (e: any) {
+      setErr((e && e.message) || "Upload failed")
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className={`flex items-center gap-3 ${className}`}>
+      <button
+        type="button"
+        onClick={() => preview && setOpen(true)}
+        className="flex h-16 w-16 items-center justify-center overflow-hidden rounded-full bg-content-bg ring-1 ring-bn-border"
+        aria-label="preview"
+      >
+        {preview ? <img src={preview} alt="" className="h-full w-full object-cover" /> : <span className="text-icon-muted">—</span>}
+      </button>
+      <div className="flex flex-col items-start gap-1">
+        <label className="cursor-pointer rounded-bn border border-bn-border bg-content-box px-3 py-1.5 text-sm text-foreground hover:bg-content-bg">
+          {busy ? "Uploading…" : chooseLabel}
+          <input
+            type="file"
+            accept={accept}
+            className="hidden"
+            disabled={busy}
+            onChange={e => {
+              const f = e.target.files && e.target.files[0]
+              if (f) onFile(f)
+              e.target.value = ""
+            }}
+          />
+        </label>
+        {preview && (
+          <button
+            type="button"
+            className="text-xs text-danger"
+            onClick={() => {
+              onChange(null)
+              setPreview(null)
+            }}
+          >
+            {removeLabel}
+          </button>
+        )}
+        {err && <span className="text-xs text-danger">{err}</span>}
+      </div>
+
+      {open && preview && (
+        <div
+          className="fixed inset-0 z-[1300] flex items-center justify-center bg-black/70 p-6"
+          onClick={() => setOpen(false)}
+        >
+          <img src={preview} alt="" className="max-h-[80vh] max-w-full rounded-lg object-contain" onClick={e => e.stopPropagation()} />
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default ImageEdit


### PR DESCRIPTION
## What

An **`ImageEdit`** token-driven ui primitive (`src/components/ui/ImageEdit.tsx`) for image/upload fields: shows the current image (round), lets the user **pick** a new one (uploaded via the injected `upload`), **Remove** it, or **click to enlarge**.

**Adapter-agnostic** — the upload + URL resolution are injected, so it works with any backend and stays out of core's way:

```tsx
// Payload, using the media helpers from #143:
{ field: "avatar",
  editComponent: p => (
    <ImageEdit
      value={p.value} onChange={p.onChange}
      upload={f => uploadMedia(f)} toValue={d => d.id}
      previewUrl={photoThumb} resultUrl={photoThumb}
    />
  ) }
```

Props: `value`/`onChange`, `upload(file)`, `toValue(result)` (→ stored value, e.g. `doc.id`), `previewUrl(value)` / `resultUrl(result)` (→ thumbnail URLs), plus `accept`/`chooseLabel`/`removeLabel`.

## Why

There's no upload/media editComponent in core today (only a presentational `Avatar` and a standalone `FileExplorer`). This is the generic version of the avatar-uploader every Payload/media admin hand-rolls — kept in **core** (so its theme classes are already scanned and it has jsdom tests) with the backend-specific bits injected, rather than a styled component inside a source package.

## Tests

3 unit tests (`__tests__/ImageEdit.test.tsx`, jsdom): upload → mapped value + preview, existing preview + Remove clears, and upload-error surfacing. Core `typecheck` clean.

Independent PR (base `master`); pairs naturally with #143's `uploadMedia`/`photoThumb`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)