### PR TITLE
feat(source-payload): payloadCrud + payloadCollection bindings

### DIFF
--- a/packages/dashin-source-payload/__tests__/bindings.test.ts
+++ b/packages/dashin-source-payload/__tests__/bindings.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from "vitest"
+
+const request = vi.fn()
+vi.mock("@dashin-dev/dashin", () => ({
+  request: (...a: any[]) => request(...a),
+  ENV: { MAIN_URL: "http://pl.test", AUTH_URL: "http://pl.test" },
+  storedToken: async () => "tok"
+}))
+vi.mock("../controllers/editableCtrl", () => ({
+  default: ({ SchemaName }: any) => ({ __schema: SchemaName, onRowUpdate: async () => ({}) })
+}))
+vi.mock("../controllers/dataCtrl", () => ({
+  default: vi.fn(async () => ({ page: 0, data: [], totalCount: 0 }))
+}))
+
+import { payloadCrud, payloadCollection } from "../bindings"
+
+const t = (s: string) => s
+
+describe("payloadCrud", () => {
+  it("returns a data() fn + a schema-bound editable", () => {
+    const { data, editable } = payloadCrud("posts", { t })
+    expect(typeof data).toBe("function")
+    expect((editable as any).__schema).toBe("posts")
+  })
+})
+
+describe("payloadCollection", () => {
+  it("passes meta/columns through and fetches /api/{slug}/{id}?depth", async () => {
+    request.mockResolvedValue({ id: 5, name: "x" })
+    const meta = { label: "Post", title: (r: any) => r.name }
+    const entry = payloadCollection("posts", {
+      meta: meta as any,
+      columns: [{ title: "Name", field: "name" }] as any,
+      t,
+      depth: 2
+    })
+    expect(entry.meta).toBe(meta)
+    expect(entry.columns).toHaveLength(1)
+    const rec = await entry.fetch!(5)
+    expect(rec).toEqual({ id: 5, name: "x" })
+    const [url, opts] = request.mock.calls[0]
+    expect(url).toBe("/api/posts/5")
+    expect(opts.method).toBe("GET")
+    expect(opts.params).toEqual({ depth: 2 })
+    expect((entry.editable as any).__schema).toBe("posts")
+  })
+})

--- a/packages/dashin-source-payload/bindings.ts
+++ b/packages/dashin-source-payload/bindings.ts
@@ -1,0 +1,56 @@
+import { request } from "@dashin-dev/dashin"
+import type { CollectionEntry, CollectionMeta, Column, CrudTableProps, Query } from "@dashin-dev/dashin"
+import dataCtrl from "./controllers/dataCtrl"
+import editableCtrl from "./controllers/editableCtrl"
+import { apiBase, apiPath, plHeaders } from "./services/plConfig"
+
+type TFn = (key: string) => string
+
+/**
+ * Wire a Payload collection into core's `<CrudTable>` — returns its `data` +
+ * `editable` props (spread them in). Bulk actions still need the table ref, so
+ * pass any `actions` to `<CrudTable>` yourself.
+ *
+ *   const crud = payloadCrud("clients", { t })
+ *   <CrudTable title="Clients" columns={columns} {...crud} />
+ */
+export function payloadCrud<T extends object = any>(
+  schema: string,
+  opts: { t: TFn; disableAdd?: boolean; searchField?: string }
+): Pick<CrudTableProps<T>, "data" | "editable"> {
+  const { t, disableAdd, searchField } = opts
+  return {
+    data: (query: Query<T>) => dataCtrl<T>({ t, tableQuery: query, path: schema, searchField } as any),
+    editable: editableCtrl({ t, SchemaName: schema, disableAdd }) as any
+  }
+}
+
+/**
+ * Wire a Payload collection into core's related-preview registry — returns a
+ * `CollectionEntry` with a depth-`fetch` (resolve one record by id) + `editable`
+ * (CRUD for the nested edit). Supply the display `meta` and the edit-form
+ * `columns`; `depth` defaults to 2 so one-hop relations populate for drill-in.
+ *
+ *   <RelatedPreviewProvider collections={{
+ *     clients:   payloadCollection("clients",   { meta: clientMeta,   columns: clientColumns,   t }),
+ *     contracts: payloadCollection("contracts", { meta: contractMeta, columns: contractColumns, t })
+ *   }}>…</RelatedPreviewProvider>
+ */
+export function payloadCollection(
+  slug: string,
+  opts: { meta: CollectionMeta; columns?: Column<any>[]; t: TFn; depth?: number }
+): CollectionEntry {
+  const { meta, columns, t, depth = 2 } = opts
+  return {
+    meta,
+    columns,
+    fetch: async (id: string | number) =>
+      await request(apiPath(slug, String(id)), {
+        params: { depth },
+        prefix: apiBase(),
+        method: "GET",
+        headers: await plHeaders()
+      }),
+    editable: editableCtrl({ t, SchemaName: slug }) as any
+  }
+}

--- a/packages/dashin-source-payload/index.ts
+++ b/packages/dashin-source-payload/index.ts
@@ -9,3 +9,4 @@ export interface EditableCtrl {
 
 export * from "./services"
 export * from "./controllers"
+export * from "./bindings"


### PR DESCRIPTION
## What

Two one-liner helpers that wire a Payload collection into core's new higher-level components (so apps don't hand-wire `dataCtrl`/`editableCtrl`/fetch per collection):

- **`payloadCrud(schema, { t, disableAdd?, searchField? })`** → `{ data, editable }` to spread into `<CrudTable>`:
  ```tsx
  <CrudTable title="Clients" columns={columns} {...payloadCrud("clients", { t })} />
  ```
- **`payloadCollection(slug, { meta, columns?, t, depth? })`** → a `CollectionEntry` (a depth `fetch`-by-id + `editable`) for the related-preview registry:
  ```tsx
  <RelatedPreviewProvider collections={{
    clients:   payloadCollection("clients",   { meta: clientMeta,   columns: clientColumns,   t }),
    contracts: payloadCollection("contracts", { meta: contractMeta, columns: contractColumns, t })
  }}>…</RelatedPreviewProvider>
  ```

Both reuse the existing `dataCtrl`/`editableCtrl` controllers + `plConfig` (`apiBase`/`plHeaders`); `payloadCollection.fetch` is a `GET /api/{slug}/{id}?depth` (depth defaults to 2 so one-hop relations populate for drill-in).

## Why

The new core `CrudTable` (#146) and related-preview (#147) are deliberately adapter-agnostic — you inject `data`/`editable`/`fetch`. These bindings give Payload apps the batteries-included one-liner, keeping the wiring in the adapter where it belongs.

## Tests

2 unit tests (`__tests__/bindings.test.ts`, node — deps mocked): `payloadCrud` shape + schema-bound editable; `payloadCollection` meta/columns passthrough + `fetch` hitting `/api/{slug}/{id}?depth`. Full package suite green (19). `tsc` clean against the core types built from this stack.

> **Top of the stack** (`#145 → #146 → #147 → this`). Base is `feat/related-preview`; needs core's `CollectionEntry`/`CrudTableProps`, so it lands once those are merged + the alpha is republished. I'll retarget the base down the stack as each parent merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)